### PR TITLE
重いのを改善する

### DIFF
--- a/lib/systems/darkness.go
+++ b/lib/systems/darkness.go
@@ -5,9 +5,7 @@ import (
 	"math"
 
 	"github.com/hajimehoshi/ebiten/v2"
-	"github.com/hajimehoshi/ebiten/v2/vector"
 	gc "github.com/kijimaD/ruins/lib/components"
-	ec "github.com/kijimaD/ruins/lib/engine/components"
 	w "github.com/kijimaD/ruins/lib/engine/world"
 	"github.com/kijimaD/ruins/lib/resources"
 	"github.com/kijimaD/ruins/lib/utils/camera"
@@ -56,32 +54,33 @@ func DarknessSystem(world w.World, screen *ebiten.Image) {
 	}
 
 	// 壁の影。影をキャストする用のコンポーネントを追加したほうがよさそう
-	world.Manager.Join(
-		gameComponents.SpriteRender,
-		gameComponents.BlockView,
-		gameComponents.BlockPass,
-	).Visit(ecs.Visit(func(entity ecs.Entity) {
-		switch {
-		case entity.HasComponent(gameComponents.Position):
-			pos := gameComponents.Position.Get(entity).(*gc.Position)
-			sprite := gameComponents.SpriteRender.Get(entity).(*ec.SpriteRender)
+	// FIXME: 見えない部分もすべてのブロックに影がついて重いのでいったんオフにしておく
+	// world.Manager.Join(
+	// 	gameComponents.SpriteRender,
+	// 	gameComponents.BlockView,
+	// 	gameComponents.BlockPass,
+	// ).Visit(ecs.Visit(func(entity ecs.Entity) {
+	// 	switch {
+	// 	case entity.HasComponent(gameComponents.Position):
+	// 		pos := gameComponents.Position.Get(entity).(*gc.Position)
+	// 		sprite := gameComponents.SpriteRender.Get(entity).(*ec.SpriteRender)
 
-			spriteWidth := float32(sprite.SpriteSheet.Sprites[sprite.SpriteNumber].Width)
-			spriteHeight := float32(sprite.SpriteSheet.Sprites[sprite.SpriteNumber].Height)
+	// 		spriteWidth := float32(sprite.SpriteSheet.Sprites[sprite.SpriteNumber].Width)
+	// 		spriteHeight := float32(sprite.SpriteSheet.Sprites[sprite.SpriteNumber].Height)
 
-			vector.DrawFilledRect(visionImage, float32(pos.X)-16, float32(pos.Y)-16, spriteWidth, spriteHeight+4, color.RGBA{0, 0, 0, 140}, true)
-			vector.DrawFilledRect(visionImage, float32(pos.X)-16, float32(pos.Y)-16, spriteWidth, spriteHeight+16, color.RGBA{0, 0, 0, 80}, true)
-		case entity.HasComponent(gameComponents.GridElement):
-			grid := gameComponents.GridElement.Get(entity).(*gc.GridElement)
-			sprite := gameComponents.SpriteRender.Get(entity).(*ec.SpriteRender)
+	// 		vector.DrawFilledRect(visionImage, float32(pos.X)-16, float32(pos.Y)-16, spriteWidth, spriteHeight+4, color.RGBA{0, 0, 0, 140}, true)
+	// 		vector.DrawFilledRect(visionImage, float32(pos.X)-16, float32(pos.Y)-16, spriteWidth, spriteHeight+16, color.RGBA{0, 0, 0, 80}, true)
+	// 	case entity.HasComponent(gameComponents.GridElement):
+	// 		grid := gameComponents.GridElement.Get(entity).(*gc.GridElement)
+	// 		sprite := gameComponents.SpriteRender.Get(entity).(*ec.SpriteRender)
 
-			spriteWidth := float32(sprite.SpriteSheet.Sprites[sprite.SpriteNumber].Width)
-			spriteHeight := float32(sprite.SpriteSheet.Sprites[sprite.SpriteNumber].Height)
+	// 		spriteWidth := float32(sprite.SpriteSheet.Sprites[sprite.SpriteNumber].Width)
+	// 		spriteHeight := float32(sprite.SpriteSheet.Sprites[sprite.SpriteNumber].Height)
 
-			vector.DrawFilledRect(visionImage, float32(grid.Row)*spriteWidth, float32(grid.Col)*spriteWidth, spriteWidth, spriteHeight+4, color.RGBA{0, 0, 0, 140}, true)
-			vector.DrawFilledRect(visionImage, float32(grid.Row)*spriteWidth, float32(grid.Col)*spriteWidth, spriteWidth, spriteHeight+16, color.RGBA{0, 0, 0, 80}, true)
-		}
-	}))
+	// 		vector.DrawFilledRect(visionImage, float32(grid.Row)*spriteWidth, float32(grid.Col)*spriteWidth, spriteWidth, spriteHeight+4, color.RGBA{0, 0, 0, 140}, true)
+	// 		vector.DrawFilledRect(visionImage, float32(grid.Row)*spriteWidth, float32(grid.Col)*spriteWidth, spriteWidth, spriteHeight+16, color.RGBA{0, 0, 0, 80}, true)
+	// 	}
+	// }))
 
 	// 光源の中心付近を明るくする
 	{

--- a/lib/systems/darkness.go
+++ b/lib/systems/darkness.go
@@ -20,7 +20,7 @@ var (
 )
 
 const (
-	visionNgon = 20
+	visionNgon = 10
 )
 
 // 周囲を暗くする

--- a/lib/systems/move.go
+++ b/lib/systems/move.go
@@ -83,9 +83,9 @@ func MoveSystem(world w.World) {
 		}
 	}
 
-	// 衝突判定して、衝突していれば元の位置に戻す
+	// 移動した場合、衝突判定して衝突していれば元の位置に戻す
 	// 2つの矩形を比較して、重複する部分があれば衝突とみなす
-	{
+	if pos.X != originalX || pos.Y != originalY {
 		sprite := spriteRender.SpriteSheet.Sprites[spriteRender.SpriteNumber]
 		padding := 4 // 1マスの道を進みやすくする
 		x1 := float64(pos.X - sprite.Width/2 + padding)

--- a/lib/systems/move.go
+++ b/lib/systems/move.go
@@ -164,10 +164,10 @@ func MoveSystem(world w.World) {
 		camera.ScaleTo += scrollY * (camera.ScaleTo / 7)
 
 		// Clamp target zoom level.
-		if camera.ScaleTo < 0.01 {
-			camera.ScaleTo = 0.01
-		} else if camera.ScaleTo > 100 {
-			camera.ScaleTo = 100
+		if camera.ScaleTo < 0.8 {
+			camera.ScaleTo = 0.8
+		} else if camera.ScaleTo > 10 {
+			camera.ScaleTo = 10
 		}
 
 		// Smooth zoom transition.


### PR DESCRIPTION
WASM版だと FPS が10を切っている。30くらいに改善する

- 移動時のみ衝突判定する
- 視界円のポリゴンを減らす
- 見えない部分もすべてのブロックに影画像を描画しているが、重いのでいったんオフ