### PR TITLE
武器をCardとする

### DIFF
--- a/assets/metadata/entities/raw/raw.toml
+++ b/assets/metadata/entities/raw/raw.toml
@@ -1,8 +1,8 @@
 # item ================
 
 [[item]]
-Name = "ルビー"
-Description = "高く売れる"
+Name = "ルビー原石"
+Description = "赤く光る鉱物。高く売れる"
 
 [[item]]
 Name = "回復薬"
@@ -57,9 +57,6 @@ Damage = 8
 AttackCount = 1
 Element = "NONE"
 AttackCategory = "SWORD"
-
-[item.equip_bonus]
-Strength = 1
 
 [[item]]
 Name = "鉄のナイフ"

--- a/assets/metadata/entities/raw/raw.toml
+++ b/assets/metadata/entities/raw/raw.toml
@@ -36,19 +36,19 @@ UsableScene = "BATTLE"
 TargetFaction = "ENEMY"
 TargetNum = "ALL"
 
-# weapon ================
+# attack ================
 
 [[item]]
 Name = "木刀"
 Description = "旅行の土産でおなじみの、木でできた刃のない刀"
 
-[item.weapon]
+[item.attack]
 Accuracy = 100
 Damage = 8
 AttackCount = 1
 EnergyConsumption = 1
 DamageAttr = "NONE"
-WeaponCategory = "SWORD"
+AttackCategory = "SWORD"
 
 [item.equip_bonus]
 Strength = 1
@@ -57,61 +57,61 @@ Strength = 1
 Name = "鉄のナイフ"
 Description = "鉄で作られた軽いナイフ"
 
-[item.weapon]
+[item.attack]
 Accuracy = 100
 Damage = 9
 AttackCount = 1
 EnergyConsumption = 1
 DamageAttr = "NONE"
-WeaponCategory = "SWORD"
+AttackCategory = "SWORD"
 
 [[item]]
 Name = "ハンドガン"
 Description = "樹脂素材を多用した自動拳銃"
 
-[item.weapon]
+[item.attack]
 Accuracy = 95
 Damage = 14
 AttackCount = 1
 EnergyConsumption = 2
 DamageAttr = "NONE"
-WeaponCategory = "HANDGUN"
+AttackCategory = "HANDGUN"
 
 [[item]]
 Name = "レイガン"
 Description = "光線を発射する拳銃"
 
-[item.weapon]
+[item.attack]
 Accuracy = 90
 Damage = 20
 AttackCount = 1
 EnergyConsumption = 3
 DamageAttr = "PHOTON"
-WeaponCategory = "HANDGUN"
+AttackCategory = "HANDGUN"
 
 [[item]]
 Name = "電撃グレネード"
 Description = "放電物質を投射する擲弾銃"
 
-[item.weapon]
+[item.attack]
 Accuracy = 80
 Damage = 26
 AttackCount = 1
 EnergyConsumption = 4
 DamageAttr = "THUNDER"
-WeaponCategory = "RIFLE"
+AttackCategory = "RIFLE"
 
 [[item]]
 Name = "冷凍グレネード"
 Description = "極低温物質を投射する擲弾銃"
 
-[item.weapon]
+[item.attack]
 Accuracy = 80
 Damage = 25
 AttackCount = 1
 EnergyConsumption = 4
 DamageAttr = "CHILL"
-WeaponCategory = "RIFLE"
+AttackCategory = "RIFLE"
 
 # wearable ================
 

--- a/assets/metadata/entities/raw/raw.toml
+++ b/assets/metadata/entities/raw/raw.toml
@@ -36,11 +36,16 @@ UsableScene = "BATTLE"
 TargetFaction = "ENEMY"
 TargetNum = "ALL"
 
-# attack ================
+# card ================
 
 [[item]]
 Name = "木刀"
 Description = "旅行の土産でおなじみの、木でできた刃のない刀"
+
+[item.card]
+Cost = 2
+TargetFaction = "ENEMY"
+TargetNum = "SINGLE"
 
 [item.attack]
 Accuracy = 100
@@ -56,6 +61,11 @@ Strength = 1
 Name = "鉄のナイフ"
 Description = "鉄で作られた軽いナイフ"
 
+[item.card]
+Cost = 2
+TargetFaction = "ENEMY"
+TargetNum = "SINGLE"
+
 [item.attack]
 Accuracy = 100
 Damage = 9
@@ -66,6 +76,11 @@ AttackCategory = "SWORD"
 [[item]]
 Name = "ハンドガン"
 Description = "樹脂素材を多用した自動拳銃"
+
+[item.card]
+Cost = 2
+TargetFaction = "ENEMY"
+TargetNum = "SINGLE"
 
 [item.attack]
 Accuracy = 95
@@ -78,6 +93,11 @@ AttackCategory = "HANDGUN"
 Name = "レイガン"
 Description = "光線を発射する拳銃"
 
+[item.card]
+Cost = 2
+TargetFaction = "ENEMY"
+TargetNum = "SINGLE"
+
 [item.attack]
 Accuracy = 90
 Damage = 20
@@ -89,6 +109,11 @@ AttackCategory = "HANDGUN"
 Name = "電撃グレネード"
 Description = "放電物質を投射する擲弾銃"
 
+[item.card]
+Cost = 2
+TargetFaction = "ENEMY"
+TargetNum = "SINGLE"
+
 [item.attack]
 Accuracy = 80
 Damage = 26
@@ -99,6 +124,11 @@ AttackCategory = "RIFLE"
 [[item]]
 Name = "冷凍グレネード"
 Description = "極低温物質を投射する擲弾銃"
+
+[item.card]
+Cost = 2
+TargetFaction = "ENEMY"
+TargetNum = "SINGLE"
 
 [item.attack]
 Accuracy = 80

--- a/assets/metadata/entities/raw/raw.toml
+++ b/assets/metadata/entities/raw/raw.toml
@@ -46,7 +46,6 @@ Description = "旅行の土産でおなじみの、木でできた刃のない�
 Accuracy = 100
 Damage = 8
 AttackCount = 1
-EnergyConsumption = 1
 DamageAttr = "NONE"
 AttackCategory = "SWORD"
 
@@ -61,7 +60,6 @@ Description = "鉄で作られた軽いナイフ"
 Accuracy = 100
 Damage = 9
 AttackCount = 1
-EnergyConsumption = 1
 DamageAttr = "NONE"
 AttackCategory = "SWORD"
 
@@ -73,7 +71,6 @@ Description = "樹脂素材を多用した自動拳銃"
 Accuracy = 95
 Damage = 14
 AttackCount = 1
-EnergyConsumption = 2
 DamageAttr = "NONE"
 AttackCategory = "HANDGUN"
 
@@ -85,7 +82,6 @@ Description = "光線を発射する拳銃"
 Accuracy = 90
 Damage = 20
 AttackCount = 1
-EnergyConsumption = 3
 DamageAttr = "PHOTON"
 AttackCategory = "HANDGUN"
 
@@ -97,7 +93,6 @@ Description = "放電物質を投射する擲弾銃"
 Accuracy = 80
 Damage = 26
 AttackCount = 1
-EnergyConsumption = 4
 DamageAttr = "THUNDER"
 AttackCategory = "RIFLE"
 
@@ -109,7 +104,6 @@ Description = "極低温物質を投射する擲弾銃"
 Accuracy = 80
 Damage = 25
 AttackCount = 1
-EnergyConsumption = 4
 DamageAttr = "CHILL"
 AttackCategory = "RIFLE"
 

--- a/assets/metadata/entities/raw/raw.toml
+++ b/assets/metadata/entities/raw/raw.toml
@@ -1,6 +1,10 @@
 # item ================
 
 [[item]]
+Name = "ルビー"
+Description = "高く売れる"
+
+[[item]]
 Name = "回復薬"
 Description = "体力を半分程度回復する"
 

--- a/assets/metadata/entities/raw/raw.toml
+++ b/assets/metadata/entities/raw/raw.toml
@@ -46,7 +46,7 @@ Description = "旅行の土産でおなじみの、木でできた刃のない�
 Accuracy = 100
 Damage = 8
 AttackCount = 1
-DamageAttr = "NONE"
+Element = "NONE"
 AttackCategory = "SWORD"
 
 [item.equip_bonus]
@@ -60,7 +60,7 @@ Description = "鉄で作られた軽いナイフ"
 Accuracy = 100
 Damage = 9
 AttackCount = 1
-DamageAttr = "NONE"
+Element = "NONE"
 AttackCategory = "SWORD"
 
 [[item]]
@@ -71,7 +71,7 @@ Description = "樹脂素材を多用した自動拳銃"
 Accuracy = 95
 Damage = 14
 AttackCount = 1
-DamageAttr = "NONE"
+Element = "NONE"
 AttackCategory = "HANDGUN"
 
 [[item]]
@@ -82,7 +82,7 @@ Description = "光線を発射する拳銃"
 Accuracy = 90
 Damage = 20
 AttackCount = 1
-DamageAttr = "PHOTON"
+Element = "PHOTON"
 AttackCategory = "HANDGUN"
 
 [[item]]
@@ -93,7 +93,7 @@ Description = "放電物質を投射する擲弾銃"
 Accuracy = 80
 Damage = 26
 AttackCount = 1
-DamageAttr = "THUNDER"
+Element = "THUNDER"
 AttackCategory = "RIFLE"
 
 [[item]]
@@ -104,7 +104,7 @@ Description = "極低温物質を投射する擲弾銃"
 Accuracy = 80
 Damage = 25
 AttackCount = 1
-DamageAttr = "CHILL"
+Element = "CHILL"
 AttackCategory = "RIFLE"
 
 # wearable ================

--- a/docs/images/202400418item.drawio.svg
+++ b/docs/images/202400418item.drawio.svg
@@ -1,0 +1,216 @@
+<svg host="65bd71144e" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="461px" height="517px" viewBox="-0.5 -0.5 461 517" content="&lt;mxfile&gt;&lt;diagram id=&quot;v9cDSuJH_laQwf1Gajgg&quot; name=&quot;Page-1&quot;&gt;5VjLcpswFP0a7S3Ec4kwabvoyouuFaOApoA8slw7+fpeQMImKE4ydW1PO+MZXx094J5zrqQBkaw5fFFsU32XBa+RtygOiCyR52EcL+CvQ54HJA7jASiVKMygI7ASL9yAZl65EwXfTgZqKWstNlNwLduWr/UEY0rJ/XTYk6ynT92wks+A1ZrVc/SHKHRlsggWR/wrF2Vln4wXpqdhdrABthUr5P4EIjkimZJSD1FzyHjdkWd5GeY9vNE7vpjirf7IBG+Y8IvVO5PbN80b82762Sa83YumZi206FYzpY0kC2ibBbjS/PDmS+AxNfAElw3X6hmGmAmRIcO4AYemvT9y6/sGq054JZZWZvQsx6WPKUNgsnYzEM4YQDlBsYfSMfD7AH6hCdKFDbDtohYJTECzPsAoha64G5nGKI+61WhqupLAPCLObEBn3AOvkC+tdAMpLDGErBZlC/Ea+OUKgI59AfZMTUcjiqKbThXfihf2WFuxNlK0uicroChYdmvttNwOauJeXSV/8kzWEtZdtrKX/EnU9SvoQ6p7Z1UPJqL7wUxznDg1/3PJE7fk5KhHSqYqkl7FQenEdgESohikBVskKIlQAgKDuoAsT7QHZInog0WI1f7BSp4iL6w7iR8VRGUXoTzoRlLP4Y+PuPP/9FA83zecHvIv4CEy81DGVHHxjfN8+mMmduf0HQxEDgbwJcoodpTR5wvC2NZD1NZcktsKIyc1FyGad2b/d6xNzmqL398fw7+0P9pr1kTZACW0lybohUhmQuwroflqw9Zdew8Xv6kql78nBGTu9sBBSXAJSvB9UjIW8i048e+TkzG5W3Diuk4m3UZIe3JioCW6B06SK3ISOX1i7jfACZwG8339CrWT3JAT1+F5B7Uz4+SateO6l9+BT14fO1e0iec+iW9OyezYuSYnjqP40tfu89m/3kvxPHnPeesOP58+NI9fg/q+k29qJP8N&lt;/diagram&gt;&lt;/mxfile&gt;">
+    <defs/>
+    <g>
+        <path d="M 20 6 L 20 6 L 460 6 L 460 6" fill="rgb(255, 255, 255)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
+        <path d="M 20 6 L 20 306 L 460 306 L 460 6" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
+        <g fill="rgb(0, 0, 0)" font-family="Helvetica" font-weight="bold" pointer-events="none" text-anchor="middle" font-size="12px">
+            <text x="239.5" y="10.5">
+                Item
+            </text>
+        </g>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 66px; margin-left: 120px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: none; white-space: nowrap;">
+                                アイテムメニューに表示される
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="120" y="70" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    アイテムメニューに表示される
+                </text>
+            </switch>
+        </g>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 106px; margin-left: 120px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: none; white-space: nowrap;">
+                                フィールド・戦闘中に使ったり
+                                <br/>
+                                売れるアイテム
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="120" y="110" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    フィールド・戦闘中に使ったり
+売れるアイテム
+                </text>
+            </switch>
+        </g>
+        <path d="M 260 146 L 260 146 L 430 146 L 430 146" fill="rgb(255, 255, 255)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
+        <path d="M 260 146 L 260 276 L 430 276 L 430 146" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
+        <g fill="rgb(0, 0, 0)" font-family="Helvetica" font-weight="bold" pointer-events="none" text-anchor="middle" font-size="12px">
+            <text x="344.5" y="150.5">
+                Card
+            </text>
+        </g>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 206px; margin-left: 355px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: none; white-space: nowrap;">
+                                戦闘中に使うコマンド群
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="355" y="210" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    戦闘中に使うコマンド群
+                </text>
+            </switch>
+        </g>
+        <rect x="20" y="376" width="50" height="50" fill="rgb(255, 255, 255)" stroke="rgb(0, 0, 0)" pointer-events="none"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 48px; height: 1px; padding-top: 401px; margin-left: 21px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: none; white-space: normal; overflow-wrap: normal;">
+                                回復
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="45" y="405" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    回復
+                </text>
+            </switch>
+        </g>
+        <rect x="80" y="376" width="50" height="50" fill="rgb(255, 255, 255)" stroke="rgb(0, 0, 0)" pointer-events="none"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 48px; height: 1px; padding-top: 401px; margin-left: 81px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: none; white-space: normal; overflow-wrap: normal;">
+                                回復
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="105" y="405" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    回復
+                </text>
+            </switch>
+        </g>
+        <rect x="200" y="376" width="50" height="50" fill="rgb(255, 255, 255)" stroke="rgb(0, 0, 0)" pointer-events="none"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 48px; height: 1px; padding-top: 401px; margin-left: 201px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: none; white-space: normal; overflow-wrap: normal;">
+                                回復
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="225" y="405" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    回復
+                </text>
+            </switch>
+        </g>
+        <rect x="200" y="436" width="50" height="50" fill="rgb(255, 255, 255)" stroke="rgb(0, 0, 0)" pointer-events="none"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 48px; height: 1px; padding-top: 461px; margin-left: 201px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: none; white-space: normal; overflow-wrap: normal;">
+                                防具
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="225" y="465" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    防具
+                </text>
+            </switch>
+        </g>
+        <rect x="140" y="436" width="50" height="50" fill="rgb(255, 255, 255)" stroke="rgb(0, 0, 0)" pointer-events="none"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 48px; height: 1px; padding-top: 461px; margin-left: 141px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: none; white-space: normal; overflow-wrap: normal;">
+                                売却
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="165" y="465" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    売却
+                </text>
+            </switch>
+        </g>
+        <rect x="140" y="376" width="50" height="50" fill="rgb(255, 255, 255)" stroke="rgb(0, 0, 0)" pointer-events="none"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 48px; height: 1px; padding-top: 401px; margin-left: 141px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: none; white-space: normal; overflow-wrap: normal;">
+                                回復
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="165" y="405" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    回復
+                </text>
+            </switch>
+        </g>
+        <rect x="20" y="436" width="50" height="50" fill="rgb(255, 255, 255)" stroke="rgb(0, 0, 0)" pointer-events="none"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 48px; height: 1px; padding-top: 461px; margin-left: 21px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: none; white-space: normal; overflow-wrap: normal;">
+                                売却
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="45" y="465" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    売却
+                </text>
+            </switch>
+        </g>
+        <rect x="80" y="436" width="50" height="50" fill="rgb(255, 255, 255)" stroke="rgb(0, 0, 0)" pointer-events="none"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 48px; height: 1px; padding-top: 461px; margin-left: 81px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: none; white-space: normal; overflow-wrap: normal;">
+                                売却
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="105" y="465" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    売却
+                </text>
+            </switch>
+        </g>
+        <path d="M 0 356 L 0 356 L 270 356 L 270 356" fill="rgb(255, 255, 255)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
+        <path d="M 0 356 L 0 516 L 270 516 L 270 356" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
+    </g>
+    <switch>
+        <g requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"/>
+        <a transform="translate(0,-5)" xlink:href="https://www.diagrams.net/doc/faq/svg-export-text-problems" target="_blank">
+            <text text-anchor="middle" font-size="10px" x="50%" y="100%">
+                Text is not SVG - cannot display
+            </text>
+        </a>
+    </switch>
+</svg>

