### PR TITLE
ステージサイズを実用的なサイズにする

### DIFF
--- a/lib/mapbuilder/lib.go
+++ b/lib/mapbuilder/lib.go
@@ -17,6 +17,58 @@ type BuilderMap struct {
 	Corridors [][]int
 }
 
+// 上にあるタイルを調べる
+func (bm BuilderMap) UpTile(idx int) Tile {
+	targetIdx := idx - int(bm.Level.TileWidth)
+	if targetIdx < 0 {
+		return TileEmpty
+	}
+
+	return bm.Tiles[targetIdx]
+}
+
+// 下にあるタイルを調べる
+func (bm BuilderMap) DownTile(idx int) Tile {
+	targetIdx := idx + int(bm.Level.TileHeight)
+	if targetIdx > len(bm.Tiles)-1 {
+		return TileEmpty
+	}
+
+	return bm.Tiles[targetIdx]
+}
+
+// 右にあるタイルを調べる
+func (bm BuilderMap) LeftTile(idx int) Tile {
+	targetIdx := idx - 1
+	if targetIdx < 0 {
+		return TileEmpty
+	}
+
+	return bm.Tiles[targetIdx]
+}
+
+// 左にあるタイルを調べる
+func (bm BuilderMap) RightTile(idx int) Tile {
+	targetIdx := idx + 1
+	if targetIdx > len(bm.Tiles)-1 {
+		return TileEmpty
+	}
+
+	return bm.Tiles[targetIdx]
+}
+
+// 直交する近傍4タイルに床があるか判定する
+func (bm BuilderMap) AdjacentOrthoAnyFloor(idx int) bool {
+	return bm.UpTile(idx) == TileFloor ||
+		bm.DownTile(idx) == TileFloor ||
+		bm.RightTile(idx) == TileFloor ||
+		bm.LeftTile(idx) == TileFloor ||
+		bm.UpTile(idx) == TileWarpNext ||
+		bm.DownTile(idx) == TileWarpNext ||
+		bm.RightTile(idx) == TileWarpNext ||
+		bm.LeftTile(idx) == TileWarpNext
+}
+
 type BuilderChain struct {
 	Starter   *InitialMapBuilder
 	Builders  []MetaMapBuilder

--- a/lib/mapbuilder/lib.go
+++ b/lib/mapbuilder/lib.go
@@ -4,6 +4,7 @@ package mapbuilder
 import (
 	"log"
 
+	"github.com/kijimaD/ruins/lib/components"
 	"github.com/kijimaD/ruins/lib/loader"
 	ecs "github.com/x-hgg-x/goecs/v2"
 )
@@ -22,8 +23,8 @@ type BuilderChain struct {
 	BuildData BuilderMap
 }
 
-func NewBuilderChain() *BuilderChain {
-	tileCount := int(20) * int(20)
+func NewBuilderChain(width components.Row, height components.Col) *BuilderChain {
+	tileCount := int(width) * int(height)
 	tiles := make([]Tile, tileCount)
 	for i, _ := range tiles {
 		tiles[i] = TileWall
@@ -34,9 +35,8 @@ func NewBuilderChain() *BuilderChain {
 		Builders: []MetaMapBuilder{},
 		BuildData: BuilderMap{
 			Level: loader.Level{
-				// 仮の値
-				TileWidth:  20,
-				TileHeight: 20,
+				TileWidth:  components.Row(width),
+				TileHeight: components.Col(height),
 				TileSize:   32,
 				Entities:   make([]ecs.Entity, tileCount),
 			},
@@ -74,8 +74,8 @@ type MetaMapBuilder interface {
 	BuildMeta(*BuilderMap)
 }
 
-func SimpleRoomBuilder() *BuilderChain {
-	chain := NewBuilderChain()
+func SimpleRoomBuilder(width components.Row, height components.Col) *BuilderChain {
+	chain := NewBuilderChain(width, height)
 	chain.StartWith(RectRoomBuilder{})
 	chain.With(RoomDraw{}) // TODO: 暫定的にここで壁を埋めてるので、先に実行する必要がある
 	chain.With(LineCorridorBuilder{})

--- a/lib/mapbuilder/lib.go
+++ b/lib/mapbuilder/lib.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/kijimaD/ruins/lib/components"
 	"github.com/kijimaD/ruins/lib/loader"
+	"github.com/kijimaD/ruins/lib/utils/consts"
 	ecs "github.com/x-hgg-x/goecs/v2"
 )
 
@@ -89,7 +90,7 @@ func NewBuilderChain(width components.Row, height components.Col) *BuilderChain 
 			Level: loader.Level{
 				TileWidth:  components.Row(width),
 				TileHeight: components.Col(height),
-				TileSize:   32,
+				TileSize:   consts.TileSize,
 				Entities:   make([]ecs.Entity, tileCount),
 			},
 			Tiles:     tiles,

--- a/lib/mapbuilder/rect_room.go
+++ b/lib/mapbuilder/rect_room.go
@@ -2,6 +2,8 @@ package mapbuilder
 
 import (
 	"math/rand"
+
+	"github.com/kijimaD/ruins/lib/utils/mathutil"
 )
 
 // 長方形の部屋を作成する
@@ -12,14 +14,19 @@ func (b RectRoomBuilder) BuildInitial(buildData *BuilderMap) {
 }
 
 func (b RectRoomBuilder) BuildRooms(buildData *BuilderMap) {
-	const maxRooms = 8
+	maxRooms := 4 + rand.Intn(10)
 	rooms := []Rect{}
 	for i := 0; i < maxRooms; i++ {
-		x := 1 + rand.Intn(16)
-		y := 1 + rand.Intn(16)
-		w := 2 + rand.Intn(2)
-		h := 2 + rand.Intn(2)
-		newRoom := Rect{X1: x, X2: x + w, Y1: y, Y2: y + h}
+		x := rand.Intn(int(buildData.Level.TileWidth))
+		y := rand.Intn(int(buildData.Level.TileHeight))
+		w := 2 + rand.Intn(8)
+		h := 2 + rand.Intn(8)
+		newRoom := Rect{
+			X1: x,
+			X2: mathutil.Min(x+w, int(buildData.Level.TileWidth)),
+			Y1: y,
+			Y2: mathutil.Min(y+h, int(buildData.Level.TileHeight)),
+		}
 		rooms = append(rooms, newRoom)
 	}
 

--- a/lib/resources/level.go
+++ b/lib/resources/level.go
@@ -8,12 +8,12 @@ import (
 	w "github.com/kijimaD/ruins/lib/engine/world"
 	"github.com/kijimaD/ruins/lib/loader"
 	"github.com/kijimaD/ruins/lib/mapbuilder"
+	"github.com/kijimaD/ruins/lib/utils/consts"
 )
 
 const (
 	offsetX       = 0
 	offsetY       = 80
-	gridBlockSize = 32
 	minGridWidth  = 30
 	minGridHeight = 20
 )
@@ -27,8 +27,6 @@ type Game struct {
 	Depth int
 }
 
-const defaultTileSize = 32
-
 func NewLevel(world w.World, newDepth int, width gc.Row, height gc.Col) loader.Level {
 	chain := mapbuilder.SimpleRoomBuilder(width, height)
 	chain.Build()
@@ -37,7 +35,7 @@ func NewLevel(world w.World, newDepth int, width gc.Row, height gc.Col) loader.L
 	// FIXME: たまに届かない位置に生成される
 	failCountWarpNext := 0
 	for {
-		if failCountWarpNext > 1000 {
+		if failCountWarpNext > 200 {
 			log.Fatal("ワープホールの生成に失敗した")
 		}
 		x := rand.Intn(int(chain.BuildData.Level.TileWidth))
@@ -53,14 +51,14 @@ func NewLevel(world w.World, newDepth int, width gc.Row, height gc.Col) loader.L
 	// プレイヤーを配置する
 	failCountPlayer := 0
 	for {
-		if failCountPlayer > 1000 {
+		if failCountPlayer > 200 {
 			log.Fatal("プレイヤーの生成に失敗した")
 		}
 		x := rand.Intn(int(chain.BuildData.Level.TileWidth))
 		y := rand.Intn(int(chain.BuildData.Level.TileHeight))
 		tileIdx := chain.BuildData.Level.XYTileIndex(x, y)
 		if chain.BuildData.Tiles[tileIdx] == mapbuilder.TileFloor {
-			SpawnPlayer(world, x*defaultTileSize+defaultTileSize/2, y*defaultTileSize+defaultTileSize/2)
+			SpawnPlayer(world, x*consts.TileSize+consts.TileSize/2, y*consts.TileSize+consts.TileSize/2)
 			break
 		}
 		failCountPlayer++
@@ -98,8 +96,8 @@ const (
 func UpdateGameLayout(world w.World) (int, int) {
 	gridWidth, gridHeight := minGridWidth, minGridHeight
 
-	gameWidth := gridWidth*gridBlockSize + offsetX
-	gameHeight := gridHeight*gridBlockSize + offsetY
+	gameWidth := gridWidth*consts.TileSize + offsetX
+	gameHeight := gridHeight*consts.TileSize + offsetY
 
 	world.Resources.ScreenDimensions.Width = gameWidth
 	world.Resources.ScreenDimensions.Height = gameHeight

--- a/lib/resources/level.go
+++ b/lib/resources/level.go
@@ -73,7 +73,10 @@ func NewLevel(world w.World, newDepth int, width gc.Row, height gc.Col) loader.L
 		case mapbuilder.TileFloor:
 			chain.BuildData.Level.Entities[i] = SpawnFloor(world, gc.Row(x), gc.Col(y))
 		case mapbuilder.TileWall:
-			chain.BuildData.Level.Entities[i] = SpawnFieldWall(world, gc.Row(x), gc.Col(y))
+			// 近傍4タイルにフロアがあるときだけ壁にする
+			if chain.BuildData.AdjacentOrthoAnyFloor(i) {
+				chain.BuildData.Level.Entities[i] = SpawnFieldWall(world, gc.Row(x), gc.Col(y))
+			}
 		case mapbuilder.TileWarpNext:
 			chain.BuildData.Level.Entities[i] = SpawnFieldWarpNext(world, gc.Row(x), gc.Col(y))
 		}

--- a/lib/resources/level.go
+++ b/lib/resources/level.go
@@ -8,7 +8,6 @@ import (
 	w "github.com/kijimaD/ruins/lib/engine/world"
 	"github.com/kijimaD/ruins/lib/loader"
 	"github.com/kijimaD/ruins/lib/mapbuilder"
-	ecs "github.com/x-hgg-x/goecs/v2"
 )
 
 const (
@@ -31,14 +30,7 @@ type Game struct {
 const defaultTileSize = 32
 
 func NewLevel(world w.World, newDepth int, width gc.Row, height gc.Col) loader.Level {
-	tileCount := int(width) * int(height)
-	level := loader.Level{
-		TileWidth:  width,
-		TileHeight: height,
-		TileSize:   defaultTileSize,
-		Entities:   make([]ecs.Entity, tileCount),
-	}
-	chain := mapbuilder.SimpleRoomBuilder()
+	chain := mapbuilder.SimpleRoomBuilder(width, height)
 	chain.Build()
 
 	// ワープホールを生成する
@@ -48,9 +40,9 @@ func NewLevel(world w.World, newDepth int, width gc.Row, height gc.Col) loader.L
 		if failCountWarpNext > 1000 {
 			log.Fatal("ワープホールの生成に失敗した")
 		}
-		x := rand.Intn(int(level.TileWidth))
-		y := rand.Intn(int(level.TileHeight))
-		tileIdx := level.XYTileIndex(x, y)
+		x := rand.Intn(int(chain.BuildData.Level.TileWidth))
+		y := rand.Intn(int(chain.BuildData.Level.TileHeight))
+		tileIdx := chain.BuildData.Level.XYTileIndex(x, y)
 		if chain.BuildData.Tiles[tileIdx] == mapbuilder.TileFloor {
 			chain.BuildData.Tiles[tileIdx] = mapbuilder.TileWarpNext
 
@@ -64,8 +56,8 @@ func NewLevel(world w.World, newDepth int, width gc.Row, height gc.Col) loader.L
 		if failCountPlayer > 1000 {
 			log.Fatal("プレイヤーの生成に失敗した")
 		}
-		x := rand.Intn(int(level.TileWidth))
-		y := rand.Intn(int(level.TileHeight))
+		x := rand.Intn(int(chain.BuildData.Level.TileWidth))
+		y := rand.Intn(int(chain.BuildData.Level.TileHeight))
 		tileIdx := chain.BuildData.Level.XYTileIndex(x, y)
 		if chain.BuildData.Tiles[tileIdx] == mapbuilder.TileFloor {
 			SpawnPlayer(world, x*defaultTileSize+defaultTileSize/2, y*defaultTileSize+defaultTileSize/2)

--- a/lib/states/dungeon.go
+++ b/lib/states/dungeon.go
@@ -46,7 +46,7 @@ func (st *DungeonState) OnStart(world w.World) {
 	baseImage.Fill(color.Black)
 
 	gameResources := world.Resources.Game.(*resources.Game)
-	gameResources.Level = resources.NewLevel(world, 1, 20, 20)
+	gameResources.Level = resources.NewLevel(world, 1, 50, 50)
 }
 
 func (st *DungeonState) OnStop(world w.World) {

--- a/lib/systems/blind_spot.go
+++ b/lib/systems/blind_spot.go
@@ -10,6 +10,7 @@ import (
 	ec "github.com/kijimaD/ruins/lib/engine/components"
 	w "github.com/kijimaD/ruins/lib/engine/world"
 	"github.com/kijimaD/ruins/lib/utils/camera"
+	"github.com/kijimaD/ruins/lib/utils/consts"
 	ecs "github.com/x-hgg-x/goecs/v2"
 )
 
@@ -17,7 +18,7 @@ var (
 	// 影生成時の、マスクのベースとして使う黒画像。
 	// TODO: Resourceに配置すべき
 	// TODO: ステージのサイズによって可変にするべき
-	shadowImage = ebiten.NewImage(32*50, 32*50)
+	shadowImage = ebiten.NewImage(consts.TileSize*50, consts.TileSize*50)
 )
 
 // 遮蔽物を隠す

--- a/lib/systems/blind_spot.go
+++ b/lib/systems/blind_spot.go
@@ -16,7 +16,8 @@ import (
 var (
 	// 影生成時の、マスクのベースとして使う黒画像。
 	// TODO: Resourceに配置すべき
-	shadowImage = ebiten.NewImage(1000, 1000)
+	// TODO: ステージのサイズによって可変にするべき
+	shadowImage = ebiten.NewImage(32*50, 32*50)
 )
 
 // 遮蔽物を隠す

--- a/lib/utils/consts/consts.go
+++ b/lib/utils/consts/consts.go
@@ -1,6 +1,8 @@
 package consts
 
 const (
+	TileSize = 32
+
 	HPLabel        = "HP"
 	SPLabel        = "SP"
 	VitalityLabel  = "体力"


### PR DESCRIPTION
- [x] 20x20固定から、指定できるようにする
- [x] 大きい値を指定するとFPSが大きく下がった。対応する
  - 到達できないタイルには壁を配置せず、視界判定対象を減らした