### PR TITLE
死亡時にコマンドを無効化する

### DIFF
--- a/lib/states/battle.go
+++ b/lib/states/battle.go
@@ -576,10 +576,6 @@ func (st *BattleState) reloadTarget(world w.World, currentPhase *phaseChooseTarg
 					st.phase = &phaseChooseAction{owner: *st.party.Value()}
 				} else {
 					// 全員分完了
-					st.party, err = party.NewParty(world, components.FactionAlly)
-					if err != nil {
-						log.Fatal(err)
-					}
 					st.phase = &phaseEnemyActionSelect{}
 					gs.BattleCommandSystem(world) // 初回実行。以降は全部消化するまでクリックで実行する
 				}

--- a/lib/states/battle.go
+++ b/lib/states/battle.go
@@ -220,14 +220,12 @@ func (st *BattleState) Update(world w.World) states.Transition {
 
 		gameComponents := world.Components.Game.(*gc.Components)
 
-		// commandが残っていればクリック待ちにする
 		commandCount := 0
 		world.Manager.Join(
 			gameComponents.BattleCommand,
 		).Visit(ecs.Visit(func(entity ecs.Entity) {
 			commandCount += 1
 		}))
-
 		if commandCount > 0 {
 			// 未処理のコマンドがまだ残っている
 			st.isWaitClick = true

--- a/lib/states/battle.go
+++ b/lib/states/battle.go
@@ -185,6 +185,7 @@ func (st *BattleState) Update(world w.World) states.Transition {
 			st.phase = &phaseExecute{}
 		case *phaseExecute:
 		case *phaseResult:
+		case *phaseGameOver:
 		}
 		st.prevPhase = st.phase
 	}
@@ -209,7 +210,8 @@ func (st *BattleState) Update(world w.World) states.Transition {
 		case systems.BattleExtinctionNone:
 		case systems.BattleExtinctionAlly:
 			gamelog.BattleLog.Append("全滅した。")
-			return states.Transition{Type: states.TransSwitch, NewStates: []states.State{&GameOverState{}}}
+			st.phase = &phaseGameOver{}
+			return states.Transition{Type: states.TransNone}
 		case systems.BattleExtinctionMonster:
 			gamelog.BattleLog.Append("敵を全滅させた。")
 			st.phase = &phaseResult{}
@@ -254,6 +256,12 @@ func (st *BattleState) Update(world w.World) states.Transition {
 				return states.Transition{Type: states.TransPop}
 			}
 			v.actionCount += 1
+		}
+	case *phaseGameOver:
+		st.reloadMsg(world)
+
+		if inpututil.IsMouseButtonJustPressed(ebiten.MouseButtonLeft) {
+			return states.Transition{Type: states.TransSwitch, NewStates: []states.State{&GameOverState{}}}
 		}
 	}
 

--- a/lib/states/battle_phase.go
+++ b/lib/states/battle_phase.go
@@ -43,3 +43,7 @@ type phaseResult struct {
 }
 
 func (p *phaseResult) isBattlePhase() {}
+
+type phaseGameOver struct{}
+
+func (p *phaseGameOver) isBattlePhase() {}