--- a/docs/images/20240414battle.drawio.svg
+++ b/docs/images/20240414battle.drawio.svg
@@ -1,0 +1,595 @@
+<svg host="65bd71144e" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="761px" height="1221px" viewBox="-0.5 -0.5 761 1221" content="&lt;mxfile&gt;&lt;diagram id=&quot;kgbczjd7_QETh0BUD7S6&quot; name=&quot;Page-1&quot;&gt;1Vtdk5rKFv01VN17H1J8OvqIQiakbIgRM0XeHPSgqDE1OgH619+1d+P4Rc7knBN1TlVSQNPd7F577bW30KNZvVV5/zT+PhPryXSpmfqk1CxPM03DaOs4UEulWtqttmrInuaTutO+YTiX07qxHpc9zyfTzVHH7Xq93M6/Hzem62/fpun2qG389LQujrv9sV4eP/X7OJueNQzT8fK89WE+2c7qVTj6vv3DdJ7Ndk829PrOarzrXDdsZuPJujhosnzN6j2t11t1tip70yWBt8NFjXv/k7svhj1Nv21/ZYBlqRE/xsvnenG1Ydtqt9pNMV8tx99w1d1sx0/b2h86rs8fV1vwY/q0nZYHTfXj76fr1XT7VKFLfdeukaiOL4s9rnetum12gKmzaxzXvsxeZt4vFyf1iptXb54v3r/TOh2t69EJaOr2zuB4Wj9/m0xpBgMIFLP5djr8Pk7pbgG6o222XS3r2+cAvSD+ywi1jxF6IdMBRE0I/Q6AnAaALK2Nf+/rk661a+nwiUmQvdwyW0tY0318wllGZ5rfIVg7ruY7WrdN/26Or2G/DrBhXgjh1r+SgnfXo+BdA0C21gVABnNI19r2fzS/pXXQ2uUTk9iHe52u1vG5hfqVxjvnv7eH8oxtDVhejG27BPrG6XbKN7t1Pb4ZxhlE5ynx+oi0bpcEjPM0abxBRK6oSUZTXmxprq+1u5rl4o51e4BOYsi8IjxNSc1hzWZdhnJ33wCDTgFqKD0vhlBTVlNllLsro+y6BcnrX1lGNeF5scRmnie2N6ja16RY44+btxeEVut2qd46T/Wa36Yqkqoh6LmnuR3Cqg24mqLwrtf47927d2fAXgFKu+McQWkZVwxAq9OYEjue1jG4YG+TtN2cbvbp64Yr0s0+16i3CNFJWmxi0cUQagrIO83tkmxRHLYp6/0rs+FVg9E+1/43mA2vySyndbb+zWz8nU7nK37b251O5tvx43La22w+Py/59fK7/6G9vu9Nxtsxint1ab7f/Mg0s1sCIbP36UNofq265vjhizVYdexPw6AIPDcT+YD+z4MPs+3jvSM/DT+uJx8+F9G8/WNiTaz+t1T2V53qa9WuhOcWfYvmCTAvZtSnD+Xy0/z73dfVcvPorXPq8Udc/Eitz87j/Yh7dWeT+yz76unzOA7Kfp6WwvMzUdmVkAM7GdqFyH27n7uViLNM9FzY5W/VdVIfv+Q4FmKoPwsvK0Ma4wncE2YUZ2hz9f7Q1nktPfSJA0fM6TioIr7OJI/N/TKseI4q4rn8EnYU6jm+HsYp9akwVyXyzML8UuThjGwIvQH6B3rI9gE3Nd6JejTeleOebvbzkSG8GfXXQylwf2CJ6rA/XfPRFGZBayuFpLX6QNXn+yHsCb3U4jE9twwwf6hwwJyTDdnE65e+Q9iF8QLjRk7dv+D+eUB4YJ6B8dizyfYS107kLWvbRupZw9o2wsgLnJBtHOliRbYFVZhn9Fw7rNck8pTGVeHRmgJTrQnjHwTbCfx5TSKno7DCPNmKoQ0shdGP/ecoXmANOrgwsmmOUGYm+yUO+L6QboXngycpjTNCmT4DEzu892mMAx/sjnv7pVvCF7rwFlgz2bMwQ/Ij5kzYPpc4Vob5QGE5p3sjS+GUwO9Cf2SsfdnPFzY4hzX7RTS0Ycei5qWbKRwC4pARrgo8d0RzlWFMa/edkPgowZN78ufIQH/jBWeFr+Q5vI+SOUuc8/Ac2BwS5szHRcU2SzxjTtcjhUs+AP9sPfJGNuMInoBfwCKTaMPzE6wJtjLWGfHY4pggDIHH6TXzRwrw1rWETA5jz4yY78KJ7okLIyuUCWFYRsrHEpyseZNKtjHPDMIy8jKaz0QcbHBtIz6rwAueQ4rFex5b4tk0d6V441J/8IDWCa0hzL33G1oLsJBR7NsNPOe4wFoZ3+iBbBRVKAfgVmIy9vGiJL9gvLkb02etEQbbF7N9OjQIzxS2yD+zv7EujIXP5oexIdgPYbykMUYUpzZwwppEEbGfEynoPmw4fFaYM+egK19onARXDNaxmOLJNwVpRIyx1cGz4qQiLYoUfqS5FuEHfG1h+qyfUcw+tLBG/Wht8cjBWIyZ0FhwMiMuKxvjwKZ70ZF+wQLSm3gkKWZwtIlfIk8k8w96Bv6Tfki17gxzJI7S3tQM81HGfvN8ijniIbAW8EEgd1oQMieEVNwg+4njzBsb8QqeBiXiDjpIuQHj4s9K6+fUf1D1a63r5wMDHNgyV72UsQ/1AjHgEz5YZwJOU8y60DnSt4V9rG+uZC2Lv26Iv4I5mBbk1ygWhDnuceyAs6QBsCFfwhbkDNZyn/oCi5TiHLwkzRgVvBbpFuFDQbyhtdE6HGDDuUtpKOlCQDnPJK704wHpDWKcns1rLJGrTMKG85b0TWBTRV5CfgV/XPOR+CZh41yHbcAu/jhjjY3BjRg5dcfXoUt2FCGvObMZW4pJxpE1DTlzQDzb6yePyVh7YKcNu8Ad1yBMFNbQq7ltRWQD+X1ImgMM4xHnWNZZL4WPMj2KmRPI7a5OMYI+NmwjvTZV3skMwesOsF6hR9xnAV4NTNZO8CtcUUxl7K99/nQ5x5A/BMUh6SGuI84FGXFsyxwhrZ4Tn0YWdMMh3UEMoD3YafhOv8i2KuRcNyi59hiStoqS/AKOEyYqX8cD8qmt8rBvUB4kn4Ssjb7B6/QyXelUVrImUY2zzxm4ppyRlBgDe5AzmKO+rjgwUvHLHPURX5Q34UPqA11VvsTzOP7BQ495Cr8OjvM+6QvPkzjkQ2h9VeuCTfiLXMUPMAGXRmotvE7XUTEpKCbLyHOdOl6dfR0A7WB/wx7SDs7hrE9cLyGHw1bgyrl4YakabVfHBarWYc1Jq3DO9YKtsHV1VYu5hsoHuxpNlKoftJmPI0fl6tRSWgNuxrQGaHNOsUC1INYioU+H9Qk0i+ePhVS5DPNKsmdgRg/sN1NpVGIc55ZUaRaOiCHkC8IgKXgM5TCqX1l7DvAnznJO/biBf0gnTYp1tNvsZ4/wB49UPiNfQQ9GpuLkgjihNLOnK23hmoD9X3J+49oF8QP7BY3FmlnnvdRkH+TcjryTWnV9UNR6RLpBNZWBdTEHIlWvSOR1OkJPBnwt2NcBtIf6BZaKD2iuquFKwoVrdkkx60IHX2r2rI4r6g9efeFatfY9+PGVtVnFvjiMDStUPEHsTQg3Ws9WcE014JiKmL8u1VaHMVwoXix0rvdIS7jGXxSqls4s5DJgnh7nSPUsO5Rsn1FzCHiwfUbINeDgcE1UGykee5Q7wHvEDHTSZJ2SWYkcKSlWDriAGKJ6CT58EORLp3424imBjnA8kVYhV6JGgO9wpHpMcq6kekQeYoR846nfKOAw+DSi2ClVLgw5X6pY8etaLKnj3rfI7oifHahcgNzBtXPMv2tQg4y4ftnnSneXm4GDW1LeQY3kMCcZ18RUtU5SHXFfxbat+CJQizNnUV9NZmwn6a2XluFhnqp1BrlcVzWAL1XNIwiLinNDnpWHz6l9gdj/vCEMVUxBUziWBwXbjVr/KJahRyr/BfKRfIeqh+ts/AZS/PJN5macHPLSEawTdHxvcqxKtqtQ9X9QHT0DeVXVl745pjyJ2lnhNWB9Cff6UmtFUv9GS+SEfEdx/tDcv+730n/M2A4Qe7NWMG/Tr+xeR05WKc5eXoScvfRoejfyyy9qjYaXkIZtn78JeWn8Ry+Hmt7U8maJrsvvI3sHe3m6u708vf02n7MXKa/tD3sFrT9/a9Q6eZHWajeA1fTayNR/x2vtpi+9d/SZt9PZ7zVpeCPZoo0UrsGoGfRluGGHys8h/rNRDr0l7nTr4R3lPYDS9nbDuvVJZ+fGdvfMaX/5fd8LbX79fd+rH6Av9wK03eA2BY67A+fuDWBy1a1mTvPnLtei71vEIZMYc93oPgnuTgNJXjYtHeJh2b8DkKZPpB2Kv7Z9EIK49DX3b9LlFXScV+A5ThTXDCHHbmQLbRXr0AlQ6ppHQtVG4rjjD6g9CrPbw2U0pYqL4fXTvbKd9k7YT/bKWvx5+Xi3R/v829UNgLuqLDV9Fv09Wv17g6+pSrsYKA378muC3B2zyaRtCjcV7aaKzGlfrCJrEG2zNV4RAZaq9lKomLuT9/VJd4ecuzvhHepqqCrbGgq5v7Td/Z8WFM5f/6h6uyLLatjmd0lPnGfmO/7V4t8C99ONJFcFvmH34MVDgHbSH8/Rtd5GCFj67VxhN1RJl3RFi2NA/b5saV2bd7z0bhQDxun2xmsCf2Xx4T8ioX1aLf4jCWefe09ru79ZwP3WNGBcdbfRLeSofrVi0q+RN0D96wLe8FPjHHBIduv41RKDtWfpazif/pXVW9D2q+Js/ZK4/2OcVUf9dDK3+9MoubHYnNY+l3QKLvd/Dc33Dv6m3PL/Dw==&lt;/diagram&gt;&lt;/mxfile&gt;">
+    <defs/>
+    <g>
+        <path d="M 0 0 L 0 0 L 760 0 L 760 0" fill="rgb(255, 255, 255)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
+        <path d="M 0 0 L 0 560 L 760 560 L 760 0" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
+        <rect x="80" y="100" width="60" height="60" rx="9" ry="9" fill="rgb(255, 255, 255)" stroke="rgb(0, 0, 0)" pointer-events="none"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 58px; height: 1px; padding-top: 130px; margin-left: 81px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: none; white-space: normal; overflow-wrap: normal;">
+                                白瀬
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="110" y="134" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    白瀬
+                </text>
+            </switch>
+        </g>
+        <rect x="140" y="100" width="120" height="60" rx="9" ry="9" fill="rgb(255, 255, 255)" stroke="rgb(0, 0, 0)" pointer-events="none"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 130px; margin-left: 141px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: none; white-space: normal; overflow-wrap: normal;">
+                                ハンドガン
+                                <br/>
+                                通常
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="200" y="134" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    ハンドガン
+通常
+                </text>
+            </switch>
+        </g>
+        <rect x="80" y="170" width="60" height="60" rx="9" ry="9" fill="rgb(255, 255, 255)" stroke="rgb(0, 0, 0)" pointer-events="none"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 58px; height: 1px; padding-top: 200px; margin-left: 81px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: none; white-space: normal; overflow-wrap: normal;">
+                                白瀬
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="110" y="204" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    白瀬
+                </text>
+            </switch>
+        </g>
+        <rect x="140" y="170" width="120" height="60" rx="9" ry="9" fill="rgb(255, 255, 255)" stroke="rgb(0, 0, 0)" pointer-events="none"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 200px; margin-left: 141px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: none; white-space: normal; overflow-wrap: normal;">
+                                乱射(攻撃回数x1.5)
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="200" y="204" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    乱射(攻撃回数x1.5)
+                </text>
+            </switch>
+        </g>
+        <rect x="280" y="460" width="60" height="60" rx="9" ry="9" fill="rgb(255, 255, 255)" stroke="rgb(0, 0, 0)" pointer-events="none"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 58px; height: 1px; padding-top: 490px; margin-left: 281px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: none; white-space: normal; overflow-wrap: normal;">
+                                白瀬
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="310" y="494" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    白瀬
+                </text>
+            </switch>
+        </g>
+        <rect x="260" y="100" width="60" height="60" rx="9" ry="9" fill="rgb(255, 255, 255)" stroke="rgb(0, 0, 0)" pointer-events="none"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 58px; height: 1px; padding-top: 130px; margin-left: 261px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: none; white-space: normal; overflow-wrap: normal;">
+                                2
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="290" y="134" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    2
+                </text>
+            </switch>
+        </g>
+        <rect x="260" y="170" width="60" height="60" rx="9" ry="9" fill="rgb(255, 255, 255)" stroke="rgb(0, 0, 0)" pointer-events="none"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 58px; height: 1px; padding-top: 200px; margin-left: 261px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: none; white-space: normal; overflow-wrap: normal;">
+                                1
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="290" y="204" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    1
+                </text>
+            </switch>
+        </g>
+        <rect x="80" y="20" width="60" height="60" rx="9" ry="9" fill="rgb(255, 255, 255)" stroke="rgb(0, 0, 0)" pointer-events="none"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 58px; height: 1px; padding-top: 50px; margin-left: 81px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: none; white-space: normal; overflow-wrap: normal;">
+                                残: 3
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="110" y="54" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    残: 3
+                </text>
+            </switch>
+        </g>
+        <rect x="80" y="240" width="60" height="60" rx="9" ry="9" fill="rgb(255, 255, 255)" stroke="rgb(0, 0, 0)" pointer-events="none"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 58px; height: 1px; padding-top: 270px; margin-left: 81px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: none; white-space: normal; overflow-wrap: normal;">
+                                平山
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="110" y="274" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    平山
+                </text>
+            </switch>
+        </g>
+        <rect x="140" y="240" width="120" height="60" rx="9" ry="9" fill="rgb(255, 255, 255)" stroke="rgb(0, 0, 0)" pointer-events="none"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 270px; margin-left: 141px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: none; white-space: normal; overflow-wrap: normal;">
+                                ナイフ
+                                <br/>
+                                通常
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="200" y="274" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    ナイフ
+通常
+                </text>
+            </switch>
+        </g>
+        <rect x="260" y="240" width="60" height="60" rx="9" ry="9" fill="rgb(255, 255, 255)" stroke="rgb(0, 0, 0)" pointer-events="none"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 58px; height: 1px; padding-top: 270px; margin-left: 261px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: none; white-space: normal; overflow-wrap: normal;">
+                                2
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="290" y="274" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    2
+                </text>
+            </switch>
+        </g>
+        <rect x="360" y="460" width="60" height="60" rx="9" ry="9" fill="rgb(255, 255, 255)" stroke="rgb(0, 0, 0)" pointer-events="none"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 58px; height: 1px; padding-top: 490px; margin-left: 361px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: none; white-space: normal; overflow-wrap: normal;">
+                                平山
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="390" y="494" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    平山
+                </text>
+            </switch>
+        </g>
+        <rect x="495" y="310" width="120" height="60" fill="rgb(255, 255, 255)" stroke="rgb(0, 0, 0)" pointer-events="none"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 340px; margin-left: 496px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: none; white-space: normal; overflow-wrap: normal;">
+                                軽歩兵
+                                <br/>
+                                ||||||||...
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="555" y="344" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    軽歩兵
+||||||||...
+                </text>
+            </switch>
+        </g>
+        <rect x="440" y="460" width="60" height="60" rx="9" ry="9" fill="rgb(255, 255, 255)" stroke="rgb(0, 0, 0)" pointer-events="none"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 58px; height: 1px; padding-top: 490px; margin-left: 441px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: none; white-space: normal; overflow-wrap: normal;">
+                                村上
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="470" y="494" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    村上
+                </text>
+            </switch>
+        </g>
+        <rect x="80" y="310" width="60" height="60" rx="9" ry="9" fill="rgb(255, 255, 255)" stroke="rgb(0, 0, 0)" pointer-events="none"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 58px; height: 1px; padding-top: 340px; margin-left: 81px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: none; white-space: normal; overflow-wrap: normal;">
+                                村上
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="110" y="344" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    村上
+                </text>
+            </switch>
+        </g>
+        <rect x="140" y="310" width="120" height="60" rx="9" ry="9" fill="rgb(255, 255, 255)" stroke="rgb(0, 0, 0)" pointer-events="none"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 340px; margin-left: 141px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: none; white-space: normal; overflow-wrap: normal;">
+                                竹刀
+                                <br/>
+                                通常
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="200" y="344" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    竹刀
+通常
+                </text>
+            </switch>
+        </g>
+        <rect x="260" y="310" width="60" height="60" rx="9" ry="9" fill="rgb(255, 255, 255)" stroke="rgb(0, 0, 0)" pointer-events="none"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 58px; height: 1px; padding-top: 340px; margin-left: 261px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: none; white-space: normal; overflow-wrap: normal;">
+                                2
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="290" y="344" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    2
+                </text>
+            </switch>
+        </g>
+        <image x="494.5" y="159.5" width="144" height="144" xlink:href="data:image/svg+xml;base64,PHN2ZyB2aWV3Qm94PSIwIDAgMjQgMjQiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+PHN0eWxlPip7ZmlsbDojMDAwfTwvc3R5bGU+PHBhdGggZD0iTTIxLjcxMDEgMy4yMzQ4YS4wMjE4LjAyMTggMCAwIDEtLjAyMTYtLjAyMTVjLjAwMS0uMDgxNS4wMDMtLjM2OTguMDA0LS40MjQgMC0uMTI5Mi0uMTQyOC0uMTgzMS0uMjExNy0uMDgyOS0uMDExMy4wMTYtLjE0NTcuMjEyLS4yMjg3LjMzMjNhLjAyNDQuMDI0NCAwIDAgMS0uMDE5OC4wMTAzaC02LjU1MDhhLjA0NzMuMDQ3MyAwIDAgMS0uMDQ3My0uMDQ2M2wtLjAxMzEtLjE3N2EuMDQ3Ny4wNDc3IDAgMCAxIC4wNTYtLjA0NzdsLjMzNS4wMzE5YS4wNTkuMDU5IDAgMCAwIC4wNjI0LS4wNDQ1bC4yNDQxLS45ODlhLjA0NzUuMDQ3NSAwIDAgMC0uMDI5NS0uMDU0MmwtLjIyNjgtLjA4NDhhLjA0MjcuMDQyNyAwIDAgMS0uMDI2My0uMDI5NWMtLjA0MTItLjE3MjItLjM3NjYtMS4zMjM1LTEuOTkzNS0xLjU4MS0uNzg2Ny0uMTI1LTEuMzAyLjIxMDctMS41NzcuNDc4NGExLjU5NCAxLjU5NCAwIDAgMC0uMzAxOC40MDk1bC0uMDk2NS4yMTI1Yy0uMDA4LjAxNjQtLjA0Ni4yMTU3LS4wNDYuMjM0bC4wNTEzLjk4MTVhLjEwOS4xMDkgMCAwIDAgLjA0MjIuMDg1NmwuMzU0Ni4xNTMtLjE5NTguMzI0NGEuMDU1LjA1NSAwIDAgMS0uMDUzLjA0MDJzLS40MTcuMDEwOC0uNjIyNy4wMTkyYy0uMzg1Ni4wMTU1LTEuMjQ0NC40ODU4LTEuODc3MyAxLjgzODUtLjYyMTkgMS4zMjgyLS43MjQgMS41NDk2LS43MjQgMS41NDk2YS4wNzM2LjA3MzYgMCAwIDEtLjA2ODQuMDM5OGwtLjU3NzYuMDAxOWMtLjAzNTYgMC0uMDczNi4wMjg1LS4wODg2LjA2MDhsLS44OTgyIDIuNTQyOGMtLjAxNDkuMDMyMy0uMDA2LjA4MS4wMTczLjEwODFsLjYyNy4zOTE4YS4wNTkuMDU5IDAgMCAxIC4wMTk1LjA1OWwtLjMyNzQuOTY2NGEuMTkxNi4xOTE2IDAgMCAxLS4wMjM1LjA2MThsLS40MzQzLjM4MjRhLjEwNTYuMTA1NiAwIDAgMC0uMDM1Ni4wNTlsLS41OTc4IDEuNTMwOGEuMDYzMi4wNjMyIDAgMCAxLS4wNjA4LjA0NTVsLS4zMzU1LjAwMThhLjE2MzMuMTYzMyAwIDAgMC0uMTYyLjE0ODhsLS4yMDA3IDIuMjg4M2ExLjcxOTQgMS43MTk0IDAgMCAxLS4wMTU5LjEyMDdsLS4xNTgzLjkwOGEuMTI4LjEyOCAwIDAgMS0uMDMzMy4wNTUzbC0uNTU4NC40MjYzYy0uMjU1OS4yNDQzLS41OTg4LjY5MDMtLjc2NjUgMS4wMDE1bC0xLjg2IDMuOTIzNWMtLjA0NS4wODMzLS4wODExLjIyNy0uMDc4OC4zMjIxbC4xMzIxLjIzNTRjLjAwMi4wODQyLS4wMzE5LjQ1NTktLjA3MDcuNTMwN0wuODE3IDIzLjY1NDVhLjA5ODUuMDk4NSAwIDAgMC0uMDAzLjA4NTZsLjAzMDkuMDcwNi4wOTMyLjE4NTkgMS44OTEzLjAwMjljLjExNzMuMDEwNi4yNDctLjEzOTYuMjUwNy0uMzAwNWwuMTAyNy0xLjI5NjUtLjAyNjgtLjE5NTIgMy42MDYzLTQuMjMyYy4wOTQyLS4xMTQ2LjIyMi0uMzE2OC4yODYxLS40NTA2bDEuNzE4Ni0zLjc4OTJhLjE3MTIuMTcxMiAwIDAgMSAuMTAwNC0uMDg4bC4xMDg2LS4wMzVhLjE2OTQuMTY5NCAwIDAgMSAuMTgyNy4wNTI4Yy4xNTA1LjE4MDcuNTA0Mi43ODEuNjc2NSAxLjAzMTUuMTQyNS4yMDc5Ljg0OTUgMS4yMzA0IDEuMTU4MiAxLjU2NzUuMDg1My4wOTI2LjM0ODEuMTk4LjQ2NTguMjY5NmEuMDgzLjA4MyAwIDAgMSAuMDI5LjExMTlsLTEuMDI5OCAxLjgwODMtLjQ1NDkgMi4xMzU3YS45NTQyLjk1NDIgMCAwIDAtLjAzNTYuMTUyNmwtLjQxMTggMS40ODMxYy4wMDMuMTg3My0uMTQxLjI4NTYtLjE1MjcuNTA2NGwtLjE1IDEuMDg0YS4wNTgxLjA1ODEgMCAwIDAgLjA1ODIuMDYxNGwyLjU0NDUuMDE0Yy4wOTUxLS4wMDAzLjE5MDItLjAwNDUuMjg1NC0uMDA2N2ExLjEwNDkgMS4xMDQ5IDAgMCAwIC4wNzU1LS4wMDY5Yy4xMjQyLS4wMTU4LjU2MjktLjA3NTQuNzUtLjE1MDMuMTA5Ny0uMDM4OC4xODA5LS4wODE5LjIyNjgtLjEyOTUuMTg1NS0uMTkzNS4yMDAyLS4yNzguMjAzNC0uMzk3NS4wMDEtLjAyMTItLjAxMS0uMDcyNi0uMDI4My0uMTA0OS0uMDA1My0uMDExNy0uMDMxNi0uMDM4Mi0uMDU5LS4wNDc3bC0xLjE4MTUtLjM1NjJhLjM2OTMuMzY5MyAwIDAgMS0uMTg4OS0uMTMzOGwtLjMxNzItLjQ2OWEuMDg2NS4wODY1IDAgMCAxIC4wMTczLS4wOTczbC42MTgtLjYwOWEuMjAxNy4yMDE3IDAgMCAwIC4wNDgzLS4wNzJsMS45MDM2LTQuNDg4Yy4wODktLjI4NS4wNTk1LS42MDU2IDAtLjk0NDUtLjA0NC0uMjUwNC0uNjg1NC0xLjMyNjQtLjg1MzItMS42MjM2LS4xNDc2LS4yNjItMS4wNjc3LTEuODcwNy0xLjI4Ni0yLjI1MTctLjA3OTMtLjEzNzYtLjE4OTQtLjEzMjgtLjIyODctLjI3NmwtLjA3MjYtMS4xMTczYS4wMzk4LjAzOTggMCAwIDEgLjAzNTYtLjA1MDVsLjMzMTItLjAyNzZhLjA5My4wOTMgMCAwIDAgLjA3NDEtLjA0ODdsMS4xNDctMi4xNTQ0YS4wOTU4LjA5NTggMCAwIDAtLjAwMi0uMDk0bC0uMjM0OS0uMjkwN2EuMDg3NC4wODc0IDAgMCAxLS4wMDEtLjA4NzVsLjM1MTUtLjM3OTZhLjA1NC4wNTQgMCAwIDEgLjA3MzYtLjAyMDZsLjkzNDMuNTI2NmEuMzgxOS4zODE5IDAgMCAwIC4xODYuMDUwNWMuMjU5LS4wMDE5LjY4NTgtLjE1NDkuOTA4LS4yOTA2YS4zODMzLjM4MzMgMCAwIDAgLjEzODYtLjE0OGwuNDU4My0xLjA3MDNjLjAwNi0uMDEzNi4wMjYyLS4wMTE3LjAyOS4wMDI4bC4xMjc4LjU5NTNhLjA2MzUuMDYzNSAwIDAgMCAuMDc4OC4wNTAxbDEuMzQ5NC0uM2EuMDY2Mi4wNjYyIDAgMCAwIC4wNS0uMDc4NmwtLjMxOC0xLjM0MzdhLjA3MTYuMDcxNiAwIDAgMSAuMDA5LS4wNTM0bC4xMzEzLS4yMDM2YS4yODEuMjgxIDAgMCAwIC4wMzYtLjA4MTRsLjE1ODktLjcyNWEuMDQwOC4wNDA4IDAgMCAxIC4wMzk3LS4wMzIzbDMuNzMyNy4wMDQ3YS4wOTE2LjA5MTYgMCAwIDAgLjA5MzItLjA5MzF2LS42MzM2YS4wMjIuMDIyIDAgMCAxIC4wMjE2LS4wMjE2aDEuNDM5M2EuMDQ2NS4wNDY1IDAgMCAwIC4wNDY0LS4wNDYzdi0uMjg1NWEuMDQ2NS4wNDY1IDAgMCAwLS4wNDY0LS4wNDYzaC0xLjQzOTh6Ii8+PC9zdmc+" pointer-events="none"/>
+        <path d="M 600 640 L 600 640 L 760 640 L 760 640" fill="rgb(255, 255, 255)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
+        <path d="M 600 640 L 600 840 L 760 840 L 760 640" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
+        <g fill="rgb(0, 0, 0)" font-family="Helvetica" font-weight="bold" pointer-events="none" text-anchor="middle" font-size="12px">
+            <text x="679.5" y="644.5">
+                固有カード
+            </text>
+        </g>
+        <rect x="620" y="660" width="120" height="60" fill="rgb(255, 255, 255)" stroke="rgb(0, 0, 0)" pointer-events="none"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 690px; margin-left: 621px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: none; white-space: normal; overflow-wrap: normal;">
+                                狙撃
+                                <br/>
+                                次の攻撃カードの攻撃力を2倍にする
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="680" y="694" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    狙撃
+次の攻撃カードの攻撃力を2倍にする
+                </text>
+            </switch>
+        </g>
+        <rect x="620" y="740" width="120" height="60" fill="rgb(255, 255, 255)" stroke="rgb(0, 0, 0)" pointer-events="none"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 770px; margin-left: 621px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: none; white-space: normal; overflow-wrap: normal;">
+                                なし
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="680" y="774" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    なし
+                </text>
+            </switch>
+        </g>
+        <path d="M 0 880 L 0 880 L 210 880 L 210 880" fill="rgb(255, 255, 255)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
+        <path d="M 0 880 L 0 1220 L 210 1220 L 210 880" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
+        <g fill="rgb(0, 0, 0)" font-family="Helvetica" font-weight="bold" pointer-events="none" text-anchor="middle" font-size="12px">
+            <text x="104.5" y="884.5">
+                装備
+            </text>
+        </g>
+        <rect x="45" y="900" width="120" height="60" fill="rgb(255, 255, 255)" stroke="rgb(0, 0, 0)" pointer-events="none"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 930px; margin-left: 46px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: none; white-space: normal; overflow-wrap: normal;">
+                                鉄の鎧
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="105" y="934" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    鉄の鎧
+                </text>
+            </switch>
+        </g>
+        <rect x="45" y="1060" width="120" height="60" fill="rgb(255, 255, 255)" stroke="rgb(0, 0, 0)" pointer-events="none"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 1090px; margin-left: 46px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: none; white-space: normal; overflow-wrap: normal;">
+                                虹色の指輪
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="105" y="1094" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    虹色の指輪
+                </text>
+            </switch>
+        </g>
+        <rect x="45" y="980" width="120" height="60" fill="rgb(255, 255, 255)" stroke="rgb(0, 0, 0)" pointer-events="none"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 1010px; margin-left: 46px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: none; white-space: normal; overflow-wrap: normal;">
+                                ヘッドライト
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="105" y="1014" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    ヘッドライト
+                </text>
+            </switch>
+        </g>
+        <rect x="45" y="1140" width="120" height="60" fill="rgb(255, 255, 255)" stroke="rgb(0, 0, 0)" pointer-events="none"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 1170px; margin-left: 46px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: none; white-space: normal; overflow-wrap: normal;">
+                                なし
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="105" y="1174" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    なし
+                </text>
+            </switch>
+        </g>
+        <path d="M 0 640 L 0 640 L 580 640 L 580 640" fill="rgb(255, 255, 255)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
+        <path d="M 0 640 L 0 840 L 580 840 L 580 640" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
+        <g fill="rgb(0, 0, 0)" font-family="Helvetica" font-weight="bold" pointer-events="none" text-anchor="middle" font-size="12px">
+            <text x="289.5" y="644.5">
+                デッキ
+            </text>
+        </g>
+        <rect x="20" y="660" width="120" height="60" fill="rgb(255, 255, 255)" stroke="rgb(0, 0, 0)" pointer-events="none"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 690px; margin-left: 21px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: none; white-space: normal; overflow-wrap: normal;">
+                                &lt;アクション&gt;
+                                <br/>
+                                ハンドガン
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="80" y="694" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    &lt;アクション&gt;...
+                </text>
+            </switch>
+        </g>
+        <rect x="440" y="660" width="120" height="60" fill="rgb(255, 255, 255)" stroke="rgb(0, 0, 0)" pointer-events="none"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 690px; margin-left: 441px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: none; white-space: normal; overflow-wrap: normal;">
+                                &lt;アクション&gt;
+                                <br/>
+                                鉄の盾
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="500" y="694" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    &lt;アクション&gt;...
+                </text>
+            </switch>
+        </g>
+        <rect x="300" y="660" width="120" height="60" fill="rgb(255, 255, 255)" stroke="rgb(0, 0, 0)" pointer-events="none"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 690px; margin-left: 301px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: none; white-space: normal; overflow-wrap: normal;">
+                                &lt;アクション&gt;
+                                <br/>
+                                マシンガン
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="360" y="694" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    &lt;アクション&gt;...
+                </text>
+            </switch>
+        </g>
+        <rect x="160" y="660" width="120" height="60" fill="rgb(255, 255, 255)" stroke="rgb(0, 0, 0)" pointer-events="none"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 690px; margin-left: 161px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: none; white-space: normal; overflow-wrap: normal;">
+                                &lt;アクション&gt;
+                                <br/>
+                                手榴弾
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="220" y="694" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    &lt;アクション&gt;...
+                </text>
+            </switch>
+        </g>
+        <rect x="20" y="750" width="120" height="60" fill="rgb(255, 255, 255)" stroke="rgb(0, 0, 0)" pointer-events="none"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 780px; margin-left: 21px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: none; white-space: normal; overflow-wrap: normal;">
+                                &lt;アクション&gt;
+                                <br/>
+                                救急キット
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="80" y="784" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    &lt;アクション&gt;...
+                </text>
+            </switch>
+        </g>
+        <rect x="160" y="750" width="120" height="60" fill="rgb(255, 255, 255)" stroke="rgb(0, 0, 0)" pointer-events="none"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 780px; margin-left: 161px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: none; white-space: normal; overflow-wrap: normal;">
+                                &lt;アクション&gt;
+                                <br/>
+                                メス
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="220" y="784" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    &lt;アクション&gt;...
+                </text>
+            </switch>
+        </g>
+        <rect x="300" y="750" width="120" height="60" fill="rgb(255, 255, 255)" stroke="rgb(0, 0, 0)" pointer-events="none"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 780px; margin-left: 301px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: none; white-space: normal; overflow-wrap: normal;">
+                                &lt;ブースト&gt;
+                                <br/>
+                                乱射
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="360" y="784" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    &lt;ブースト&gt;...
+                </text>
+            </switch>
+        </g>
+        <rect x="440" y="750" width="120" height="60" fill="rgb(255, 255, 255)" stroke="rgb(0, 0, 0)" pointer-events="none"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 780px; margin-left: 441px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: none; white-space: normal; overflow-wrap: normal;">
+                                &lt;ブースト&gt;
+                                <br/>
+                                ダブルショット
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="500" y="784" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    &lt;ブースト&gt;...
+                </text>
+            </switch>
+        </g>
+    </g>
+    <switch>
+        <g requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"/>
+        <a transform="translate(0,-5)" xlink:href="https://www.diagrams.net/doc/faq/svg-export-text-problems" target="_blank">
+            <text text-anchor="middle" font-size="10px" x="50%" y="100%">
+                Text is not SVG - cannot display
+            </text>
+        </a>
+    </switch>
+</svg>