--- a/lib/systems/battle_command.go
+++ b/lib/systems/battle_command.go
@@ -44,6 +44,16 @@ func BattleCommandSystem(world w.World) {
 
 	entity := bcEntities[0]
 	cmd := gameComponents.BattleCommand.Get(entity).(*gc.BattleCommand)
+	{
+		ownerPools := gameComponents.Pools.Get(cmd.Owner).(*gc.Pools)
+		// 持ち主が死んでいる場合はコマンドを削除する
+		if ownerPools.HP.Current == 0 {
+			world.Manager.DeleteEntity(entity)
+			BattleCommandSystem(world)
+
+			return
+		}
+	}
 
 	// wayから攻撃の属性を取り出す
 	attack := gameComponents.Attack.Get(cmd.Way).(*gc.Attack)

--- a/lib/systems/battle_extinction.go
+++ b/lib/systems/battle_extinction.go
@@ -1,0 +1,58 @@
+package systems
+
+import (
+	gc "github.com/kijimaD/ruins/lib/components"
+	w "github.com/kijimaD/ruins/lib/engine/world"
+	ecs "github.com/x-hgg-x/goecs/v2"
+)
+
+type BattleExtinctionType int
+
+const (
+	BattleExtinctionNone BattleExtinctionType = iota
+	BattleExtinctionAlly
+	BattleExtinctionMonster
+)
+
+// 敵や味方の全滅をチェックする
+func BattleExtinctionSystem(world w.World) BattleExtinctionType {
+	gameComponents := world.Components.Game.(*gc.Components)
+
+	// 味方が全員死んでいたらゲームオーバーにする
+	liveAllyCount := 0
+	world.Manager.Join(
+		gameComponents.Name,
+		gameComponents.FactionAlly,
+		gameComponents.Attributes,
+		gameComponents.Pools,
+	).Visit(ecs.Visit(func(entity ecs.Entity) {
+		pools := gameComponents.Pools.Get(entity).(*gc.Pools)
+		if pools.HP.Current == 0 {
+			return
+		}
+		liveAllyCount += 1
+	}))
+	if liveAllyCount == 0 {
+		return BattleExtinctionAlly
+	}
+
+	// 敵が全員死んでいたらリザルトフェーズに遷移する
+	liveEnemyCount := 0
+	world.Manager.Join(
+		gameComponents.Name,
+		gameComponents.FactionEnemy,
+		gameComponents.Attributes,
+		gameComponents.Pools,
+	).Visit(ecs.Visit(func(entity ecs.Entity) {
+		pools := gameComponents.Pools.Get(entity).(*gc.Pools)
+		if pools.HP.Current == 0 {
+			return
+		}
+		liveEnemyCount += 1
+	}))
+	if liveEnemyCount == 0 {
+		return BattleExtinctionMonster
+	}
+
+	return BattleExtinctionNone
+}

--- a/lib/worldhelper/party/party.go
+++ b/lib/worldhelper/party/party.go
@@ -1,0 +1,137 @@
+package party
+
+import (
+	"errors"
+
+	"github.com/kijimaD/ruins/lib/components"
+	gc "github.com/kijimaD/ruins/lib/components"
+	w "github.com/kijimaD/ruins/lib/engine/world"
+	"github.com/kijimaD/ruins/lib/utils/mathutil"
+	ecs "github.com/x-hgg-x/goecs/v2"
+	"github.com/yourbasic/bit"
+)
+
+// グルーピングする単位
+// 味方あるいは敵がある
+type Party struct {
+	// メンバー一覧
+	members []ecs.Entity
+	// 死んでいる場合はnilが入る
+	lives []*ecs.Entity
+	// 現在のインデックス。0始まり
+	cur int
+}
+
+// memberは仲間入れ替えなどをしないと減ったりしない
+// 派閥を指定して取得する
+// 最初にセットされるインデックスは生存しているエンティティである
+// みんな生きていない場合は異常である。エラーとする
+func NewParty(world w.World, factionType gc.FactionType) (Party, error) {
+	gameComponents := world.Components.Game.(*gc.Components)
+
+	var q *bit.Set
+	switch factionType {
+	case components.FactionAlly:
+		q = world.Manager.Join(
+			gameComponents.FactionAlly,
+			gameComponents.Pools,
+			gameComponents.Attributes,
+		)
+	case components.FactionEnemy:
+		q = world.Manager.Join(
+			gameComponents.FactionEnemy,
+			gameComponents.Pools,
+			gameComponents.Attributes,
+			gameComponents.CommandTable,
+		)
+	}
+	members := []ecs.Entity{}
+	q.Visit(ecs.Visit(func(entity ecs.Entity) {
+		members = append(members, entity)
+	}))
+
+	lives := []*ecs.Entity{}
+	for _, member := range members {
+		pools := gameComponents.Pools.Get(member).(*gc.Pools)
+		if pools.HP.Current == 0 {
+			lives = append(lives, nil)
+		} else {
+			lives = append(lives, &member)
+		}
+	}
+
+	party := Party{
+		members: members,
+		lives:   lives,
+		cur:     0,
+	}
+	if party.lives[party.cur] == nil {
+		err := party.Next()
+		if err != nil {
+			return Party{}, errors.New("生存Entityが存在しない")
+		}
+	}
+
+	return party, nil
+}
+
+// entityを返す
+func (p *Party) Value() *ecs.Entity {
+	return p.lives[p.cur]
+}
+
+var reachEdgeError = errors.New("reach edge error")
+
+func (p *Party) next() error {
+	memo := p.cur
+	p.cur = mathutil.Min(p.cur+1, len(p.members)-1)
+	if memo == p.cur {
+		// 末端に到達してcurが変化しなかった
+		return reachEdgeError
+	}
+
+	return nil
+}
+
+// curを進める
+func (p *Party) Next() error {
+	for {
+		err := p.next()
+		if err != nil {
+			// 末端に到達した
+			return err
+		}
+		if p.lives[p.cur] == nil {
+			continue
+		}
+
+		return nil
+	}
+}
+
+func (p *Party) prev() error {
+	memo := p.cur
+	p.cur = mathutil.Max(p.cur-1, 0)
+	if memo == p.cur {
+		// 末端に到達してcurが変化しなかった
+		return reachEdgeError
+	}
+
+	return nil
+}
+
+// curを戻す
+func (p *Party) Prev() error {
+	for {
+		err := p.prev()
+		if err != nil {
+			// 末端に到達した
+			return err
+		}
+		if p.lives[p.cur] == nil {
+			continue
+		}
+
+		return nil
+	}
+}

--- a/lib/worldhelper/party/party.go
+++ b/lib/worldhelper/party/party.go
@@ -78,23 +78,12 @@ func NewParty(world w.World, factionType gc.FactionType) (Party, error) {
 	return party, nil
 }
 
-// entityを返す
+// 選択中のentityを返す
 func (p *Party) Value() *ecs.Entity {
 	return p.lives[p.cur]
 }
 
 var reachEdgeError = errors.New("reach edge error")
-
-func (p *Party) next() error {
-	memo := p.cur
-	p.cur = mathutil.Min(p.cur+1, len(p.members)-1)
-	if memo == p.cur {
-		// 末端に到達してcurが変化しなかった
-		return reachEdgeError
-	}
-
-	return nil
-}
 
 // curを進める
 func (p *Party) Next() error {
@@ -112,17 +101,6 @@ func (p *Party) Next() error {
 	}
 }
 
-func (p *Party) prev() error {
-	memo := p.cur
-	p.cur = mathutil.Max(p.cur-1, 0)
-	if memo == p.cur {
-		// 末端に到達してcurが変化しなかった
-		return reachEdgeError
-	}
-
-	return nil
-}
-
 // curを戻す
 func (p *Party) Prev() error {
 	for {
@@ -137,4 +115,26 @@ func (p *Party) Prev() error {
 
 		return nil
 	}
+}
+
+func (p *Party) next() error {
+	memo := p.cur
+	p.cur = mathutil.Min(p.cur+1, len(p.members)-1)
+	if memo == p.cur {
+		// 末端に到達してcurが変化しなかった
+		return reachEdgeError
+	}
+
+	return nil
+}
+
+func (p *Party) prev() error {
+	memo := p.cur
+	p.cur = mathutil.Max(p.cur-1, 0)
+	if memo == p.cur {
+		// 末端に到達してcurが変化しなかった
+		return reachEdgeError
+	}
+
+	return nil
 }

--- a/lib/worldhelper/party/party.go
+++ b/lib/worldhelper/party/party.go
@@ -2,6 +2,7 @@ package party
 
 import (
 	"errors"
+	"log"
 
 	"github.com/kijimaD/ruins/lib/components"
 	gc "github.com/kijimaD/ruins/lib/components"
@@ -25,7 +26,7 @@ type Party struct {
 // memberは仲間入れ替えなどをしないと減ったりしない
 // 派閥を指定して取得する
 // 最初にセットされるインデックスは生存しているエンティティである
-// みんな生きていない場合は異常である。エラーとする
+// みんな生きていない場合は想定していない。エラーを返す
 func NewParty(world w.World, factionType gc.FactionType) (Party, error) {
 	gameComponents := world.Components.Game.(*gc.Components)
 
@@ -44,6 +45,8 @@ func NewParty(world w.World, factionType gc.FactionType) (Party, error) {
 			gameComponents.Attributes,
 			gameComponents.CommandTable,
 		)
+	default:
+		log.Fatalf("invalid case: %v")
 	}
 	members := []ecs.Entity{}
 	q.Visit(ecs.Visit(func(entity ecs.Entity) {

--- a/lib/worldhelper/party/party_test.go
+++ b/lib/worldhelper/party/party_test.go
@@ -1,0 +1,72 @@
+package party
+
+import (
+	"testing"
+
+	"github.com/kijimaD/ruins/lib/utils"
+	"github.com/stretchr/testify/assert"
+	ecs "github.com/x-hgg-x/goecs/v2"
+)
+
+func TestNext(t *testing.T) {
+	party := Party{
+		members: []ecs.Entity{0, 1, 2, 3},
+		lives: []*ecs.Entity{
+			utils.GetPtr(ecs.Entity(0)),
+			nil,
+			utils.GetPtr(ecs.Entity(2)),
+			utils.GetPtr(ecs.Entity(3)),
+		},
+		cur: 0,
+	}
+	{
+		// nilを飛ばして0->2で取得できる
+		err := party.Next()
+		assert.NoError(t, err)
+		assert.Equal(t, 2, int(*party.Value()))
+		assert.Equal(t, 2, party.cur)
+	}
+	{
+		// 2->3で取得できる
+		err := party.Next()
+		assert.NoError(t, err)
+		assert.Equal(t, 3, int(*party.Value()))
+		assert.Equal(t, 3, party.cur)
+	}
+	{
+		// 末端に到達した
+		err := party.Next()
+		assert.Error(t, err)
+	}
+}
+
+func TestPrev(t *testing.T) {
+	party := Party{
+		members: []ecs.Entity{0, 1, 2},
+		lives: []*ecs.Entity{
+			utils.GetPtr(ecs.Entity(0)),
+			nil,
+			utils.GetPtr(ecs.Entity(2)),
+		},
+		cur: 0,
+	}
+	{
+		// 末端に到達した
+		err := party.Prev()
+		assert.Error(t, err)
+	}
+	{
+		// 0->2で進める
+		err := party.Next()
+		assert.NoError(t, err)
+		assert.Equal(t, 2, int(*party.Value()))
+		assert.Equal(t, 2, party.cur)
+	}
+	{
+		// 2->0で戻れる
+		err := party.Prev()
+		assert.NoError(t, err)
+		assert.Equal(t, 0, int(*party.Value()))
+		assert.Equal(t, 0, party.cur)
+	}
+}

--- a/lib/worldhelper/party/party_test.go
+++ b/lib/worldhelper/party/party_test.go
@@ -40,6 +40,78 @@ func TestNext(t *testing.T) {
 	}
 }
 
+func TestGetNext(t *testing.T) {
+	party := Party{
+		members: []ecs.Entity{0, 1, 2, 3},
+		lives: []*ecs.Entity{
+			utils.GetPtr(ecs.Entity(0)),
+			nil,
+			utils.GetPtr(ecs.Entity(2)),
+			utils.GetPtr(ecs.Entity(3)),
+		},
+		cur: 0,
+	}
+	{
+		// nilを飛ばして0->2で取得できる
+		v, err := party.GetNext()
+		assert.NoError(t, err)
+		assert.Equal(t, 2, int(v))
+	}
+	{
+		party.Next()
+	}
+	{
+		// 2->3
+		v, err := party.GetNext()
+		assert.NoError(t, err)
+		assert.Equal(t, 3, int(v))
+	}
+	{
+		party.Next()
+	}
+	{
+		// 末端に到達した
+		_, err := party.GetNext()
+		assert.Error(t, err)
+	}
+}
+
+func TestGetPrev(t *testing.T) {
+	party := Party{
+		members: []ecs.Entity{0, 1, 2, 3},
+		lives: []*ecs.Entity{
+			utils.GetPtr(ecs.Entity(0)),
+			nil,
+			utils.GetPtr(ecs.Entity(2)),
+			utils.GetPtr(ecs.Entity(3)),
+		},
+		cur: 3,
+	}
+	{
+		// 3->2
+		v, err := party.GetPrev()
+		assert.NoError(t, err)
+		assert.Equal(t, 2, int(v))
+	}
+	{
+		party.Prev()
+	}
+	{
+		// nilを飛ばして2->0で取得できる
+		v, err := party.GetPrev()
+		assert.NoError(t, err)
+		assert.Equal(t, 0, int(v))
+	}
+	{
+		party.Prev()
+	}
+	{
+		// 末端に到達した
+		_, err := party.GetPrev()
+		assert.Error(t, err)
+	}
+}
+
 func TestPrev(t *testing.T) {
 	party := Party{
 		members: []ecs.Entity{0, 1, 2},


### PR DESCRIPTION
死亡したときは特殊で、戦闘に関していくつかの制約がある

- ownerが死亡するとそのbattleCommandは削除され実行されない
- targetが死亡したとき、同じ派閥の別のエンティティにターゲットが切り替わる。2つ以上ある場合は前→後の順番に切り替わる
- UI