--- a/lib/components/components.go
+++ b/lib/components/components.go
@@ -135,10 +135,10 @@ type Card struct {
 }
 
 type Attack struct {
-	Accuracy       int            // 命中率
-	Damage         int            // 攻撃力
-	AttackCount    int            // 攻撃回数
-	DamageAttr     DamageAttrType // 攻撃属性
-	AttackCategory AttackType     // 攻撃種別
-	EquipBonus     EquipBonus     // ステータスへのボーナス
+	Accuracy       int         // 命中率
+	Damage         int         // 攻撃力
+	AttackCount    int         // 攻撃回数
+	Element        ElementType // 攻撃属性
+	AttackCategory AttackType  // 攻撃種別
+	EquipBonus     EquipBonus  // ステータスへのボーナス
 }

--- a/lib/components/components.go
+++ b/lib/components/components.go
@@ -43,8 +43,8 @@ type Warp struct {
 	Mode warpMode
 }
 
-// アイテム枠に入るもの
-// 使用できない売却専用アイテムなどはItem単独に含まれる
+// キャラクターが保持できるもの
+// 装備品、カード、回復アイテム、売却アイテム
 type Item struct{}
 
 // 消耗品。一度使うとなくなる
@@ -63,23 +63,23 @@ type Description struct {
 	Description string
 }
 
-// インベントリに所持している状態
+// インベントリに入っている状態
 type InBackpack struct{}
 
-// キャラクタが装備している状態
+// キャラクタが装備している状態。InBackpackとは排反
 type Equipped struct {
 	Owner         ecs.Entity
 	EquipmentSlot EquipmentSlotNumber
 }
 
-// 防具
+// 装備品。キャラクタが装備することでパラメータを変更できる
 type Wearable struct {
 	Defense           int           // 防御力
 	EquipmentCategory EquipmentType // 装備部位
 	EquipBonus        EquipBonus    // ステータスへのボーナス
 }
 
-// パーティに参加している状態
+// 冒険パーティに参加している状態
 type InParty struct{}
 
 // 冒険に参加できるメンバー
@@ -91,7 +91,7 @@ type Pools struct {
 	Level int
 }
 
-// エンティティが持つステータス。各種計算式で使う
+// エンティティが持つステータス値。各種計算式で使う
 type Attributes struct {
 	Vitality  Attribute // 体力。丈夫さ、持久力、しぶとさ。HPやSPに影響する
 	Strength  Attribute // 筋力。主に近接攻撃のダメージに影響する
@@ -102,16 +102,18 @@ type Attributes struct {
 }
 
 // 回復する性質
+// 直接的な数値が作用し、ステータスなどは考慮されない
 type ProvidesHealing struct {
 	Amount Amounter
 }
 
 // ダメージを与える性質
+// 直接的な数値が作用し、ステータスなどは考慮されない
 type InflictsDamage struct {
 	Amount int
 }
 
-// 合成素材。
+// 合成素材
 // アイテムとの違い:
 // - 個々のインスタンスで性能の違いはなく、単に数量だけを見る
 // - 複数の単位で扱うのでAmountを持つ。x3を合成で使ったりする
@@ -127,14 +129,15 @@ type Recipe struct {
 // 装備変更直後を示すダーティーフラグ
 type EquipmentChanged struct{}
 
-// カードは戦闘中に選択するためのコマンド
-// 攻撃や防御など、人に影響を及ぼすものをアクションカードという
-// 他カードをターゲットとするものをブーストカードという
+// カードは戦闘中に選択するコマンド
+// 攻撃、防御、回復など、人に影響を及ぼすものをアクションカードという
+// アクションカードをターゲットとして効果を変容させるものをブーストカードという
 type Card struct {
 	TargetType TargetType
 	Cost       int
 }
 
+// 攻撃の性質。攻撃毎にこの数値と作用対象のステータスを加味して、最終的なダメージ量を決定する
 type Attack struct {
 	Accuracy       int         // 命中率
 	Damage         int         // 攻撃力

--- a/lib/components/components.go
+++ b/lib/components/components.go
@@ -24,6 +24,7 @@ type Components struct {
 	Wearable         *ecs.SliceComponent
 	Attributes       *ecs.SliceComponent
 	EquipmentChanged *ecs.NullComponent
+	Card             *ecs.SliceComponent
 }
 
 type GridElement struct {
@@ -43,7 +44,7 @@ type Warp struct {
 }
 
 // アイテム枠に入るもの
-// 一切使用できない売却専用アイテムとかはItem単独に含まれる
+// 使用できない売却専用アイテムなどはItem単独に含まれる
 type Item struct{}
 
 // 消耗品。一度使うとなくなる

--- a/lib/components/components.go
+++ b/lib/components/components.go
@@ -141,5 +141,4 @@ type Attack struct {
 	AttackCount    int         // 攻撃回数
 	Element        ElementType // 攻撃属性
 	AttackCategory AttackType  // 攻撃種別
-	EquipBonus     EquipBonus  // ステータスへのボーナス
 }

--- a/lib/components/components.go
+++ b/lib/components/components.go
@@ -18,7 +18,7 @@ type Components struct {
 	Pools            *ecs.SliceComponent
 	ProvidesHealing  *ecs.SliceComponent
 	InflictsDamage   *ecs.SliceComponent
-	Weapon           *ecs.SliceComponent
+	Attack           *ecs.SliceComponent
 	Material         *ecs.SliceComponent
 	Recipe           *ecs.SliceComponent
 	Wearable         *ecs.SliceComponent
@@ -69,17 +69,6 @@ type InBackpack struct{}
 type Equipped struct {
 	Owner         ecs.Entity
 	EquipmentSlot EquipmentSlotNumber
-}
-
-// 武器
-type Weapon struct {
-	Accuracy          int            // 命中率
-	Damage            int            // 攻撃力
-	AttackCount       int            // 攻撃回数
-	EnergyConsumption int            // 消費エネルギー
-	DamageAttr        DamageAttrType // 攻撃属性
-	WeaponCategory    WeaponType     // 武器種別
-	EquipBonus        EquipBonus
 }
 
 // 防具
@@ -136,3 +125,21 @@ type Recipe struct {
 
 // 装備変更直後を示すダーティーフラグ
 type EquipmentChanged struct{}
+
+// カードは戦闘中に選択するためのコマンド
+// 攻撃や防御など、人に影響を及ぼすものをアクションカードという
+// 他カードをターゲットとするものをブーストカードという
+type Card struct {
+	TargetType TargetType
+	Cost       int
+}
+
+type Attack struct {
+	Accuracy          int            // 命中率
+	Damage            int            // 攻撃力
+	AttackCount       int            // 攻撃回数
+	EnergyConsumption int            // 消費エネルギー
+	DamageAttr        DamageAttrType // 攻撃属性
+	AttackCategory    AttackType     // 攻撃種別
+	EquipBonus        EquipBonus     // ステータスへのボーナス
+}

--- a/lib/components/components.go
+++ b/lib/components/components.go
@@ -135,11 +135,10 @@ type Card struct {
 }
 
 type Attack struct {
-	Accuracy          int            // 命中率
-	Damage            int            // 攻撃力
-	AttackCount       int            // 攻撃回数
-	EnergyConsumption int            // 消費エネルギー
-	DamageAttr        DamageAttrType // 攻撃属性
-	AttackCategory    AttackType     // 攻撃種別
-	EquipBonus        EquipBonus     // ステータスへのボーナス
+	Accuracy       int            // 命中率
+	Damage         int            // 攻撃力
+	AttackCount    int            // 攻撃回数
+	DamageAttr     DamageAttrType // 攻撃属性
+	AttackCategory AttackType     // 攻撃種別
+	EquipBonus     EquipBonus     // ステータスへのボーナス
 }

--- a/lib/components/enum.go
+++ b/lib/components/enum.go
@@ -154,39 +154,39 @@ func (es EquipmentType) String() string {
 // ================
 // 攻撃属性
 
-type DamageAttrType string
+type ElementType string
 
 const (
-	DamageAttrNone    DamageAttrType = "NONE"
-	DamageAttrFire    DamageAttrType = "FIRE"
-	DamageAttrThunder DamageAttrType = "THUNDER"
-	DamageAttrChill   DamageAttrType = "CHILL"
-	DamageAttrPhoton  DamageAttrType = "PHOTON"
+	ElementTypeNone    ElementType = "NONE"
+	ElementTypeFire    ElementType = "FIRE"
+	ElementTypeThunder ElementType = "THUNDER"
+	ElementTypeChill   ElementType = "CHILL"
+	ElementTypePhoton  ElementType = "PHOTON"
 )
 
-func (enum DamageAttrType) Valid() error {
+func (enum ElementType) Valid() error {
 	switch enum {
-	case DamageAttrNone, DamageAttrFire, DamageAttrThunder, DamageAttrChill, DamageAttrPhoton:
+	case ElementTypeNone, ElementTypeFire, ElementTypeThunder, ElementTypeChill, ElementTypePhoton:
 		return nil
 	}
 	return errors.Wrapf(ErrInvalidEnumType, "get %s", enum)
 }
 
-func (da DamageAttrType) String() string {
+func (da ElementType) String() string {
 	var result string
 	switch da {
-	case DamageAttrNone:
+	case ElementTypeNone:
 		result = "無"
-	case DamageAttrFire:
+	case ElementTypeFire:
 		result = "火"
-	case DamageAttrThunder:
+	case ElementTypeThunder:
 		result = "電"
-	case DamageAttrChill:
+	case ElementTypeChill:
 		result = "冷"
-	case DamageAttrPhoton:
+	case ElementTypePhoton:
 		result = "光"
 	default:
-		log.Fatal("invalid damage attr type")
+		log.Fatal("invalid element type")
 	}
 	return result
 }

--- a/lib/components/enum.go
+++ b/lib/components/enum.go
@@ -76,6 +76,7 @@ func (enum UsableSceneType) Valid() error {
 
 // ================
 // 武器種別
+// 種別によって適用する計算式が異なる
 
 type AttackType string
 
@@ -95,9 +96,9 @@ func (enum AttackType) Valid() error {
 	return errors.Wrapf(ErrInvalidEnumType, "get %s", enum)
 }
 
-func (wc AttackType) String() string {
+func (at AttackType) String() string {
 	var result string
-	switch wc {
+	switch at {
 	case AttackSword:
 		result = "刀剣"
 	case AttackSpear:
@@ -172,9 +173,9 @@ func (enum ElementType) Valid() error {
 	return errors.Wrapf(ErrInvalidEnumType, "get %s", enum)
 }
 
-func (da ElementType) String() string {
+func (et ElementType) String() string {
 	var result string
-	switch da {
+	switch et {
 	case ElementTypeNone:
 		result = "無"
 	case ElementTypeFire:

--- a/lib/components/enum.go
+++ b/lib/components/enum.go
@@ -42,6 +42,7 @@ type TargetFactionType string
 const (
 	TargetFactionAlly  = TargetFactionType("ALLY")  // 味方
 	TargetFactionEnemy = TargetFactionType("ENEMY") // 敵
+	TargetFactionCard  = TargetFactionType("CARD")  // カード
 	TargetFactionNone  = TargetFactionType("NONE")  // なし
 )
 
@@ -76,37 +77,37 @@ func (enum UsableSceneType) Valid() error {
 // ================
 // 武器種別
 
-type WeaponType string
+type AttackType string
 
 const (
-	WeaponSword   = WeaponType("SWORD")   // 刀剣
-	WeaponSpear   = WeaponType("SPEAR")   // 長物
-	WeaponHandgun = WeaponType("HANDGUN") // 拳銃
-	WeaponRifle   = WeaponType("RIFLE")   // 小銃
+	AttackSword   = AttackType("SWORD")   // 刀剣
+	AttackSpear   = AttackType("SPEAR")   // 長物
+	AttackHandgun = AttackType("HANDGUN") // 拳銃
+	AttackRifle   = AttackType("RIFLE")   // 小銃
 )
 
-func (enum WeaponType) Valid() error {
+func (enum AttackType) Valid() error {
 	switch enum {
-	case WeaponSword, WeaponSpear, WeaponHandgun, WeaponRifle:
+	case AttackSword, AttackSpear, AttackHandgun, AttackRifle:
 		return nil
 	}
 
 	return errors.Wrapf(ErrInvalidEnumType, "get %s", enum)
 }
 
-func (wc WeaponType) String() string {
+func (wc AttackType) String() string {
 	var result string
 	switch wc {
-	case WeaponSword:
+	case AttackSword:
 		result = "刀剣"
-	case WeaponSpear:
+	case AttackSpear:
 		result = "長物"
-	case WeaponHandgun:
+	case AttackHandgun:
 		result = "拳銃"
-	case WeaponRifle:
+	case AttackRifle:
 		result = "小銃"
 	default:
-		log.Fatal("invalid weapon type")
+		log.Fatal("invalid attack type")
 	}
 
 	return result

--- a/lib/components/types.go
+++ b/lib/components/types.go
@@ -34,9 +34,8 @@ type EquipBonus struct {
 	Agility   int
 
 	// 残り項目:
-	// 火属性などの属性耐性
-	// 頑丈+1、貫通+2などのパッシブスキル
-	// 「救護」「乱射」などのアクティブスキル
+	// - 火属性などの属性耐性
+	// - 頑丈+1、連射+2などのスキル
 }
 
 // ================
@@ -46,6 +45,7 @@ type Amounter interface {
 
 var _ Amounter = RatioAmount{}
 
+// 倍率指定
 type RatioAmount struct {
 	Ratio float64
 }
@@ -57,6 +57,7 @@ func (ra RatioAmount) Calc(base int) int {
 
 var _ Amounter = NumeralAmount{}
 
+// 絶対量指定
 type NumeralAmount struct {
 	Numeral int
 }

--- a/lib/loader/loader.go
+++ b/lib/loader/loader.go
@@ -33,6 +33,7 @@ type GameComponentList struct {
 	Wearable         *gc.Wearable
 	Attributes       *gc.Attributes
 	EquipmentChanged *gc.EquipmentChanged
+	Card             *gc.Card
 }
 
 type Entity struct {

--- a/lib/loader/loader.go
+++ b/lib/loader/loader.go
@@ -27,7 +27,7 @@ type GameComponentList struct {
 	Pools            *gc.Pools
 	ProvidesHealing  *gc.ProvidesHealing
 	InflictsDamage   *gc.InflictsDamage
-	Weapon           *gc.Weapon
+	Attack           *gc.Attack
 	Material         *gc.Material
 	Recipe           *gc.Recipe
 	Wearable         *gc.Wearable

--- a/lib/raw/raw.go
+++ b/lib/raw/raw.go
@@ -26,7 +26,6 @@ type Raws struct {
 	Members   []Member   `toml:"member"`
 }
 
-// tomlで入力として受け取る項目
 type Item struct {
 	Name            string
 	Description     string
@@ -193,12 +192,36 @@ func (rw *RawMaster) GenerateItem(name string, spawnType SpawnType) gloader.Game
 	}
 
 	if item.Card != nil {
+		if err := gc.TargetFactionType(item.Card.TargetFaction).Valid(); err != nil {
+			log.Fatal(err)
+		}
+		if err := gc.TargetNumType(item.Card.TargetNum).Valid(); err != nil {
+			log.Fatal(err)
+		}
+
 		cl.Card = &gc.Card{
 			TargetType: gc.TargetType{
 				TargetFaction: gc.TargetFactionType(item.Card.TargetFaction),
 				TargetNum:     gc.TargetNumType(item.Card.TargetNum),
 			},
 			Cost: item.Card.Cost,
+		}
+	}
+
+	if item.Attack != nil {
+		if err := gc.ElementType(item.Attack.Element).Valid(); err != nil {
+			log.Fatal(err)
+		}
+		if err := gc.AttackType(item.Attack.AttackCategory).Valid(); err != nil {
+			log.Fatal(err)
+		}
+
+		cl.Attack = &gc.Attack{
+			Accuracy:       item.Attack.Accuracy,
+			Damage:         item.Attack.Damage,
+			AttackCount:    item.Attack.AttackCount,
+			Element:        gc.ElementType(item.Attack.Element),
+			AttackCategory: gc.AttackType(item.Attack.AttackCategory),
 		}
 	}
 
@@ -213,22 +236,6 @@ func (rw *RawMaster) GenerateItem(name string, spawnType SpawnType) gloader.Game
 		}
 	}
 
-	if item.Attack != nil {
-		if err := components.AttackType(item.Attack.AttackCategory).Valid(); err != nil {
-			log.Fatal(err)
-		}
-		if err := components.ElementType(item.Attack.Element).Valid(); err != nil {
-			log.Fatal(err)
-		}
-		cl.Attack = &gc.Attack{
-			Accuracy:       item.Attack.Accuracy,
-			Damage:         item.Attack.Damage,
-			AttackCount:    item.Attack.AttackCount,
-			Element:        components.ElementType(item.Attack.Element),
-			AttackCategory: components.AttackType(item.Attack.AttackCategory),
-			EquipBonus:     bonus,
-		}
-	}
 	if item.Wearable != nil {
 		if err := components.EquipmentType(item.Wearable.EquipmentCategory).Valid(); err != nil {
 			log.Fatal(err)
@@ -273,7 +280,7 @@ func (rw *RawMaster) GenerateRecipe(name string) gloader.GameComponentList {
 		cl.Recipe.Inputs = append(cl.Recipe.Inputs, gc.RecipeInput{Name: input.Name, Amount: input.Amount})
 	}
 
-	// マッチしたitemの定義から持ってくる
+	// 説明文などのため、マッチしたitemの定義から持ってくる
 	item := rw.GenerateItem(recipe.Name, SpawnInBackpack)
 	cl.Description = &gc.Description{Description: item.Description.Description}
 	if item.Card != nil {

--- a/lib/raw/raw.go
+++ b/lib/raw/raw.go
@@ -51,12 +51,11 @@ type Consumable struct {
 }
 
 type Attack struct {
-	Accuracy          int    // 命中率
-	Damage            int    // 攻撃力
-	AttackCount       int    // 攻撃回数
-	EnergyConsumption int    // 攻撃で消費するエネルギー
-	DamageAttr        string // 攻撃属性
-	AttackCategory    string // 武器カテゴリ
+	Accuracy       int    // 命中率
+	Damage         int    // 攻撃力
+	AttackCount    int    // 攻撃回数
+	DamageAttr     string // 攻撃属性
+	AttackCategory string // 武器カテゴリ
 }
 
 type Wearable struct {
@@ -205,13 +204,12 @@ func (rw *RawMaster) GenerateItem(name string, spawnType SpawnType) gloader.Game
 			log.Fatal(err)
 		}
 		cl.Attack = &gc.Attack{
-			Accuracy:          item.Attack.Accuracy,
-			Damage:            item.Attack.Damage,
-			AttackCount:       item.Attack.AttackCount,
-			EnergyConsumption: item.Attack.EnergyConsumption,
-			DamageAttr:        components.DamageAttrType(item.Attack.DamageAttr),
-			AttackCategory:    components.AttackType(item.Attack.AttackCategory),
-			EquipBonus:        bonus,
+			Accuracy:       item.Attack.Accuracy,
+			Damage:         item.Attack.Damage,
+			AttackCount:    item.Attack.AttackCount,
+			DamageAttr:     components.DamageAttrType(item.Attack.DamageAttr),
+			AttackCategory: components.AttackType(item.Attack.AttackCategory),
+			EquipBonus:     bonus,
 		}
 	}
 	if item.Wearable != nil {

--- a/lib/raw/raw.go
+++ b/lib/raw/raw.go
@@ -33,7 +33,7 @@ type Item struct {
 	InflictsDamage  int
 	Consumable      *Consumable      `toml:"consumable"`
 	ProvidesHealing *ProvidesHealing `toml:"provides_healing"`
-	Weapon          *Weapon          `toml:"weapon"`
+	Attack          *Attack          `toml:"attack"`
 	Wearable        *Wearable        `toml:"wearable"`
 	EquipBonus      *EquipBonus      `toml:"equip_bonus"`
 }
@@ -50,13 +50,13 @@ type Consumable struct {
 	TargetNum     string
 }
 
-type Weapon struct {
+type Attack struct {
 	Accuracy          int    // 命中率
 	Damage            int    // 攻撃力
 	AttackCount       int    // 攻撃回数
 	EnergyConsumption int    // 攻撃で消費するエネルギー
 	DamageAttr        string // 攻撃属性
-	WeaponCategory    string // 武器カテゴリ
+	AttackCategory    string // 武器カテゴリ
 }
 
 type Wearable struct {
@@ -197,20 +197,20 @@ func (rw *RawMaster) GenerateItem(name string, spawnType SpawnType) gloader.Game
 		}
 	}
 
-	if item.Weapon != nil {
-		if err := components.WeaponType(item.Weapon.WeaponCategory).Valid(); err != nil {
+	if item.Attack != nil {
+		if err := components.AttackType(item.Attack.AttackCategory).Valid(); err != nil {
 			log.Fatal(err)
 		}
-		if err := components.DamageAttrType(item.Weapon.DamageAttr).Valid(); err != nil {
+		if err := components.DamageAttrType(item.Attack.DamageAttr).Valid(); err != nil {
 			log.Fatal(err)
 		}
-		cl.Weapon = &gc.Weapon{
-			Accuracy:          item.Weapon.Accuracy,
-			Damage:            item.Weapon.Damage,
-			AttackCount:       item.Weapon.AttackCount,
-			EnergyConsumption: item.Weapon.EnergyConsumption,
-			DamageAttr:        components.DamageAttrType(item.Weapon.DamageAttr),
-			WeaponCategory:    components.WeaponType(item.Weapon.WeaponCategory),
+		cl.Attack = &gc.Attack{
+			Accuracy:          item.Attack.Accuracy,
+			Damage:            item.Attack.Damage,
+			AttackCount:       item.Attack.AttackCount,
+			EnergyConsumption: item.Attack.EnergyConsumption,
+			DamageAttr:        components.DamageAttrType(item.Attack.DamageAttr),
+			AttackCategory:    components.AttackType(item.Attack.AttackCategory),
 			EquipBonus:        bonus,
 		}
 	}
@@ -261,8 +261,8 @@ func (rw *RawMaster) GenerateRecipe(name string) gloader.GameComponentList {
 	// マッチしたitemの定義から持ってくる
 	item := rw.GenerateItem(recipe.Name, SpawnInBackpack)
 	cl.Description = &gc.Description{Description: item.Description.Description}
-	if item.Weapon != nil {
-		cl.Weapon = item.Weapon
+	if item.Attack != nil {
+		cl.Attack = item.Attack
 	}
 	if item.Wearable != nil {
 		cl.Wearable = item.Wearable

--- a/lib/raw/raw.go
+++ b/lib/raw/raw.go
@@ -54,7 +54,7 @@ type Attack struct {
 	Accuracy       int    // 命中率
 	Damage         int    // 攻撃力
 	AttackCount    int    // 攻撃回数
-	DamageAttr     string // 攻撃属性
+	Element        string // 攻撃属性
 	AttackCategory string // 武器カテゴリ
 }
 
@@ -200,14 +200,14 @@ func (rw *RawMaster) GenerateItem(name string, spawnType SpawnType) gloader.Game
 		if err := components.AttackType(item.Attack.AttackCategory).Valid(); err != nil {
 			log.Fatal(err)
 		}
-		if err := components.DamageAttrType(item.Attack.DamageAttr).Valid(); err != nil {
+		if err := components.ElementType(item.Attack.Element).Valid(); err != nil {
 			log.Fatal(err)
 		}
 		cl.Attack = &gc.Attack{
 			Accuracy:       item.Attack.Accuracy,
 			Damage:         item.Attack.Damage,
 			AttackCount:    item.Attack.AttackCount,
-			DamageAttr:     components.DamageAttrType(item.Attack.DamageAttr),
+			Element:        components.ElementType(item.Attack.Element),
 			AttackCategory: components.AttackType(item.Attack.AttackCategory),
 			EquipBonus:     bonus,
 		}

--- a/lib/raw/raw.go
+++ b/lib/raw/raw.go
@@ -33,9 +33,10 @@ type Item struct {
 	InflictsDamage  int
 	Consumable      *Consumable      `toml:"consumable"`
 	ProvidesHealing *ProvidesHealing `toml:"provides_healing"`
-	Attack          *Attack          `toml:"attack"`
 	Wearable        *Wearable        `toml:"wearable"`
 	EquipBonus      *EquipBonus      `toml:"equip_bonus"`
+	Card            *Card            `toml:"card"`
+	Attack          *Attack          `toml:"attack"`
 }
 
 type ProvidesHealing struct {
@@ -46,6 +47,12 @@ type ProvidesHealing struct {
 
 type Consumable struct {
 	UsableScene   string
+	TargetFaction string
+	TargetNum     string
+}
+
+type Card struct {
+	Cost          int
 	TargetFaction string
 	TargetNum     string
 }
@@ -185,6 +192,16 @@ func (rw *RawMaster) GenerateItem(name string, spawnType SpawnType) gloader.Game
 		cl.InflictsDamage = &gc.InflictsDamage{Amount: item.InflictsDamage}
 	}
 
+	if item.Card != nil {
+		cl.Card = &gc.Card{
+			TargetType: gc.TargetType{
+				TargetFaction: gc.TargetFactionType(item.Card.TargetFaction),
+				TargetNum:     gc.TargetNumType(item.Card.TargetNum),
+			},
+			Cost: item.Card.Cost,
+		}
+	}
+
 	var bonus gc.EquipBonus
 	if item.EquipBonus != nil {
 		bonus = gc.EquipBonus{
@@ -259,6 +276,9 @@ func (rw *RawMaster) GenerateRecipe(name string) gloader.GameComponentList {
 	// マッチしたitemの定義から持ってくる
 	item := rw.GenerateItem(recipe.Name, SpawnInBackpack)
 	cl.Description = &gc.Description{Description: item.Description.Description}
+	if item.Card != nil {
+		cl.Card = item.Card
+	}
 	if item.Attack != nil {
 		cl.Attack = item.Attack
 	}

--- a/lib/states/camp_menu.go
+++ b/lib/states/camp_menu.go
@@ -68,7 +68,7 @@ func (st *CampMenuState) setSelection(selection int) {
 func (st *CampMenuState) confirmSelection(world w.World) states.Transition {
 	switch st.selection {
 	case 0:
-		return states.Transition{Type: states.TransSwitch, NewStates: []states.State{&InventoryMenuState{category: itemCategoryTypeConsumable}}}
+		return states.Transition{Type: states.TransSwitch, NewStates: []states.State{&InventoryMenuState{category: itemCategoryTypeItem}}}
 	case 1:
 		return states.Transition{Type: states.TransSwitch, NewStates: []states.State{&EquipMenuState{}}}
 	}

--- a/lib/states/craft_menu.go
+++ b/lib/states/craft_menu.go
@@ -118,7 +118,7 @@ func (st *CraftMenuState) categoryReload(world w.World) {
 
 	switch st.category {
 	case itemCategoryTypeItem:
-		st.items = simple.QueryMenuItem(world)
+		st.items = st.queryMenuConsumable(world)
 	case itemCategoryTypeCard:
 		st.items = st.queryMenuCard(world)
 	case itemCategoryTypeWearable:
@@ -142,7 +142,7 @@ func (st *CraftMenuState) initUI(world w.World) *ebitenui.UI {
 	st.itemDesc = eui.NewMenuText(" ", world) // 空白だと初期状態の縦サイズがなくなる
 	itemDescContainer.AddChild(st.itemDesc)
 
-	simple.QueryMenuItem(world)
+	st.queryMenuConsumable(world)
 	toggleContainer := eui.NewRowContainer()
 	toggleConsumableButton := eui.NewItemButton("道具", func(args *widget.ButtonClickedEventArgs) { st.setCategoryReload(world, itemCategoryTypeItem) }, world)
 	toggleWearableButton := eui.NewItemButton("装備", func(args *widget.ButtonClickedEventArgs) { st.setCategoryReload(world, itemCategoryTypeWearable) }, world)
@@ -169,6 +169,25 @@ func (st *CraftMenuState) initUI(world w.World) *ebitenui.UI {
 	}
 
 	return &ebitenui.UI{Container: rootContainer}
+}
+
+func (st *CraftMenuState) queryMenuConsumable(world w.World) []ecs.Entity {
+	items := []ecs.Entity{}
+
+	gameComponents := world.Components.Game.(*gc.Components)
+	world.Manager.Join(
+		gameComponents.Name,
+		gameComponents.Recipe,
+		gameComponents.Consumable,
+	).Visit(ecs.Visit(func(entity ecs.Entity) {
+		if entity.HasComponent(gameComponents.Card) {
+			return
+		}
+
+		items = append(items, entity)
+	}))
+
+	return items
 }
 
 func (st *CraftMenuState) queryMenuCard(world w.World) []ecs.Entity {

--- a/lib/states/craft_menu.go
+++ b/lib/states/craft_menu.go
@@ -145,11 +145,11 @@ func (st *CraftMenuState) initUI(world w.World) *ebitenui.UI {
 	st.queryMenuConsumable(world)
 	toggleContainer := eui.NewRowContainer()
 	toggleConsumableButton := eui.NewItemButton("道具", func(args *widget.ButtonClickedEventArgs) { st.setCategoryReload(world, itemCategoryTypeConsumable) }, world)
+	toggleWearableButton := eui.NewItemButton("装備", func(args *widget.ButtonClickedEventArgs) { st.setCategoryReload(world, itemCategoryTypeWearable) }, world)
 	toggleCardButton := eui.NewItemButton("手札", func(args *widget.ButtonClickedEventArgs) { st.setCategoryReload(world, itemCategoryTypeCard) }, world)
-	toggleWearableButton := eui.NewItemButton("防具", func(args *widget.ButtonClickedEventArgs) { st.setCategoryReload(world, itemCategoryTypeWearable) }, world)
 	toggleContainer.AddChild(toggleConsumableButton)
-	toggleContainer.AddChild(toggleCardButton)
 	toggleContainer.AddChild(toggleWearableButton)
+	toggleContainer.AddChild(toggleCardButton)
 
 	st.recipeList = st.newItemSpecContainer(world)
 	st.specContainer = st.newItemSpecContainer(world)

--- a/lib/states/craft_menu.go
+++ b/lib/states/craft_menu.go
@@ -117,8 +117,8 @@ func (st *CraftMenuState) categoryReload(world w.World) {
 	st.items = []ecs.Entity{}
 
 	switch st.category {
-	case itemCategoryTypeConsumable:
-		st.items = st.queryMenuConsumable(world)
+	case itemCategoryTypeItem:
+		st.items = simple.QueryMenuItem(world)
 	case itemCategoryTypeCard:
 		st.items = st.queryMenuCard(world)
 	case itemCategoryTypeWearable:
@@ -142,9 +142,9 @@ func (st *CraftMenuState) initUI(world w.World) *ebitenui.UI {
 	st.itemDesc = eui.NewMenuText(" ", world) // 空白だと初期状態の縦サイズがなくなる
 	itemDescContainer.AddChild(st.itemDesc)
 
-	st.queryMenuConsumable(world)
+	simple.QueryMenuItem(world)
 	toggleContainer := eui.NewRowContainer()
-	toggleConsumableButton := eui.NewItemButton("道具", func(args *widget.ButtonClickedEventArgs) { st.setCategoryReload(world, itemCategoryTypeConsumable) }, world)
+	toggleConsumableButton := eui.NewItemButton("道具", func(args *widget.ButtonClickedEventArgs) { st.setCategoryReload(world, itemCategoryTypeItem) }, world)
 	toggleWearableButton := eui.NewItemButton("装備", func(args *widget.ButtonClickedEventArgs) { st.setCategoryReload(world, itemCategoryTypeWearable) }, world)
 	toggleCardButton := eui.NewItemButton("手札", func(args *widget.ButtonClickedEventArgs) { st.setCategoryReload(world, itemCategoryTypeCard) }, world)
 	toggleContainer.AddChild(toggleConsumableButton)
@@ -169,21 +169,6 @@ func (st *CraftMenuState) initUI(world w.World) *ebitenui.UI {
 	}
 
 	return &ebitenui.UI{Container: rootContainer}
-}
-
-func (st *CraftMenuState) queryMenuConsumable(world w.World) []ecs.Entity {
-	items := []ecs.Entity{}
-
-	gameComponents := world.Components.Game.(*gc.Components)
-	world.Manager.Join(
-		gameComponents.Name,
-		gameComponents.Recipe,
-		gameComponents.Consumable,
-	).Visit(ecs.Visit(func(entity ecs.Entity) {
-		items = append(items, entity)
-	}))
-
-	return items
 }
 
 func (st *CraftMenuState) queryMenuCard(world w.World) []ecs.Entity {

--- a/lib/states/craft_menu.go
+++ b/lib/states/craft_menu.go
@@ -119,8 +119,8 @@ func (st *CraftMenuState) categoryReload(world w.World) {
 	switch st.category {
 	case itemCategoryTypeConsumable:
 		st.items = st.queryMenuConsumable(world)
-	case itemCategoryTypeWeapon:
-		st.items = st.queryMenuWeapon(world)
+	case itemCategoryTypeAttack:
+		st.items = st.queryMenuAttack(world)
 	case itemCategoryTypeWearable:
 		st.items = st.queryMenuWearable(world)
 	default:
@@ -145,10 +145,10 @@ func (st *CraftMenuState) initUI(world w.World) *ebitenui.UI {
 	st.queryMenuConsumable(world)
 	toggleContainer := eui.NewRowContainer()
 	toggleConsumableButton := eui.NewItemButton("道具", func(args *widget.ButtonClickedEventArgs) { st.setCategoryReload(world, itemCategoryTypeConsumable) }, world)
-	toggleWeaponButton := eui.NewItemButton("武器", func(args *widget.ButtonClickedEventArgs) { st.setCategoryReload(world, itemCategoryTypeWeapon) }, world)
+	toggleAttackButton := eui.NewItemButton("武器", func(args *widget.ButtonClickedEventArgs) { st.setCategoryReload(world, itemCategoryTypeAttack) }, world)
 	toggleWearableButton := eui.NewItemButton("防具", func(args *widget.ButtonClickedEventArgs) { st.setCategoryReload(world, itemCategoryTypeWearable) }, world)
 	toggleContainer.AddChild(toggleConsumableButton)
-	toggleContainer.AddChild(toggleWeaponButton)
+	toggleContainer.AddChild(toggleAttackButton)
 	toggleContainer.AddChild(toggleWearableButton)
 
 	st.recipeList = st.newItemSpecContainer(world)
@@ -186,14 +186,14 @@ func (st *CraftMenuState) queryMenuConsumable(world w.World) []ecs.Entity {
 	return items
 }
 
-func (st *CraftMenuState) queryMenuWeapon(world w.World) []ecs.Entity {
+func (st *CraftMenuState) queryMenuAttack(world w.World) []ecs.Entity {
 	items := []ecs.Entity{}
 
 	gameComponents := world.Components.Game.(*gc.Components)
 	world.Manager.Join(
 		gameComponents.Name,
 		gameComponents.Recipe,
-		gameComponents.Weapon,
+		gameComponents.Attack,
 	).Visit(ecs.Visit(func(entity ecs.Entity) {
 		items = append(items, entity)
 	}))
@@ -241,7 +241,7 @@ func (st *CraftMenuState) generateActionContainer(world world.World) {
 			}
 			st.itemDesc.Label = simple.GetDescription(world, entity).Description
 			views.UpdateSpec(world, st.specContainer, []any{
-				simple.GetWeapon(world, entity),
+				simple.GetAttack(world, entity),
 				simple.GetWearable(world, entity),
 			})
 			st.updateRecipeList(world)
@@ -297,7 +297,7 @@ func (st *CraftMenuState) initResultWindow(world w.World, entity ecs.Entity) {
 	st.resultWindow = eui.NewSmallWindow(eui.NewWindowHeaderContainer("合成結果", world), resultContainer)
 
 	views.UpdateSpec(world, resultContainer, []any{
-		simple.GetWeapon(world, entity),
+		simple.GetAttack(world, entity),
 		simple.GetWearable(world, entity),
 	})
 

--- a/lib/states/craft_menu.go
+++ b/lib/states/craft_menu.go
@@ -119,8 +119,8 @@ func (st *CraftMenuState) categoryReload(world w.World) {
 	switch st.category {
 	case itemCategoryTypeConsumable:
 		st.items = st.queryMenuConsumable(world)
-	case itemCategoryTypeAttack:
-		st.items = st.queryMenuAttack(world)
+	case itemCategoryTypeCard:
+		st.items = st.queryMenuCard(world)
 	case itemCategoryTypeWearable:
 		st.items = st.queryMenuWearable(world)
 	default:
@@ -145,10 +145,10 @@ func (st *CraftMenuState) initUI(world w.World) *ebitenui.UI {
 	st.queryMenuConsumable(world)
 	toggleContainer := eui.NewRowContainer()
 	toggleConsumableButton := eui.NewItemButton("道具", func(args *widget.ButtonClickedEventArgs) { st.setCategoryReload(world, itemCategoryTypeConsumable) }, world)
-	toggleAttackButton := eui.NewItemButton("武器", func(args *widget.ButtonClickedEventArgs) { st.setCategoryReload(world, itemCategoryTypeAttack) }, world)
+	toggleCardButton := eui.NewItemButton("手札", func(args *widget.ButtonClickedEventArgs) { st.setCategoryReload(world, itemCategoryTypeCard) }, world)
 	toggleWearableButton := eui.NewItemButton("防具", func(args *widget.ButtonClickedEventArgs) { st.setCategoryReload(world, itemCategoryTypeWearable) }, world)
 	toggleContainer.AddChild(toggleConsumableButton)
-	toggleContainer.AddChild(toggleAttackButton)
+	toggleContainer.AddChild(toggleCardButton)
 	toggleContainer.AddChild(toggleWearableButton)
 
 	st.recipeList = st.newItemSpecContainer(world)
@@ -186,14 +186,14 @@ func (st *CraftMenuState) queryMenuConsumable(world w.World) []ecs.Entity {
 	return items
 }
 
-func (st *CraftMenuState) queryMenuAttack(world w.World) []ecs.Entity {
+func (st *CraftMenuState) queryMenuCard(world w.World) []ecs.Entity {
 	items := []ecs.Entity{}
 
 	gameComponents := world.Components.Game.(*gc.Components)
 	world.Manager.Join(
 		gameComponents.Name,
 		gameComponents.Recipe,
-		gameComponents.Attack,
+		gameComponents.Card,
 	).Visit(ecs.Visit(func(entity ecs.Entity) {
 		items = append(items, entity)
 	}))
@@ -219,6 +219,7 @@ func (st *CraftMenuState) queryMenuWearable(world w.World) []ecs.Entity {
 // itemsからactionContainerを生成する
 func (st *CraftMenuState) generateActionContainer(world world.World) {
 	gameComponents := world.Components.Game.(*gc.Components)
+
 	for _, entity := range st.items {
 		entity := entity
 		name := gameComponents.Name.Get(entity).(*gc.Name)
@@ -241,6 +242,7 @@ func (st *CraftMenuState) generateActionContainer(world world.World) {
 			}
 			st.itemDesc.Label = simple.GetDescription(world, entity).Description
 			views.UpdateSpec(world, st.specContainer, []any{
+				simple.GetCard(world, entity),
 				simple.GetAttack(world, entity),
 				simple.GetWearable(world, entity),
 			})
@@ -297,6 +299,7 @@ func (st *CraftMenuState) initResultWindow(world w.World, entity ecs.Entity) {
 	st.resultWindow = eui.NewSmallWindow(eui.NewWindowHeaderContainer("合成結果", world), resultContainer)
 
 	views.UpdateSpec(world, resultContainer, []any{
+		simple.GetCard(world, entity),
 		simple.GetAttack(world, entity),
 		simple.GetWearable(world, entity),
 	})

--- a/lib/states/equip_menu.go
+++ b/lib/states/equip_menu.go
@@ -173,7 +173,7 @@ func (st *EquipMenuState) generateActionContainer(world w.World) {
 			st.itemDesc.Label = desc
 			if v != nil {
 				views.UpdateSpec(world, st.specContainer, []any{
-					simple.GetWeapon(world, *v),
+					simple.GetAttack(world, *v),
 					simple.GetWearable(world, *v),
 				})
 			} else {
@@ -181,7 +181,7 @@ func (st *EquipMenuState) generateActionContainer(world w.World) {
 			}
 		})
 		equipButton := eui.NewItemButton("装備する", func(args *widget.ButtonClickedEventArgs) {
-			st.items = st.queryMenuWeapon(world)
+			st.items = st.queryMenuAttack(world)
 			f := func() { st.generateActionContainerEquip(world, member, gc.EquipmentSlotNumber(i), v) }
 			f()
 			st.toggleSubMenu(world, true, f)
@@ -230,7 +230,7 @@ func (st *EquipMenuState) generateActionContainerEquip(world w.World, member ecs
 		itemButton.GetWidget().CursorEnterEvent.AddHandler(func(args interface{}) {
 			st.itemDesc.Label = simple.GetDescription(world, entity).Description
 			views.UpdateSpec(world, st.specContainer, []any{
-				simple.GetWeapon(world, entity),
+				simple.GetAttack(world, entity),
 				simple.GetWearable(world, entity),
 				simple.GetMaterial(world, entity),
 			})
@@ -244,9 +244,9 @@ func (st *EquipMenuState) toggleSubMenu(world w.World, isInventory bool, reloadF
 	st.subMenuContainer.RemoveChildren()
 
 	if isInventory {
-		toggleWeaponButton := eui.NewItemButton("武器", func(args *widget.ButtonClickedEventArgs) { st.items = st.queryMenuWeapon(world); reloadFunc() }, world)
+		toggleAttackButton := eui.NewItemButton("武器", func(args *widget.ButtonClickedEventArgs) { st.items = st.queryMenuAttack(world); reloadFunc() }, world)
 		toggleWearableButton := eui.NewItemButton("防具", func(args *widget.ButtonClickedEventArgs) { st.items = st.queryMenuWearable(world); reloadFunc() }, world)
-		st.subMenuContainer.AddChild(toggleWeaponButton)
+		st.subMenuContainer.AddChild(toggleAttackButton)
 		st.subMenuContainer.AddChild(toggleWearableButton)
 	} else {
 		members := []ecs.Entity{}
@@ -308,14 +308,14 @@ func (st *EquipMenuState) reloadAbilityContainer(world w.World) {
 }
 
 // 装備可能な武器を取得する
-func (st *EquipMenuState) queryMenuWeapon(world w.World) []ecs.Entity {
+func (st *EquipMenuState) queryMenuAttack(world w.World) []ecs.Entity {
 	items := []ecs.Entity{}
 
 	gameComponents := world.Components.Game.(*gc.Components)
 	world.Manager.Join(
 		gameComponents.Item,
 		gameComponents.InBackpack,
-		gameComponents.Weapon,
+		gameComponents.Attack,
 	).Visit(ecs.Visit(func(entity ecs.Entity) {
 		items = append(items, entity)
 	}))

--- a/lib/states/equip_menu.go
+++ b/lib/states/equip_menu.go
@@ -174,7 +174,6 @@ func (st *EquipMenuState) generateActionContainer(world w.World) {
 			if v != nil {
 				views.UpdateSpec(world, st.specContainer, []any{
 					simple.GetCard(world, *v),
-					simple.GetAttack(world, *v),
 					simple.GetWearable(world, *v),
 					simple.GetMaterial(world, *v),
 				})
@@ -183,7 +182,7 @@ func (st *EquipMenuState) generateActionContainer(world w.World) {
 			}
 		})
 		equipButton := eui.NewItemButton("装備する", func(args *widget.ButtonClickedEventArgs) {
-			st.items = st.queryMenuAttack(world)
+			st.items = st.queryMenuWearable(world)
 			f := func() { st.generateActionContainerEquip(world, member, gc.EquipmentSlotNumber(i), v) }
 			f()
 			st.toggleSubMenu(world, true, f)
@@ -233,7 +232,6 @@ func (st *EquipMenuState) generateActionContainerEquip(world w.World, member ecs
 			st.itemDesc.Label = simple.GetDescription(world, entity).Description
 			views.UpdateSpec(world, st.specContainer, []any{
 				simple.GetCard(world, entity),
-				simple.GetAttack(world, entity),
 				simple.GetWearable(world, entity),
 				simple.GetMaterial(world, entity),
 			})
@@ -247,9 +245,7 @@ func (st *EquipMenuState) toggleSubMenu(world w.World, isInventory bool, reloadF
 	st.subMenuContainer.RemoveChildren()
 
 	if isInventory {
-		toggleAttackButton := eui.NewItemButton("武器", func(args *widget.ButtonClickedEventArgs) { st.items = st.queryMenuAttack(world); reloadFunc() }, world)
 		toggleWearableButton := eui.NewItemButton("防具", func(args *widget.ButtonClickedEventArgs) { st.items = st.queryMenuWearable(world); reloadFunc() }, world)
-		st.subMenuContainer.AddChild(toggleAttackButton)
 		st.subMenuContainer.AddChild(toggleWearableButton)
 	} else {
 		members := []ecs.Entity{}
@@ -308,22 +304,6 @@ func (st *EquipMenuState) reloadAbilityContainer(world w.World) {
 		st.abilityContainer.AddChild(eui.NewBodyText(fmt.Sprintf("%s %2d(%+d)", consts.AgilityLabel, attrs.Agility.Total, attrs.Agility.Modifier), styles.TextColor, world))
 		st.abilityContainer.AddChild(eui.NewBodyText(fmt.Sprintf("%s %2d(%+d)", consts.DefenseLabel, attrs.Defense.Total, attrs.Defense.Modifier), styles.TextColor, world))
 	}
-}
-
-// 装備可能な武器を取得する
-func (st *EquipMenuState) queryMenuAttack(world w.World) []ecs.Entity {
-	items := []ecs.Entity{}
-
-	gameComponents := world.Components.Game.(*gc.Components)
-	world.Manager.Join(
-		gameComponents.Item,
-		gameComponents.InBackpack,
-		gameComponents.Attack,
-	).Visit(ecs.Visit(func(entity ecs.Entity) {
-		items = append(items, entity)
-	}))
-
-	return items
 }
 
 // 装備可能な防具を取得する

--- a/lib/states/equip_menu.go
+++ b/lib/states/equip_menu.go
@@ -173,8 +173,10 @@ func (st *EquipMenuState) generateActionContainer(world w.World) {
 			st.itemDesc.Label = desc
 			if v != nil {
 				views.UpdateSpec(world, st.specContainer, []any{
+					simple.GetCard(world, *v),
 					simple.GetAttack(world, *v),
 					simple.GetWearable(world, *v),
+					simple.GetMaterial(world, *v),
 				})
 			} else {
 				st.specContainer.RemoveChildren()
@@ -230,6 +232,7 @@ func (st *EquipMenuState) generateActionContainerEquip(world w.World, member ecs
 		itemButton.GetWidget().CursorEnterEvent.AddHandler(func(args interface{}) {
 			st.itemDesc.Label = simple.GetDescription(world, entity).Description
 			views.UpdateSpec(world, st.specContainer, []any{
+				simple.GetCard(world, entity),
 				simple.GetAttack(world, entity),
 				simple.GetWearable(world, entity),
 				simple.GetMaterial(world, entity),

--- a/lib/states/home_menu.go
+++ b/lib/states/home_menu.go
@@ -56,7 +56,7 @@ func (st *HomeMenuState) OnStart(world w.World) {
 		armor := spawner.SpawnItem(world, "西洋鎧", raw.SpawnInBackpack)
 		spawner.SpawnItem(world, "作業用ヘルメット", raw.SpawnInBackpack)
 		spawner.SpawnItem(world, "革のブーツ", raw.SpawnInBackpack)
-		spawner.SpawnItem(world, "ルビー", raw.SpawnInBackpack)
+		spawner.SpawnItem(world, "ルビー原石", raw.SpawnInBackpack)
 		spawner.SpawnItem(world, "回復薬", raw.SpawnInBackpack)
 		spawner.SpawnItem(world, "回復薬", raw.SpawnInBackpack)
 		spawner.SpawnItem(world, "回復スプレー", raw.SpawnInBackpack)

--- a/lib/states/home_menu.go
+++ b/lib/states/home_menu.go
@@ -56,6 +56,7 @@ func (st *HomeMenuState) OnStart(world w.World) {
 		armor := spawner.SpawnItem(world, "西洋鎧", raw.SpawnInBackpack)
 		spawner.SpawnItem(world, "作業用ヘルメット", raw.SpawnInBackpack)
 		spawner.SpawnItem(world, "革のブーツ", raw.SpawnInBackpack)
+		spawner.SpawnItem(world, "ルビー", raw.SpawnInBackpack)
 		spawner.SpawnItem(world, "回復薬", raw.SpawnInBackpack)
 		spawner.SpawnItem(world, "回復薬", raw.SpawnInBackpack)
 		spawner.SpawnItem(world, "回復スプレー", raw.SpawnInBackpack)

--- a/lib/states/home_menu.go
+++ b/lib/states/home_menu.go
@@ -50,7 +50,7 @@ func (st *HomeMenuState) OnStart(world w.World) {
 		count++
 	}))
 	if count == 0 {
-		sword := spawner.SpawnItem(world, "木刀", raw.SpawnInBackpack)
+		spawner.SpawnItem(world, "木刀", raw.SpawnInBackpack)
 		spawner.SpawnItem(world, "ハンドガン", raw.SpawnInBackpack)
 		spawner.SpawnItem(world, "レイガン", raw.SpawnInBackpack)
 		armor := spawner.SpawnItem(world, "西洋鎧", raw.SpawnInBackpack)
@@ -74,8 +74,7 @@ func (st *HomeMenuState) OnStart(world w.World) {
 		material.PlusAmount("フェライトコア", 30, world)
 		spawner.SpawnAllRecipes(world)
 
-		equips.Equip(world, sword, ishihara, gc.EquipmentSlotZero)
-		equips.Equip(world, armor, ishihara, gc.EquipmentSlotOne)
+		equips.Equip(world, armor, ishihara, gc.EquipmentSlotZero)
 	}
 }
 
@@ -184,7 +183,7 @@ func (st *HomeMenuState) confirmSelection(world w.World) states.Transition {
 	case 0:
 		return states.Transition{Type: states.TransPush, NewStates: []states.State{&DungeonSelectState{}}}
 	case 1:
-		return states.Transition{Type: states.TransSwitch, NewStates: []states.State{&CraftMenuState{category: itemCategoryTypeConsumable}}}
+		return states.Transition{Type: states.TransSwitch, NewStates: []states.State{&CraftMenuState{category: itemCategoryTypeItem}}}
 	case 2:
 		// TODO: 実装する
 		return states.Transition{Type: states.TransNone}

--- a/lib/states/inventory_menu.go
+++ b/lib/states/inventory_menu.go
@@ -109,7 +109,7 @@ func (st *InventoryMenuState) categoryReload(world w.World) {
 	st.items = []ecs.Entity{}
 
 	switch st.category {
-	case itemCategoryTypeConsumable:
+	case itemCategoryTypeItem:
 		st.items = simple.QueryMenuItem(world)
 	case itemCategoryTypeCard:
 		st.items = st.queryMenuCard(world)
@@ -282,7 +282,7 @@ func (st *InventoryMenuState) initPartyWindow(world w.World) {
 
 func (st *InventoryMenuState) newToggleContainer(world w.World) *widget.Container {
 	toggleContainer := eui.NewRowContainer()
-	toggleConsumableButton := eui.NewItemButton("道具", func(args *widget.ButtonClickedEventArgs) { st.setCategoryReload(world, itemCategoryTypeConsumable) }, world)
+	toggleConsumableButton := eui.NewItemButton("道具", func(args *widget.ButtonClickedEventArgs) { st.setCategoryReload(world, itemCategoryTypeItem) }, world)
 	toggleCardButton := eui.NewItemButton("手札", func(args *widget.ButtonClickedEventArgs) { st.setCategoryReload(world, itemCategoryTypeCard) }, world)
 	toggleMaterialButton := eui.NewItemButton("素材", func(args *widget.ButtonClickedEventArgs) { st.setCategoryReload(world, itemCategoryTypeMaterial) }, world)
 	toggleContainer.AddChild(toggleConsumableButton)

--- a/lib/states/inventory_menu.go
+++ b/lib/states/inventory_menu.go
@@ -111,8 +111,8 @@ func (st *InventoryMenuState) categoryReload(world w.World) {
 	switch st.category {
 	case itemCategoryTypeConsumable:
 		st.items = st.queryMenuConsumable(world)
-	case itemCategoryTypeWeapon:
-		st.items = st.queryMenuWeapon(world)
+	case itemCategoryTypeAttack:
+		st.items = st.queryMenuAttack(world)
 	case itemCategoryTypeWearable:
 		st.items = st.queryMenuWearable(world)
 	case itemCategoryTypeMaterial:
@@ -173,14 +173,14 @@ func (st *InventoryMenuState) queryMenuConsumable(world w.World) []ecs.Entity {
 	return items
 }
 
-func (st *InventoryMenuState) queryMenuWeapon(world w.World) []ecs.Entity {
+func (st *InventoryMenuState) queryMenuAttack(world w.World) []ecs.Entity {
 	items := []ecs.Entity{}
 
 	gameComponents := world.Components.Game.(*gc.Components)
 	world.Manager.Join(
 		gameComponents.Item,
 		gameComponents.InBackpack,
-		gameComponents.Weapon,
+		gameComponents.Attack,
 	).Visit(ecs.Visit(func(entity ecs.Entity) {
 		items = append(items, entity)
 	}))
@@ -244,7 +244,7 @@ func (st *InventoryMenuState) generateList(world world.World) {
 			}
 			st.itemDesc.Label = simple.GetDescription(world, entity).Description
 			views.UpdateSpec(world, st.specContainer, []any{
-				simple.GetWeapon(world, entity),
+				simple.GetAttack(world, entity),
 				simple.GetWearable(world, entity),
 				simple.GetMaterial(world, entity),
 			})
@@ -278,7 +278,7 @@ func (st *InventoryMenuState) generateList(world world.World) {
 			actionWindow.Close()
 			st.categoryReload(world)
 		}, world)
-		if entity.HasComponent(gameComponents.Consumable) || entity.HasComponent(gameComponents.Weapon) || entity.HasComponent(gameComponents.Wearable) {
+		if entity.HasComponent(gameComponents.Consumable) || entity.HasComponent(gameComponents.Attack) || entity.HasComponent(gameComponents.Wearable) {
 			windowContainer.AddChild(dropButton)
 		}
 
@@ -314,11 +314,11 @@ func (st *InventoryMenuState) initPartyWindow(world w.World) {
 func (st *InventoryMenuState) newToggleContainer(world w.World) *widget.Container {
 	toggleContainer := eui.NewRowContainer()
 	toggleConsumableButton := eui.NewItemButton("道具", func(args *widget.ButtonClickedEventArgs) { st.setCategoryReload(world, itemCategoryTypeConsumable) }, world)
-	toggleWeaponButton := eui.NewItemButton("武器", func(args *widget.ButtonClickedEventArgs) { st.setCategoryReload(world, itemCategoryTypeWeapon) }, world)
+	toggleAttackButton := eui.NewItemButton("攻撃", func(args *widget.ButtonClickedEventArgs) { st.setCategoryReload(world, itemCategoryTypeAttack) }, world)
 	toggleWearableButton := eui.NewItemButton("防具", func(args *widget.ButtonClickedEventArgs) { st.setCategoryReload(world, itemCategoryTypeWearable) }, world)
 	toggleMaterialButton := eui.NewItemButton("素材", func(args *widget.ButtonClickedEventArgs) { st.setCategoryReload(world, itemCategoryTypeMaterial) }, world)
 	toggleContainer.AddChild(toggleConsumableButton)
-	toggleContainer.AddChild(toggleWeaponButton)
+	toggleContainer.AddChild(toggleAttackButton)
 	toggleContainer.AddChild(toggleWearableButton)
 	toggleContainer.AddChild(toggleMaterialButton)
 

--- a/lib/states/inventory_menu.go
+++ b/lib/states/inventory_menu.go
@@ -110,7 +110,7 @@ func (st *InventoryMenuState) categoryReload(world w.World) {
 
 	switch st.category {
 	case itemCategoryTypeConsumable:
-		st.items = st.queryMenuConsumable(world)
+		st.items = simple.QueryMenuItem(world)
 	case itemCategoryTypeCard:
 		st.items = st.queryMenuCard(world)
 	case itemCategoryTypeMaterial:
@@ -156,28 +156,14 @@ func (st *InventoryMenuState) initUI(world w.World) *ebitenui.UI {
 	return &ebitenui.UI{Container: rootContainer}
 }
 
-func (st *InventoryMenuState) queryMenuConsumable(world w.World) []ecs.Entity {
-	items := []ecs.Entity{}
-
-	gameComponents := world.Components.Game.(*gc.Components)
-	world.Manager.Join(
-		gameComponents.Item,
-		gameComponents.InBackpack,
-	).Visit(ecs.Visit(func(entity ecs.Entity) {
-		items = append(items, entity)
-	}))
-
-	return items
-}
-
 func (st *InventoryMenuState) queryMenuCard(world w.World) []ecs.Entity {
 	items := []ecs.Entity{}
 
 	gameComponents := world.Components.Game.(*gc.Components)
 	world.Manager.Join(
 		gameComponents.Item,
-		gameComponents.InBackpack,
 		gameComponents.Card,
+		gameComponents.InBackpack,
 	).Visit(ecs.Visit(func(entity ecs.Entity) {
 		items = append(items, entity)
 	}))

--- a/lib/states/inventory_menu.go
+++ b/lib/states/inventory_menu.go
@@ -111,8 +111,8 @@ func (st *InventoryMenuState) categoryReload(world w.World) {
 	switch st.category {
 	case itemCategoryTypeConsumable:
 		st.items = st.queryMenuConsumable(world)
-	case itemCategoryTypeAttack:
-		st.items = st.queryMenuAttack(world)
+	case itemCategoryTypeCard:
+		st.items = st.queryMenuCard(world)
 	case itemCategoryTypeWearable:
 		st.items = st.queryMenuWearable(world)
 	case itemCategoryTypeMaterial:
@@ -173,14 +173,14 @@ func (st *InventoryMenuState) queryMenuConsumable(world w.World) []ecs.Entity {
 	return items
 }
 
-func (st *InventoryMenuState) queryMenuAttack(world w.World) []ecs.Entity {
+func (st *InventoryMenuState) queryMenuCard(world w.World) []ecs.Entity {
 	items := []ecs.Entity{}
 
 	gameComponents := world.Components.Game.(*gc.Components)
 	world.Manager.Join(
 		gameComponents.Item,
 		gameComponents.InBackpack,
-		gameComponents.Attack,
+		gameComponents.Card,
 	).Visit(ecs.Visit(func(entity ecs.Entity) {
 		items = append(items, entity)
 	}))
@@ -244,6 +244,7 @@ func (st *InventoryMenuState) generateList(world world.World) {
 			}
 			st.itemDesc.Label = simple.GetDescription(world, entity).Description
 			views.UpdateSpec(world, st.specContainer, []any{
+				simple.GetCard(world, entity),
 				simple.GetAttack(world, entity),
 				simple.GetWearable(world, entity),
 				simple.GetMaterial(world, entity),
@@ -278,7 +279,7 @@ func (st *InventoryMenuState) generateList(world world.World) {
 			actionWindow.Close()
 			st.categoryReload(world)
 		}, world)
-		if entity.HasComponent(gameComponents.Consumable) || entity.HasComponent(gameComponents.Attack) || entity.HasComponent(gameComponents.Wearable) {
+		if entity.HasComponent(gameComponents.Consumable) || entity.HasComponent(gameComponents.Card) || entity.HasComponent(gameComponents.Wearable) {
 			windowContainer.AddChild(dropButton)
 		}
 
@@ -314,11 +315,11 @@ func (st *InventoryMenuState) initPartyWindow(world w.World) {
 func (st *InventoryMenuState) newToggleContainer(world w.World) *widget.Container {
 	toggleContainer := eui.NewRowContainer()
 	toggleConsumableButton := eui.NewItemButton("道具", func(args *widget.ButtonClickedEventArgs) { st.setCategoryReload(world, itemCategoryTypeConsumable) }, world)
-	toggleAttackButton := eui.NewItemButton("攻撃", func(args *widget.ButtonClickedEventArgs) { st.setCategoryReload(world, itemCategoryTypeAttack) }, world)
+	toggleCardButton := eui.NewItemButton("手札", func(args *widget.ButtonClickedEventArgs) { st.setCategoryReload(world, itemCategoryTypeCard) }, world)
 	toggleWearableButton := eui.NewItemButton("防具", func(args *widget.ButtonClickedEventArgs) { st.setCategoryReload(world, itemCategoryTypeWearable) }, world)
 	toggleMaterialButton := eui.NewItemButton("素材", func(args *widget.ButtonClickedEventArgs) { st.setCategoryReload(world, itemCategoryTypeMaterial) }, world)
 	toggleContainer.AddChild(toggleConsumableButton)
-	toggleContainer.AddChild(toggleAttackButton)
+	toggleContainer.AddChild(toggleCardButton)
 	toggleContainer.AddChild(toggleWearableButton)
 	toggleContainer.AddChild(toggleMaterialButton)
 

--- a/lib/states/inventory_menu.go
+++ b/lib/states/inventory_menu.go
@@ -113,8 +113,6 @@ func (st *InventoryMenuState) categoryReload(world w.World) {
 		st.items = st.queryMenuConsumable(world)
 	case itemCategoryTypeCard:
 		st.items = st.queryMenuCard(world)
-	case itemCategoryTypeWearable:
-		st.items = st.queryMenuWearable(world)
 	case itemCategoryTypeMaterial:
 		st.items = st.queryMenuMaterial(world)
 	default:
@@ -165,7 +163,6 @@ func (st *InventoryMenuState) queryMenuConsumable(world w.World) []ecs.Entity {
 	world.Manager.Join(
 		gameComponents.Item,
 		gameComponents.InBackpack,
-		gameComponents.Consumable,
 	).Visit(ecs.Visit(func(entity ecs.Entity) {
 		items = append(items, entity)
 	}))
@@ -181,21 +178,6 @@ func (st *InventoryMenuState) queryMenuCard(world w.World) []ecs.Entity {
 		gameComponents.Item,
 		gameComponents.InBackpack,
 		gameComponents.Card,
-	).Visit(ecs.Visit(func(entity ecs.Entity) {
-		items = append(items, entity)
-	}))
-
-	return items
-}
-
-func (st *InventoryMenuState) queryMenuWearable(world w.World) []ecs.Entity {
-	items := []ecs.Entity{}
-
-	gameComponents := world.Components.Game.(*gc.Components)
-	world.Manager.Join(
-		gameComponents.Item,
-		gameComponents.InBackpack,
-		gameComponents.Wearable,
 	).Visit(ecs.Visit(func(entity ecs.Entity) {
 		items = append(items, entity)
 	}))
@@ -279,7 +261,7 @@ func (st *InventoryMenuState) generateList(world world.World) {
 			actionWindow.Close()
 			st.categoryReload(world)
 		}, world)
-		if entity.HasComponent(gameComponents.Consumable) || entity.HasComponent(gameComponents.Card) || entity.HasComponent(gameComponents.Wearable) {
+		if !entity.HasComponent(gameComponents.Material) {
 			windowContainer.AddChild(dropButton)
 		}
 
@@ -316,11 +298,9 @@ func (st *InventoryMenuState) newToggleContainer(world w.World) *widget.Containe
 	toggleContainer := eui.NewRowContainer()
 	toggleConsumableButton := eui.NewItemButton("道具", func(args *widget.ButtonClickedEventArgs) { st.setCategoryReload(world, itemCategoryTypeConsumable) }, world)
 	toggleCardButton := eui.NewItemButton("手札", func(args *widget.ButtonClickedEventArgs) { st.setCategoryReload(world, itemCategoryTypeCard) }, world)
-	toggleWearableButton := eui.NewItemButton("防具", func(args *widget.ButtonClickedEventArgs) { st.setCategoryReload(world, itemCategoryTypeWearable) }, world)
 	toggleMaterialButton := eui.NewItemButton("素材", func(args *widget.ButtonClickedEventArgs) { st.setCategoryReload(world, itemCategoryTypeMaterial) }, world)
 	toggleContainer.AddChild(toggleConsumableButton)
 	toggleContainer.AddChild(toggleCardButton)
-	toggleContainer.AddChild(toggleWearableButton)
 	toggleContainer.AddChild(toggleMaterialButton)
 
 	return toggleContainer

--- a/lib/states/lib.go
+++ b/lib/states/lib.go
@@ -30,7 +30,7 @@ type itemCategoryType string
 
 var (
 	itemCategoryTypeConsumable itemCategoryType = "CONSUMABLE"
-	itemCategoryTypeWeapon     itemCategoryType = "WEAPON"
+	itemCategoryTypeAttack     itemCategoryType = "ATTACK"
 	itemCategoryTypeWearable   itemCategoryType = "WEARABLE"
 	itemCategoryTypeMaterial   itemCategoryType = "MATERIAL"
 )

--- a/lib/states/lib.go
+++ b/lib/states/lib.go
@@ -29,10 +29,10 @@ func getWinRect() image.Rectangle {
 type itemCategoryType string
 
 var (
-	itemCategoryTypeConsumable itemCategoryType = "CONSUMABLE"
-	itemCategoryTypeCard       itemCategoryType = "CARD"
-	itemCategoryTypeWearable   itemCategoryType = "WEARABLE"
-	itemCategoryTypeMaterial   itemCategoryType = "MATERIAL"
+	itemCategoryTypeItem     itemCategoryType = "ITEM"
+	itemCategoryTypeCard     itemCategoryType = "CARD"
+	itemCategoryTypeWearable itemCategoryType = "WEARABLE"
+	itemCategoryTypeMaterial itemCategoryType = "MATERIAL"
 )
 
 // ================

--- a/lib/states/lib.go
+++ b/lib/states/lib.go
@@ -30,7 +30,7 @@ type itemCategoryType string
 
 var (
 	itemCategoryTypeConsumable itemCategoryType = "CONSUMABLE"
-	itemCategoryTypeAttack     itemCategoryType = "ATTACK"
+	itemCategoryTypeCard       itemCategoryType = "CARD"
 	itemCategoryTypeWearable   itemCategoryType = "WEARABLE"
 	itemCategoryTypeMaterial   itemCategoryType = "MATERIAL"
 )

--- a/lib/systems/equipment_changed.go
+++ b/lib/systems/equipment_changed.go
@@ -45,28 +45,6 @@ func EquipmentChangedSystem(world w.World) bool {
 
 	world.Manager.Join(
 		gameComponents.Equipped,
-		gameComponents.Attack,
-	).Visit(ecs.Visit(func(item ecs.Entity) {
-		equipped := gameComponents.Equipped.Get(item).(*gc.Equipped)
-		attack := gameComponents.Attack.Get(item).(*gc.Attack)
-
-		owner := equipped.Owner
-		attrs := gameComponents.Attributes.Get(owner).(*gc.Attributes)
-
-		attrs.Vitality.Modifier += attack.EquipBonus.Vitality
-		attrs.Vitality.Total = attrs.Vitality.Base + attrs.Vitality.Modifier
-		attrs.Strength.Modifier += attack.EquipBonus.Strength
-		attrs.Strength.Total = attrs.Strength.Base + attrs.Strength.Modifier
-		attrs.Sensation.Modifier += attack.EquipBonus.Sensation
-		attrs.Sensation.Total = attrs.Sensation.Base + attrs.Sensation.Modifier
-		attrs.Dexterity.Modifier += attack.EquipBonus.Dexterity
-		attrs.Dexterity.Total = attrs.Dexterity.Base + attrs.Dexterity.Modifier
-		attrs.Agility.Modifier += attack.EquipBonus.Agility
-		attrs.Agility.Total = attrs.Agility.Base + attrs.Agility.Modifier
-	}))
-
-	world.Manager.Join(
-		gameComponents.Equipped,
 		gameComponents.Wearable,
 	).Visit(ecs.Visit(func(item ecs.Entity) {
 		equipped := gameComponents.Equipped.Get(item).(*gc.Equipped)

--- a/lib/systems/equipment_changed.go
+++ b/lib/systems/equipment_changed.go
@@ -45,23 +45,23 @@ func EquipmentChangedSystem(world w.World) bool {
 
 	world.Manager.Join(
 		gameComponents.Equipped,
-		gameComponents.Weapon,
+		gameComponents.Attack,
 	).Visit(ecs.Visit(func(item ecs.Entity) {
 		equipped := gameComponents.Equipped.Get(item).(*gc.Equipped)
-		weapon := gameComponents.Weapon.Get(item).(*gc.Weapon)
+		attack := gameComponents.Attack.Get(item).(*gc.Attack)
 
 		owner := equipped.Owner
 		attrs := gameComponents.Attributes.Get(owner).(*gc.Attributes)
 
-		attrs.Vitality.Modifier += weapon.EquipBonus.Vitality
+		attrs.Vitality.Modifier += attack.EquipBonus.Vitality
 		attrs.Vitality.Total = attrs.Vitality.Base + attrs.Vitality.Modifier
-		attrs.Strength.Modifier += weapon.EquipBonus.Strength
+		attrs.Strength.Modifier += attack.EquipBonus.Strength
 		attrs.Strength.Total = attrs.Strength.Base + attrs.Strength.Modifier
-		attrs.Sensation.Modifier += weapon.EquipBonus.Sensation
+		attrs.Sensation.Modifier += attack.EquipBonus.Sensation
 		attrs.Sensation.Total = attrs.Sensation.Base + attrs.Sensation.Modifier
-		attrs.Dexterity.Modifier += weapon.EquipBonus.Dexterity
+		attrs.Dexterity.Modifier += attack.EquipBonus.Dexterity
 		attrs.Dexterity.Total = attrs.Dexterity.Base + attrs.Dexterity.Modifier
-		attrs.Agility.Modifier += weapon.EquipBonus.Agility
+		attrs.Agility.Modifier += attack.EquipBonus.Agility
 		attrs.Agility.Total = attrs.Agility.Base + attrs.Agility.Modifier
 	}))
 

--- a/lib/utils/consts/consts.go
+++ b/lib/utils/consts/consts.go
@@ -10,9 +10,8 @@ const (
 	AgilityLabel   = "敏捷"
 	DefenseLabel   = "防御"
 
-	AccuracyLabel          = "命中"
-	DamageLabel            = "攻撃力"
-	AttackCountLabel       = "回数"
-	EnergyConsumptionLabel = "消費SP"
-	EquimentCategoryLabel  = "部位"
+	AccuracyLabel         = "命中"
+	DamageLabel           = "攻撃力"
+	AttackCountLabel      = "回数"
+	EquimentCategoryLabel = "部位"
 )

--- a/lib/views/views.go
+++ b/lib/views/views.go
@@ -38,8 +38,8 @@ func UpdateSpec(world w.World, targetContainer *widget.Container, cs []any) *wid
 			attackCount := fmt.Sprintf("%s %s", consts.AttackCountLabel, strconv.Itoa(v.AttackCount))
 			targetContainer.AddChild(eui.NewBodyText(attackCount, styles.TextColor, world))
 
-			if v.DamageAttr != components.DamageAttrNone {
-				targetContainer.AddChild(damageAttrText(world, v.DamageAttr, v.DamageAttr.String()))
+			if v.Element != components.ElementTypeNone {
+				targetContainer.AddChild(damageAttrText(world, v.Element, v.Element.String()))
 			}
 			addEquipBonus(targetContainer, v.EquipBonus, world)
 		case *components.Wearable:
@@ -59,16 +59,16 @@ func UpdateSpec(world w.World, targetContainer *widget.Container, cs []any) *wid
 }
 
 // 属性によって色付けする
-func damageAttrText(world w.World, dat components.DamageAttrType, str string) *widget.Text {
+func damageAttrText(world w.World, dat components.ElementType, str string) *widget.Text {
 	var text *widget.Text
 	switch dat {
-	case components.DamageAttrFire:
+	case components.ElementTypeFire:
 		text = eui.NewBodyText(str, styles.FireColor, world)
-	case components.DamageAttrThunder:
+	case components.ElementTypeThunder:
 		text = eui.NewBodyText(str, styles.ThunderColor, world)
-	case components.DamageAttrChill:
+	case components.ElementTypeChill:
 		text = eui.NewBodyText(str, styles.ChillColor, world)
-	case components.DamageAttrPhoton:
+	case components.ElementTypePhoton:
 		text = eui.NewBodyText(str, styles.PhotonColor, world)
 	default:
 		text = eui.NewBodyText(str, styles.TextColor, world)

--- a/lib/views/views.go
+++ b/lib/views/views.go
@@ -52,6 +52,12 @@ func UpdateSpec(world w.World, targetContainer *widget.Container, cs []any) *wid
 			defense := fmt.Sprintf("%s %s", consts.DefenseLabel, strconv.Itoa(v.Defense))
 			targetContainer.AddChild(eui.NewBodyText(defense, styles.TextColor, world))
 			addEquipBonus(targetContainer, v.EquipBonus, world)
+		case *components.Card:
+			if v == nil {
+				continue
+			}
+			cost := fmt.Sprintf("コスト %d", v.Cost)
+			targetContainer.AddChild(eui.NewBodyText(cost, styles.TextColor, world))
 		}
 	}
 

--- a/lib/views/views.go
+++ b/lib/views/views.go
@@ -41,7 +41,6 @@ func UpdateSpec(world w.World, targetContainer *widget.Container, cs []any) *wid
 			if v.Element != components.ElementTypeNone {
 				targetContainer.AddChild(damageAttrText(world, v.Element, v.Element.String()))
 			}
-			addEquipBonus(targetContainer, v.EquipBonus, world)
 		case *components.Wearable:
 			if v == nil {
 				continue

--- a/lib/views/views.go
+++ b/lib/views/views.go
@@ -23,11 +23,11 @@ func UpdateSpec(world w.World, targetContainer *widget.Container, cs []any) *wid
 			}
 			amount := fmt.Sprintf("%d 個", v.Amount)
 			targetContainer.AddChild(eui.NewBodyText(amount, styles.TextColor, world))
-		case *components.Weapon:
+		case *components.Attack:
 			if v == nil {
 				continue
 			}
-			targetContainer.AddChild(eui.NewBodyText(v.WeaponCategory.String(), styles.TextColor, world))
+			targetContainer.AddChild(eui.NewBodyText(v.AttackCategory.String(), styles.TextColor, world))
 
 			accuracy := fmt.Sprintf("%s %s", consts.AccuracyLabel, strconv.Itoa(v.Accuracy))
 			targetContainer.AddChild(eui.NewBodyText(accuracy, styles.TextColor, world))

--- a/lib/views/views.go
+++ b/lib/views/views.go
@@ -38,9 +38,6 @@ func UpdateSpec(world w.World, targetContainer *widget.Container, cs []any) *wid
 			attackCount := fmt.Sprintf("%s %s", consts.AttackCountLabel, strconv.Itoa(v.AttackCount))
 			targetContainer.AddChild(eui.NewBodyText(attackCount, styles.TextColor, world))
 
-			consumption := fmt.Sprintf("%s %s", consts.EnergyConsumptionLabel, strconv.Itoa(v.EnergyConsumption))
-			targetContainer.AddChild(eui.NewBodyText(consumption, styles.TextColor, world))
-
 			if v.DamageAttr != components.DamageAttrNone {
 				targetContainer.AddChild(damageAttrText(world, v.DamageAttr, v.DamageAttr.String()))
 			}

--- a/lib/worldhelper/craft/craft.go
+++ b/lib/worldhelper/craft/craft.go
@@ -70,9 +70,8 @@ func randomize(world w.World, entity ecs.Entity) {
 	if entity.HasComponent(gameComponents.Attack) {
 		attack := gameComponents.Attack.Get(entity).(*gc.Attack)
 
-		attack.Accuracy += (-10 + rand.Intn(20))        // -10 ~ +9
-		attack.Damage += (-5 + rand.Intn(15))           // -5  ~ +9
-		attack.EnergyConsumption += (-1 + rand.Intn(3)) // -1  ~ +1
+		attack.Accuracy += (-10 + rand.Intn(20)) // -10 ~ +9
+		attack.Damage += (-5 + rand.Intn(15))    // -5  ~ +9
 	}
 	if entity.HasComponent(gameComponents.Wearable) {
 		wearable := gameComponents.Wearable.Get(entity).(*gc.Wearable)

--- a/lib/worldhelper/craft/craft.go
+++ b/lib/worldhelper/craft/craft.go
@@ -67,12 +67,12 @@ func requiredMaterials(world w.World, goal string) []components.RecipeInput {
 
 func randomize(world w.World, entity ecs.Entity) {
 	gameComponents := world.Components.Game.(*gc.Components)
-	if entity.HasComponent(gameComponents.Weapon) {
-		weapon := gameComponents.Weapon.Get(entity).(*gc.Weapon)
+	if entity.HasComponent(gameComponents.Attack) {
+		attack := gameComponents.Attack.Get(entity).(*gc.Attack)
 
-		weapon.Accuracy += (-10 + rand.Intn(20))        // -10 ~ +9
-		weapon.Damage += (-5 + rand.Intn(15))           // -5  ~ +9
-		weapon.EnergyConsumption += (-1 + rand.Intn(3)) // -1  ~ +1
+		attack.Accuracy += (-10 + rand.Intn(20))        // -10 ~ +9
+		attack.Damage += (-5 + rand.Intn(15))           // -5  ~ +9
+		attack.EnergyConsumption += (-1 + rand.Intn(3)) // -1  ~ +1
 	}
 	if entity.HasComponent(gameComponents.Wearable) {
 		wearable := gameComponents.Wearable.Get(entity).(*gc.Wearable)

--- a/lib/worldhelper/simple/query.go
+++ b/lib/worldhelper/simple/query.go
@@ -1,0 +1,26 @@
+package simple
+
+import (
+	gc "github.com/kijimaD/ruins/lib/components"
+	w "github.com/kijimaD/ruins/lib/engine/world"
+	ecs "github.com/x-hgg-x/goecs/v2"
+)
+
+// メニュー上でいうアイテムを取得する。エンティティ上はCardもItemを持っているので、排除する
+func QueryMenuItem(world w.World) []ecs.Entity {
+	items := []ecs.Entity{}
+
+	gameComponents := world.Components.Game.(*gc.Components)
+	world.Manager.Join(
+		gameComponents.Item,
+		gameComponents.InBackpack,
+	).Visit(ecs.Visit(func(entity ecs.Entity) {
+		if entity.HasComponent(gameComponents.Card) {
+			return
+		}
+
+		items = append(items, entity)
+	}))
+
+	return items
+}

--- a/lib/worldhelper/simple/simple.go
+++ b/lib/worldhelper/simple/simple.go
@@ -7,12 +7,12 @@ import (
 	ecs "github.com/x-hgg-x/goecs/v2"
 )
 
-func GetWeapon(world w.World, target ecs.Entity) *components.Weapon {
-	var result *components.Weapon
+func GetAttack(world w.World, target ecs.Entity) *components.Attack {
+	var result *components.Attack
 	gameComponents := world.Components.Game.(*gc.Components)
-	world.Manager.Join(gameComponents.Weapon).Visit(ecs.Visit(func(entity ecs.Entity) {
-		if entity == target && entity.HasComponent(gameComponents.Weapon) {
-			result = gameComponents.Weapon.Get(entity).(*gc.Weapon)
+	world.Manager.Join(gameComponents.Attack).Visit(ecs.Visit(func(entity ecs.Entity) {
+		if entity == target && entity.HasComponent(gameComponents.Attack) {
+			result = gameComponents.Attack.Get(entity).(*gc.Attack)
 		}
 	}))
 

--- a/lib/worldhelper/simple/simple.go
+++ b/lib/worldhelper/simple/simple.go
@@ -7,6 +7,18 @@ import (
 	ecs "github.com/x-hgg-x/goecs/v2"
 )
 
+func GetCard(world w.World, target ecs.Entity) *components.Card {
+	var result *components.Card
+	gameComponents := world.Components.Game.(*gc.Components)
+	world.Manager.Join(gameComponents.Card).Visit(ecs.Visit(func(entity ecs.Entity) {
+		if entity == target && entity.HasComponent(gameComponents.Card) {
+			result = gameComponents.Card.Get(entity).(*gc.Card)
+		}
+	}))
+
+	return result
+}
+
 func GetAttack(world w.World, target ecs.Entity) *components.Attack {
 	var result *components.Attack
 	gameComponents := world.Components.Game.(*gc.Components)


### PR DESCRIPTION
今までは武器と防具が同じレベルの概念だったが、それを変える。

防具のみを装備できるようにし、武器は戦闘中に選択するアクションの候補として「カード」とする。

- (前)weapon -> (後)card + attack
- 装備品とカードを分離
  - 着てステータスを上げるものは装備品とする
  - 攻撃や回復など、戦闘で選ぶ単位となるアクションをカードとする