### PR TITLE
開発用設定と本番用設定を指定できるようにする

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 .PHONY: run
 run: ## 実行する。スクショのキーを指定している
-	EBITENGINE_SCREENSHOT_KEY=1 LOG_LEVEL=info LOG_CATEGORIES=battle=debug go run .
+	RUINS_PROFILE=development go run . play
 
 .PHONY: test
 test: ## テストを実行する

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 )
 
 require (
+	github.com/caarlos0/env/v11 v11.3.1 // indirect
 	github.com/cpuguy83/go-md2man/v2 v2.0.7 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/ebitengine/gomobile v0.0.0-20250209143333-6071a2a2351c // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/BurntSushi/toml v1.5.0 h1:W5quZX/G/csjUnuI8SUYlsHs9M38FC7znL0lIO+DvMg=
 github.com/BurntSushi/toml v1.5.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
+github.com/caarlos0/env/v11 v11.3.1 h1:cArPWC15hWmEt+gWk7YBi7lEXTXCvpaSdCiZE2X5mCA=
+github.com/caarlos0/env/v11 v11.3.1/go.mod h1:qupehSf/Y0TUTsxKywqRt/vJjN5nz6vauiYEUUr8P4U=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=

--- a/lib/cmd/play.go
+++ b/lib/cmd/play.go
@@ -33,7 +33,7 @@ func runPlay(_ *cli.Context) error {
 	cfg := config.Get()
 
 	// ログ設定を読み込み
-	logger.LoadFromConfig(cfg.LogLevel)
+	logger.LoadFromConfig(cfg.LogLevel, cfg.LogCategories)
 
 	// デバッグモードの場合は設定を表示
 	if cfg.Debug {

--- a/lib/cmd/play.go
+++ b/lib/cmd/play.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hajimehoshi/ebiten/v2"
 	"github.com/kijimaD/ruins/lib/config"
 	"github.com/kijimaD/ruins/lib/game"
+	"github.com/kijimaD/ruins/lib/logger"
 	"github.com/pkg/profile"
 	"github.com/urfave/cli/v2"
 
@@ -30,6 +31,9 @@ var CmdPlay = &cli.Command{
 func runPlay(_ *cli.Context) error {
 	// 設定を読み込み
 	cfg := config.Get()
+
+	// ログ設定を読み込み
+	logger.LoadFromConfig(cfg.LogLevel)
 
 	// デバッグモードの場合は設定を表示
 	if cfg.Debug {

--- a/lib/cmd/play.go
+++ b/lib/cmd/play.go
@@ -1,12 +1,13 @@
 package cmd
 
 import (
+	"fmt"
 	"log"
 	"net/http"
 	"runtime"
 
 	"github.com/hajimehoshi/ebiten/v2"
-	"github.com/kijimaD/ruins/lib/consts"
+	"github.com/kijimaD/ruins/lib/config"
 	"github.com/kijimaD/ruins/lib/game"
 	"github.com/pkg/profile"
 	"github.com/urfave/cli/v2"
@@ -27,26 +28,85 @@ var CmdPlay = &cli.Command{
 }
 
 func runPlay(_ *cli.Context) error {
+	// 設定を読み込み
+	cfg := config.Get()
+
+	// デバッグモードの場合は設定を表示
+	if cfg.Debug {
+		log.Printf("Configuration loaded:\n%s", cfg.String())
+	}
+
+	// ウィンドウ設定
 	ebiten.SetWindowResizingMode(ebiten.WindowResizingModeEnabled)
-	ebiten.SetWindowSize(consts.MinGameWidth, consts.MinGameHeight)
+	ebiten.SetWindowSize(cfg.WindowWidth, cfg.WindowHeight)
 	ebiten.SetWindowTitle("ruins")
 
-	// プロファイラ。WASMは除外する
-	if runtime.GOOS != "js" {
-		defer profile.Start(profile.MemProfile, profile.ProfilePath(".")).Stop()
+	// フルスクリーン設定
+	if cfg.Fullscreen {
+		ebiten.SetFullscreen(true)
+	}
+
+	// FPS設定
+	if cfg.TargetFPS != 60 {
+		ebiten.SetTPS(cfg.TargetFPS)
+	}
+
+	// プロファイラー設定（WASMは除外）
+	if runtime.GOOS != "js" && cfg.DebugPProf {
+		var profileOptions []func(*profile.Profile)
+
+		if cfg.ProfileMemory {
+			profileOptions = append(profileOptions, profile.MemProfile)
+		}
+		if cfg.ProfileCPU {
+			profileOptions = append(profileOptions, profile.CPUProfile)
+		}
+		if cfg.ProfileMutex {
+			profileOptions = append(profileOptions, profile.MutexProfile)
+		}
+		if cfg.ProfileTrace {
+			profileOptions = append(profileOptions, profile.TraceProfile)
+		}
+
+		// デフォルトでメモリプロファイルを有効化
+		if len(profileOptions) == 0 {
+			profileOptions = append(profileOptions, profile.MemProfile)
+		}
+
+		profileOptions = append(profileOptions, profile.ProfilePath(cfg.ProfilePath))
+		defer profile.Start(profileOptions...).Stop()
+
+		// pprofサーバー起動
+		pprofAddr := fmt.Sprintf("localhost:%d", cfg.PProfPort)
 		go func() {
-			log.Fatal(http.ListenAndServe("localhost:6060", nil))
+			log.Printf("pprof server starting on http://%s", pprofAddr)
+			log.Fatal(http.ListenAndServe(pprofAddr, nil))
 		}()
 	}
 
-	world, err := game.InitWorld(consts.MinGameWidth, consts.MinGameHeight)
+	world, err := game.InitWorld(cfg.WindowWidth, cfg.WindowHeight)
 	if err != nil {
 		return err
 	}
 
+	// 開始ステートの決定
+	var initialState es.State
+	switch cfg.StartingState {
+	case "home_menu":
+		initialState = &gs.HomeMenuState{}
+	case "debug_menu":
+		initialState = &gs.DebugMenuState{}
+	case "dungeon":
+		initialState = &gs.DungeonState{Depth: 1}
+	case "main_menu":
+		initialState = &gs.MainMenuState{}
+	default:
+		log.Fatalf("無効なstate: %s", cfg.StartingState)
+	}
+
 	err = ebiten.RunGame(&game.MainGame{
 		World:        world,
-		StateMachine: es.Init(&gs.MainMenuState{}, world),
+		StateMachine: es.Init(initialState, world),
 	})
 	if err != nil {
 		return err

--- a/lib/config/config.go
+++ b/lib/config/config.go
@@ -1,7 +1,6 @@
 package config
 
 import (
-	"fmt"
 	"os"
 
 	"github.com/caarlos0/env/v11"
@@ -11,8 +10,10 @@ import (
 type Profile string
 
 const (
-	ProfileProduction  Profile = "production"  // 本番環境
-	ProfileDevelopment Profile = "development" // 開発環境
+	// ProfileProduction は本番環境プロファイル
+	ProfileProduction Profile = "production"
+	// ProfileDevelopment は開発環境プロファイル
+	ProfileDevelopment Profile = "development"
 )
 
 // Config はアプリケーションの設定を管理する
@@ -26,10 +27,11 @@ type Config struct {
 	Fullscreen   bool `env:"RUINS_FULLSCREEN"`
 
 	// デバッグ設定
-	Debug      bool   `env:"RUINS_DEBUG"`
-	LogLevel   string `env:"RUINS_LOG_LEVEL"`
-	DebugPProf bool   `env:"RUINS_DEBUG_PPROF"`
-	PProfPort  int    `env:"RUINS_PPROF_PORT"`
+	Debug         bool   `env:"RUINS_DEBUG"`
+	LogLevel      string `env:"RUINS_LOG_LEVEL"`
+	LogCategories string `env:"RUINS_LOG_CATEGORIES"`
+	DebugPProf    bool   `env:"RUINS_DEBUG_PPROF"`
+	PProfPort     int    `env:"RUINS_PPROF_PORT"`
 
 	// ゲーム設定
 	StartingState string `env:"RUINS_STARTING_STATE"`
@@ -99,6 +101,9 @@ func (c *Config) applyProductionDefaults() {
 	if os.Getenv("RUINS_LOG_LEVEL") == "" {
 		c.LogLevel = "info"
 	}
+	if os.Getenv("RUINS_LOG_CATEGORIES") == "" {
+		c.LogCategories = ""
+	}
 	if os.Getenv("RUINS_DEBUG_PPROF") == "" {
 		c.DebugPProf = false
 	}
@@ -152,6 +157,9 @@ func (c *Config) applyDevelopmentDefaults() {
 	}
 	if os.Getenv("RUINS_LOG_LEVEL") == "" {
 		c.LogLevel = "info"
+	}
+	if os.Getenv("RUINS_LOG_CATEGORIES") == "" {
+		c.LogCategories = ""
 	}
 	if os.Getenv("RUINS_DEBUG_PPROF") == "" {
 		c.DebugPProf = true
@@ -212,7 +220,7 @@ func (c *Config) Validate() error {
 		"fatal": true,
 	}
 	if !validLogLevels[c.LogLevel] {
-		return fmt.Errorf("無効なログレベル: %s", c.LogLevel)
+		c.LogLevel = "info" // 無効な値はinfoに修正
 	}
 
 	return nil

--- a/lib/config/config.go
+++ b/lib/config/config.go
@@ -211,17 +211,5 @@ func (c *Config) Validate() error {
 		c.PProfPort = 6060
 	}
 
-	// LogLevel の検証
-	validLogLevels := map[string]bool{
-		"debug": true,
-		"info":  true,
-		"warn":  true,
-		"error": true,
-		"fatal": true,
-	}
-	if !validLogLevels[c.LogLevel] {
-		c.LogLevel = "info" // 無効な値はinfoに修正
-	}
-
 	return nil
 }

--- a/lib/config/config.go
+++ b/lib/config/config.go
@@ -1,0 +1,199 @@
+package config
+
+import (
+	"os"
+
+	"github.com/caarlos0/env/v11"
+)
+
+// Profile は設定プロファイルを表す
+type Profile string
+
+const (
+	ProfileProduction  Profile = "production"  // 本番環境
+	ProfileDevelopment Profile = "development" // 開発環境
+)
+
+// Config はアプリケーションの設定を管理する
+type Config struct {
+	// 環境プロファイル
+	Profile Profile `env:"RUINS_PROFILE" envDefault:"production"`
+
+	// ゲームウィンドウ設定
+	WindowWidth  int  `env:"RUINS_WINDOW_WIDTH"`
+	WindowHeight int  `env:"RUINS_WINDOW_HEIGHT"`
+	Fullscreen   bool `env:"RUINS_FULLSCREEN"`
+
+	// デバッグ設定
+	Debug      bool `env:"RUINS_DEBUG"`
+	DebugPProf bool `env:"RUINS_DEBUG_PPROF"`
+	PProfPort  int  `env:"RUINS_PPROF_PORT"`
+
+	// ゲーム設定
+	StartingState string `env:"RUINS_STARTING_STATE"`
+
+	// パフォーマンス設定
+	TargetFPS     int    `env:"RUINS_TARGET_FPS"`
+	ProfileMemory bool   `env:"RUINS_PROFILE_MEMORY"`
+	ProfileCPU    bool   `env:"RUINS_PROFILE_CPU"`
+	ProfileMutex  bool   `env:"RUINS_PROFILE_MUTEX"`
+	ProfileTrace  bool   `env:"RUINS_PROFILE_TRACE"`
+	ProfilePath   string `env:"RUINS_PROFILE_PATH"`
+}
+
+// Load は環境変数から設定を読み込む
+func Load() (*Config, error) {
+	cfg := &Config{}
+
+	// プロファイルを最初に決定(デフォルトはproduction)
+	profile := os.Getenv("RUINS_PROFILE")
+	if profile == "" {
+		cfg.Profile = ProfileProduction
+	} else {
+		cfg.Profile = Profile(profile)
+	}
+
+	// プロファイルに基づくデフォルト値を設定
+	cfg.applyProfileDefaults()
+
+	// 環境変数で明示的に設定された値で上書き
+	if err := env.Parse(cfg); err != nil {
+		return nil, err
+	}
+
+	return cfg, nil
+}
+
+// applyProfileDefaults はプロファイルに基づいてデフォルト値を設定する
+func (c *Config) applyProfileDefaults() {
+	switch c.Profile {
+	case ProfileDevelopment:
+		c.applyDevelopmentDefaults()
+	case ProfileProduction:
+		c.applyProductionDefaults()
+	default:
+		// デフォルトは本番設定
+		c.applyProductionDefaults()
+	}
+}
+
+// applyProductionDefaults は本番環境のデフォルト値を設定
+func (c *Config) applyProductionDefaults() {
+	// ウィンドウ設定
+	if os.Getenv("RUINS_WINDOW_WIDTH") == "" {
+		c.WindowWidth = 960
+	}
+	if os.Getenv("RUINS_WINDOW_HEIGHT") == "" {
+		c.WindowHeight = 720
+	}
+	if os.Getenv("RUINS_FULLSCREEN") == "" {
+		c.Fullscreen = false
+	}
+
+	// デバッグ設定
+	if os.Getenv("RUINS_DEBUG") == "" {
+		c.Debug = false
+	}
+	if os.Getenv("RUINS_DEBUG_PPROF") == "" {
+		c.DebugPProf = false
+	}
+	if os.Getenv("RUINS_PPROF_PORT") == "" {
+		c.PProfPort = 6060
+	}
+
+	// ゲーム設定
+	if os.Getenv("RUINS_STARTING_STATE") == "" {
+		c.StartingState = "main_menu"
+	}
+
+	// パフォーマンス設定
+	if os.Getenv("RUINS_TARGET_FPS") == "" {
+		c.TargetFPS = 60
+	}
+
+	// プロファイル設定
+	if os.Getenv("RUINS_PROFILE_MEMORY") == "" {
+		c.ProfileMemory = false
+	}
+	if os.Getenv("RUINS_PROFILE_CPU") == "" {
+		c.ProfileCPU = false
+	}
+	if os.Getenv("RUINS_PROFILE_MUTEX") == "" {
+		c.ProfileMutex = false
+	}
+	if os.Getenv("RUINS_PROFILE_TRACE") == "" {
+		c.ProfileTrace = false
+	}
+	if os.Getenv("RUINS_PROFILE_PATH") == "" {
+		c.ProfilePath = "."
+	}
+}
+
+// applyDevelopmentDefaults は開発環境のデフォルト値を設定
+func (c *Config) applyDevelopmentDefaults() {
+	if os.Getenv("RUINS_WINDOW_WIDTH") == "" {
+		c.WindowWidth = 960
+	}
+	if os.Getenv("RUINS_WINDOW_HEIGHT") == "" {
+		c.WindowHeight = 720
+	}
+	if os.Getenv("RUINS_FULLSCREEN") == "" {
+		c.Fullscreen = false
+	}
+
+	// デバッグ設定
+	if os.Getenv("RUINS_DEBUG") == "" {
+		c.Debug = true
+	}
+	if os.Getenv("RUINS_DEBUG_PPROF") == "" {
+		c.DebugPProf = true
+	}
+	if os.Getenv("RUINS_PPROF_PORT") == "" {
+		c.PProfPort = 6060
+	}
+
+	// ゲーム設定
+	if os.Getenv("RUINS_STARTING_STATE") == "" {
+		c.StartingState = "home_menu"
+	}
+
+	// パフォーマンス設定
+	if os.Getenv("RUINS_TARGET_FPS") == "" {
+		c.TargetFPS = 60
+	}
+
+	// プロファイル設定
+	if os.Getenv("RUINS_PROFILE_MEMORY") == "" {
+		c.ProfileMemory = true
+	}
+	if os.Getenv("RUINS_PROFILE_CPU") == "" {
+		c.ProfileCPU = false
+	}
+	if os.Getenv("RUINS_PROFILE_MUTEX") == "" {
+		c.ProfileMutex = false
+	}
+	if os.Getenv("RUINS_PROFILE_TRACE") == "" {
+		c.ProfileTrace = false
+	}
+	if os.Getenv("RUINS_PROFILE_PATH") == "" {
+		c.ProfilePath = "./profiles" // 開発時は専用フォルダ
+	}
+}
+
+// Validate は設定値の妥当性を検証する
+func (c *Config) Validate() error {
+	if c.WindowWidth < 320 {
+		c.WindowWidth = 320
+	}
+	if c.WindowHeight < 240 {
+		c.WindowHeight = 240
+	}
+	if c.TargetFPS < 1 {
+		c.TargetFPS = 60
+	}
+	if c.PProfPort < 1024 || c.PProfPort > 65535 {
+		c.PProfPort = 6060
+	}
+
+	return nil
+}

--- a/lib/config/config.go
+++ b/lib/config/config.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/caarlos0/env/v11"
@@ -25,9 +26,10 @@ type Config struct {
 	Fullscreen   bool `env:"RUINS_FULLSCREEN"`
 
 	// デバッグ設定
-	Debug      bool `env:"RUINS_DEBUG"`
-	DebugPProf bool `env:"RUINS_DEBUG_PPROF"`
-	PProfPort  int  `env:"RUINS_PPROF_PORT"`
+	Debug      bool   `env:"RUINS_DEBUG"`
+	LogLevel   string `env:"RUINS_LOG_LEVEL"`
+	DebugPProf bool   `env:"RUINS_DEBUG_PPROF"`
+	PProfPort  int    `env:"RUINS_PPROF_PORT"`
 
 	// ゲーム設定
 	StartingState string `env:"RUINS_STARTING_STATE"`
@@ -94,6 +96,9 @@ func (c *Config) applyProductionDefaults() {
 	if os.Getenv("RUINS_DEBUG") == "" {
 		c.Debug = false
 	}
+	if os.Getenv("RUINS_LOG_LEVEL") == "" {
+		c.LogLevel = "info"
+	}
 	if os.Getenv("RUINS_DEBUG_PPROF") == "" {
 		c.DebugPProf = false
 	}
@@ -145,6 +150,9 @@ func (c *Config) applyDevelopmentDefaults() {
 	if os.Getenv("RUINS_DEBUG") == "" {
 		c.Debug = true
 	}
+	if os.Getenv("RUINS_LOG_LEVEL") == "" {
+		c.LogLevel = "info"
+	}
 	if os.Getenv("RUINS_DEBUG_PPROF") == "" {
 		c.DebugPProf = true
 	}
@@ -193,6 +201,18 @@ func (c *Config) Validate() error {
 	}
 	if c.PProfPort < 1024 || c.PProfPort > 65535 {
 		c.PProfPort = 6060
+	}
+
+	// LogLevel の検証
+	validLogLevels := map[string]bool{
+		"debug": true,
+		"info":  true,
+		"warn":  true,
+		"error": true,
+		"fatal": true,
+	}
+	if !validLogLevels[c.LogLevel] {
+		return fmt.Errorf("無効なログレベル: %s", c.LogLevel)
 	}
 
 	return nil

--- a/lib/config/config_test.go
+++ b/lib/config/config_test.go
@@ -34,10 +34,10 @@ func TestLoad(t *testing.T) {
 		assert.Equal(t, 720, cfg.WindowHeight)
 		assert.Equal(t, false, cfg.Fullscreen)
 		assert.Equal(t, false, cfg.Debug) // 本番ではfalse
+		assert.Equal(t, "info", cfg.LogLevel) // 本番ではinfo
 		assert.Equal(t, false, cfg.DebugPProf) // 本番ではfalse
 		assert.Equal(t, 6060, cfg.PProfPort)
 		assert.Equal(t, "main_menu", cfg.StartingState)
-		assert.Equal(t, false, cfg.SkipIntro)
 		assert.Equal(t, 60, cfg.TargetFPS)
 		assert.Equal(t, false, cfg.ProfileMemory) // 本番ではfalse
 		assert.Equal(t, false, cfg.ProfileCPU)
@@ -69,14 +69,14 @@ func TestLoad(t *testing.T) {
 		require.NoError(t, err)
 		
 		assert.Equal(t, ProfileDevelopment, cfg.Profile)
-		assert.Equal(t, 800, cfg.WindowWidth) // 開発では小さめ
-		assert.Equal(t, 600, cfg.WindowHeight) // 開発では小さめ
+		assert.Equal(t, 960, cfg.WindowWidth) // 開発でも通常サイズ
+		assert.Equal(t, 720, cfg.WindowHeight) // 開発でも通常サイズ
 		assert.Equal(t, false, cfg.Fullscreen)
 		assert.Equal(t, true, cfg.Debug) // 開発ではtrue
+		assert.Equal(t, "debug", cfg.LogLevel) // 開発ではdebug
 		assert.Equal(t, true, cfg.DebugPProf) // 開発ではtrue
 		assert.Equal(t, 6060, cfg.PProfPort)
-		assert.Equal(t, "debug_menu", cfg.StartingState) // 開発ではdebug_menu
-		assert.Equal(t, true, cfg.SkipIntro) // 開発ではtrue
+		assert.Equal(t, "home_menu", cfg.StartingState) // 開発ではhome_menu
 		assert.Equal(t, 60, cfg.TargetFPS)
 		assert.Equal(t, true, cfg.ProfileMemory) // 開発ではtrue
 		assert.Equal(t, false, cfg.ProfileCPU)
@@ -138,10 +138,11 @@ func TestValidate(t *testing.T) {
 		t.Parallel()
 		
 		cfg := &Config{
-			WindowWidth:  100, // 最小値以下
-			WindowHeight: 50,  // 最小値以下
-			TargetFPS:    0,   // 無効
-			PProfPort:    80,  // 範囲外
+			WindowWidth:  100,       // 最小値以下
+			WindowHeight: 50,        // 最小値以下
+			TargetFPS:    0,         // 無効
+			PProfPort:    80,        // 範囲外
+			LogLevel:     "invalid", // 無効なログレベル
 		}
 
 		err := cfg.Validate()
@@ -151,6 +152,7 @@ func TestValidate(t *testing.T) {
 		assert.Equal(t, 240, cfg.WindowHeight)
 		assert.Equal(t, 60, cfg.TargetFPS)
 		assert.Equal(t, 6060, cfg.PProfPort)
+		assert.Equal(t, "info", cfg.LogLevel) // 無効な値はinfoに修正
 	})
 
 	t.Run("有効な値は変更されない", func(t *testing.T) {
@@ -161,6 +163,7 @@ func TestValidate(t *testing.T) {
 			WindowHeight: 1080,
 			TargetFPS:    144,
 			PProfPort:    8080,
+			LogLevel:     "debug",
 		}
 
 		err := cfg.Validate()
@@ -170,6 +173,7 @@ func TestValidate(t *testing.T) {
 		assert.Equal(t, 1080, cfg.WindowHeight)
 		assert.Equal(t, 144, cfg.TargetFPS)
 		assert.Equal(t, 8080, cfg.PProfPort)
+		assert.Equal(t, "debug", cfg.LogLevel)
 	})
 }
 
@@ -220,6 +224,7 @@ func TestString(t *testing.T) {
 		WindowWidth:   1280,
 		WindowHeight:  720,
 		Debug:         true,
+		LogLevel:      "debug",
 		StartingState: "debug_menu",
 	}
 
@@ -228,5 +233,6 @@ func TestString(t *testing.T) {
 	assert.Contains(t, str, "WindowWidth: 1280")
 	assert.Contains(t, str, "WindowHeight: 720")
 	assert.Contains(t, str, "Debug: true")
+	assert.Contains(t, str, "LogLevel: debug")
 	assert.Contains(t, str, "StartingState: debug_menu")
 }

--- a/lib/config/config_test.go
+++ b/lib/config/config_test.go
@@ -13,11 +13,10 @@ func TestValidate(t *testing.T) {
 		t.Parallel()
 
 		cfg := &Config{
-			WindowWidth:  100,       // 最小値以下
-			WindowHeight: 50,        // 最小値以下
-			TargetFPS:    0,         // 無効
-			PProfPort:    80,        // 範囲外
-			LogLevel:     "invalid", // 無効なログレベル
+			WindowWidth:  100, // 最小値以下
+			WindowHeight: 50,  // 最小値以下
+			TargetFPS:    0,   // 無効
+			PProfPort:    80,  // 範囲外
 		}
 
 		err := cfg.Validate()
@@ -27,7 +26,6 @@ func TestValidate(t *testing.T) {
 		assert.Equal(t, 240, cfg.WindowHeight)
 		assert.Equal(t, 60, cfg.TargetFPS)
 		assert.Equal(t, 6060, cfg.PProfPort)
-		assert.Equal(t, "info", cfg.LogLevel) // 無効な値はinfoに修正
 	})
 
 	t.Run("有効な値は変更されない", func(t *testing.T) {
@@ -38,7 +36,6 @@ func TestValidate(t *testing.T) {
 			WindowHeight: 1080,
 			TargetFPS:    144,
 			PProfPort:    8080,
-			LogLevel:     "debug",
 		}
 
 		err := cfg.Validate()
@@ -48,7 +45,6 @@ func TestValidate(t *testing.T) {
 		assert.Equal(t, 1080, cfg.WindowHeight)
 		assert.Equal(t, 144, cfg.TargetFPS)
 		assert.Equal(t, 8080, cfg.PProfPort)
-		assert.Equal(t, "debug", cfg.LogLevel)
 	})
 }
 

--- a/lib/config/config_test.go
+++ b/lib/config/config_test.go
@@ -1,0 +1,232 @@
+package config
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoad(t *testing.T) {
+	t.Parallel()
+
+	t.Run("本番プロファイルのデフォルト設定が正しく読み込まれる", func(t *testing.T) {
+		t.Parallel()
+		
+		// 環境変数をクリア
+		os.Unsetenv("RUINS_PROFILE")
+		os.Unsetenv("RUINS_DEBUG")
+		os.Unsetenv("RUINS_DEBUG_PPROF")
+		os.Unsetenv("RUINS_PROFILE_MEMORY")
+		defer func() {
+			os.Unsetenv("RUINS_PROFILE")
+			os.Unsetenv("RUINS_DEBUG")
+			os.Unsetenv("RUINS_DEBUG_PPROF")
+			os.Unsetenv("RUINS_PROFILE_MEMORY")
+		}()
+		
+		cfg, err := Load()
+		require.NoError(t, err)
+		
+		assert.Equal(t, ProfileProduction, cfg.Profile)
+		assert.Equal(t, 960, cfg.WindowWidth)
+		assert.Equal(t, 720, cfg.WindowHeight)
+		assert.Equal(t, false, cfg.Fullscreen)
+		assert.Equal(t, false, cfg.Debug) // 本番ではfalse
+		assert.Equal(t, false, cfg.DebugPProf) // 本番ではfalse
+		assert.Equal(t, 6060, cfg.PProfPort)
+		assert.Equal(t, "main_menu", cfg.StartingState)
+		assert.Equal(t, false, cfg.SkipIntro)
+		assert.Equal(t, 60, cfg.TargetFPS)
+		assert.Equal(t, false, cfg.ProfileMemory) // 本番ではfalse
+		assert.Equal(t, false, cfg.ProfileCPU)
+		assert.Equal(t, false, cfg.ProfileMutex)
+		assert.Equal(t, false, cfg.ProfileTrace)
+		assert.Equal(t, ".", cfg.ProfilePath)
+	})
+	
+	t.Run("開発プロファイルのデフォルト設定が正しく読み込まれる", func(t *testing.T) {
+		t.Parallel()
+		
+		// 全ての環境変数をクリアしてから開発プロファイルを設定
+		os.Unsetenv("RUINS_WINDOW_WIDTH")
+		os.Unsetenv("RUINS_WINDOW_HEIGHT")
+		os.Unsetenv("RUINS_DEBUG")
+		os.Unsetenv("RUINS_STARTING_STATE")
+		os.Unsetenv("RUINS_TARGET_FPS")
+		os.Setenv("RUINS_PROFILE", "development")
+		defer func() {
+			os.Unsetenv("RUINS_PROFILE")
+			os.Unsetenv("RUINS_WINDOW_WIDTH")
+			os.Unsetenv("RUINS_WINDOW_HEIGHT")
+			os.Unsetenv("RUINS_DEBUG")
+			os.Unsetenv("RUINS_STARTING_STATE")
+			os.Unsetenv("RUINS_TARGET_FPS")
+		}()
+		
+		cfg, err := Load()
+		require.NoError(t, err)
+		
+		assert.Equal(t, ProfileDevelopment, cfg.Profile)
+		assert.Equal(t, 800, cfg.WindowWidth) // 開発では小さめ
+		assert.Equal(t, 600, cfg.WindowHeight) // 開発では小さめ
+		assert.Equal(t, false, cfg.Fullscreen)
+		assert.Equal(t, true, cfg.Debug) // 開発ではtrue
+		assert.Equal(t, true, cfg.DebugPProf) // 開発ではtrue
+		assert.Equal(t, 6060, cfg.PProfPort)
+		assert.Equal(t, "debug_menu", cfg.StartingState) // 開発ではdebug_menu
+		assert.Equal(t, true, cfg.SkipIntro) // 開発ではtrue
+		assert.Equal(t, 60, cfg.TargetFPS)
+		assert.Equal(t, true, cfg.ProfileMemory) // 開発ではtrue
+		assert.Equal(t, false, cfg.ProfileCPU)
+		assert.Equal(t, false, cfg.ProfileMutex)
+		assert.Equal(t, false, cfg.ProfileTrace)
+		assert.Equal(t, "./profiles", cfg.ProfilePath) // 開発では専用フォルダ
+	})
+
+	t.Run("環境変数がプロファイルデフォルトを上書きする", func(t *testing.T) {
+		t.Parallel()
+		
+		// 全ての関連環境変数をクリア
+		os.Unsetenv("RUINS_PROFILE")
+		os.Unsetenv("RUINS_WINDOW_WIDTH")
+		os.Unsetenv("RUINS_WINDOW_HEIGHT") 
+		os.Unsetenv("RUINS_DEBUG")
+		os.Unsetenv("RUINS_DEBUG_PPROF")
+		os.Unsetenv("RUINS_STARTING_STATE")
+		os.Unsetenv("RUINS_TARGET_FPS")
+		os.Unsetenv("RUINS_PROFILE_MEMORY")
+		
+		// 本番プロファイルを設定してから個別の環境変数で上書き
+		os.Setenv("RUINS_PROFILE", "production")
+		os.Setenv("RUINS_WINDOW_WIDTH", "1280")
+		os.Setenv("RUINS_WINDOW_HEIGHT", "1024")
+		os.Setenv("RUINS_DEBUG", "true") // 本番でもデバッグを有効に
+		os.Setenv("RUINS_STARTING_STATE", "debug_menu")
+		os.Setenv("RUINS_TARGET_FPS", "120")
+		defer func() {
+			os.Unsetenv("RUINS_PROFILE")
+			os.Unsetenv("RUINS_WINDOW_WIDTH")
+			os.Unsetenv("RUINS_WINDOW_HEIGHT")
+			os.Unsetenv("RUINS_DEBUG")
+			os.Unsetenv("RUINS_DEBUG_PPROF")
+			os.Unsetenv("RUINS_STARTING_STATE")
+			os.Unsetenv("RUINS_TARGET_FPS")
+			os.Unsetenv("RUINS_PROFILE_MEMORY")
+		}()
+
+		cfg, err := Load()
+		require.NoError(t, err)
+
+		assert.Equal(t, ProfileProduction, cfg.Profile)
+		assert.Equal(t, 1280, cfg.WindowWidth) // 環境変数で上書き
+		assert.Equal(t, 1024, cfg.WindowHeight) // 環境変数で上書き
+		assert.Equal(t, true, cfg.Debug) // 環境変数で上書き
+		assert.Equal(t, "debug_menu", cfg.StartingState) // 環境変数で上書き
+		assert.Equal(t, 120, cfg.TargetFPS) // 環境変数で上書き
+		// 他の設定は本番プロファイルのデフォルト
+		assert.Equal(t, false, cfg.DebugPProf)
+		assert.Equal(t, false, cfg.ProfileMemory)
+	})
+}
+
+func TestValidate(t *testing.T) {
+	t.Parallel()
+
+	t.Run("無効な値が修正される", func(t *testing.T) {
+		t.Parallel()
+		
+		cfg := &Config{
+			WindowWidth:  100, // 最小値以下
+			WindowHeight: 50,  // 最小値以下
+			TargetFPS:    0,   // 無効
+			PProfPort:    80,  // 範囲外
+		}
+
+		err := cfg.Validate()
+		assert.NoError(t, err)
+
+		assert.Equal(t, 320, cfg.WindowWidth)
+		assert.Equal(t, 240, cfg.WindowHeight)
+		assert.Equal(t, 60, cfg.TargetFPS)
+		assert.Equal(t, 6060, cfg.PProfPort)
+	})
+
+	t.Run("有効な値は変更されない", func(t *testing.T) {
+		t.Parallel()
+		
+		cfg := &Config{
+			WindowWidth:  1920,
+			WindowHeight: 1080,
+			TargetFPS:    144,
+			PProfPort:    8080,
+		}
+
+		err := cfg.Validate()
+		assert.NoError(t, err)
+
+		assert.Equal(t, 1920, cfg.WindowWidth)
+		assert.Equal(t, 1080, cfg.WindowHeight)
+		assert.Equal(t, 144, cfg.TargetFPS)
+		assert.Equal(t, 8080, cfg.PProfPort)
+	})
+}
+
+func TestManager(t *testing.T) {
+	t.Parallel()
+
+	t.Run("Get()がシングルトンとして動作する", func(t *testing.T) {
+		// 注意: これはパラレルテストできない（シングルトンのため）
+		Reset() // テスト用にリセット
+
+		cfg1 := Get()
+		cfg2 := Get()
+
+		assert.Same(t, cfg1, cfg2, "Get()は同じインスタンスを返すべき")
+	})
+
+	t.Run("MustGet()が設定を返す", func(t *testing.T) {
+		// 環境変数をクリア
+		os.Unsetenv("RUINS_PROFILE")
+		os.Unsetenv("RUINS_WINDOW_WIDTH")
+		os.Unsetenv("RUINS_WINDOW_HEIGHT")
+		os.Unsetenv("RUINS_DEBUG")
+		os.Unsetenv("RUINS_STARTING_STATE")
+		os.Unsetenv("RUINS_TARGET_FPS")
+		defer func() {
+			os.Unsetenv("RUINS_PROFILE")
+			os.Unsetenv("RUINS_WINDOW_WIDTH")
+			os.Unsetenv("RUINS_WINDOW_HEIGHT")
+			os.Unsetenv("RUINS_DEBUG")
+			os.Unsetenv("RUINS_STARTING_STATE")
+			os.Unsetenv("RUINS_TARGET_FPS")
+		}()
+		
+		Reset() // テスト用にリセット
+
+		cfg := MustGet()
+		assert.NotNil(t, cfg)
+		assert.Equal(t, ProfileProduction, cfg.Profile) // デフォルトは本番
+		assert.Equal(t, 960, cfg.WindowWidth) // 本番プロファイルのデフォルト値
+	})
+}
+
+func TestString(t *testing.T) {
+	t.Parallel()
+
+	cfg := &Config{
+		Profile:       ProfileDevelopment,
+		WindowWidth:   1280,
+		WindowHeight:  720,
+		Debug:         true,
+		StartingState: "debug_menu",
+	}
+
+	str := cfg.String()
+	assert.Contains(t, str, "Profile: development")
+	assert.Contains(t, str, "WindowWidth: 1280")
+	assert.Contains(t, str, "WindowHeight: 720")
+	assert.Contains(t, str, "Debug: true")
+	assert.Contains(t, str, "StartingState: debug_menu")
+}

--- a/lib/config/config_test.go
+++ b/lib/config/config_test.go
@@ -1,142 +1,17 @@
 package config
 
 import (
-	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
-
-func TestLoad(t *testing.T) {
-	t.Parallel()
-
-	t.Run("本番プロファイルのデフォルト設定が正しく読み込まれる", func(t *testing.T) {
-		t.Parallel()
-		
-		// 環境変数をクリア
-		os.Unsetenv("RUINS_PROFILE")
-		os.Unsetenv("RUINS_DEBUG")
-		os.Unsetenv("RUINS_DEBUG_PPROF")
-		os.Unsetenv("RUINS_PROFILE_MEMORY")
-		defer func() {
-			os.Unsetenv("RUINS_PROFILE")
-			os.Unsetenv("RUINS_DEBUG")
-			os.Unsetenv("RUINS_DEBUG_PPROF")
-			os.Unsetenv("RUINS_PROFILE_MEMORY")
-		}()
-		
-		cfg, err := Load()
-		require.NoError(t, err)
-		
-		assert.Equal(t, ProfileProduction, cfg.Profile)
-		assert.Equal(t, 960, cfg.WindowWidth)
-		assert.Equal(t, 720, cfg.WindowHeight)
-		assert.Equal(t, false, cfg.Fullscreen)
-		assert.Equal(t, false, cfg.Debug) // 本番ではfalse
-		assert.Equal(t, "info", cfg.LogLevel) // 本番ではinfo
-		assert.Equal(t, false, cfg.DebugPProf) // 本番ではfalse
-		assert.Equal(t, 6060, cfg.PProfPort)
-		assert.Equal(t, "main_menu", cfg.StartingState)
-		assert.Equal(t, 60, cfg.TargetFPS)
-		assert.Equal(t, false, cfg.ProfileMemory) // 本番ではfalse
-		assert.Equal(t, false, cfg.ProfileCPU)
-		assert.Equal(t, false, cfg.ProfileMutex)
-		assert.Equal(t, false, cfg.ProfileTrace)
-		assert.Equal(t, ".", cfg.ProfilePath)
-	})
-	
-	t.Run("開発プロファイルのデフォルト設定が正しく読み込まれる", func(t *testing.T) {
-		t.Parallel()
-		
-		// 全ての環境変数をクリアしてから開発プロファイルを設定
-		os.Unsetenv("RUINS_WINDOW_WIDTH")
-		os.Unsetenv("RUINS_WINDOW_HEIGHT")
-		os.Unsetenv("RUINS_DEBUG")
-		os.Unsetenv("RUINS_STARTING_STATE")
-		os.Unsetenv("RUINS_TARGET_FPS")
-		os.Setenv("RUINS_PROFILE", "development")
-		defer func() {
-			os.Unsetenv("RUINS_PROFILE")
-			os.Unsetenv("RUINS_WINDOW_WIDTH")
-			os.Unsetenv("RUINS_WINDOW_HEIGHT")
-			os.Unsetenv("RUINS_DEBUG")
-			os.Unsetenv("RUINS_STARTING_STATE")
-			os.Unsetenv("RUINS_TARGET_FPS")
-		}()
-		
-		cfg, err := Load()
-		require.NoError(t, err)
-		
-		assert.Equal(t, ProfileDevelopment, cfg.Profile)
-		assert.Equal(t, 960, cfg.WindowWidth) // 開発でも通常サイズ
-		assert.Equal(t, 720, cfg.WindowHeight) // 開発でも通常サイズ
-		assert.Equal(t, false, cfg.Fullscreen)
-		assert.Equal(t, true, cfg.Debug) // 開発ではtrue
-		assert.Equal(t, "debug", cfg.LogLevel) // 開発ではdebug
-		assert.Equal(t, true, cfg.DebugPProf) // 開発ではtrue
-		assert.Equal(t, 6060, cfg.PProfPort)
-		assert.Equal(t, "home_menu", cfg.StartingState) // 開発ではhome_menu
-		assert.Equal(t, 60, cfg.TargetFPS)
-		assert.Equal(t, true, cfg.ProfileMemory) // 開発ではtrue
-		assert.Equal(t, false, cfg.ProfileCPU)
-		assert.Equal(t, false, cfg.ProfileMutex)
-		assert.Equal(t, false, cfg.ProfileTrace)
-		assert.Equal(t, "./profiles", cfg.ProfilePath) // 開発では専用フォルダ
-	})
-
-	t.Run("環境変数がプロファイルデフォルトを上書きする", func(t *testing.T) {
-		t.Parallel()
-		
-		// 全ての関連環境変数をクリア
-		os.Unsetenv("RUINS_PROFILE")
-		os.Unsetenv("RUINS_WINDOW_WIDTH")
-		os.Unsetenv("RUINS_WINDOW_HEIGHT") 
-		os.Unsetenv("RUINS_DEBUG")
-		os.Unsetenv("RUINS_DEBUG_PPROF")
-		os.Unsetenv("RUINS_STARTING_STATE")
-		os.Unsetenv("RUINS_TARGET_FPS")
-		os.Unsetenv("RUINS_PROFILE_MEMORY")
-		
-		// 本番プロファイルを設定してから個別の環境変数で上書き
-		os.Setenv("RUINS_PROFILE", "production")
-		os.Setenv("RUINS_WINDOW_WIDTH", "1280")
-		os.Setenv("RUINS_WINDOW_HEIGHT", "1024")
-		os.Setenv("RUINS_DEBUG", "true") // 本番でもデバッグを有効に
-		os.Setenv("RUINS_STARTING_STATE", "debug_menu")
-		os.Setenv("RUINS_TARGET_FPS", "120")
-		defer func() {
-			os.Unsetenv("RUINS_PROFILE")
-			os.Unsetenv("RUINS_WINDOW_WIDTH")
-			os.Unsetenv("RUINS_WINDOW_HEIGHT")
-			os.Unsetenv("RUINS_DEBUG")
-			os.Unsetenv("RUINS_DEBUG_PPROF")
-			os.Unsetenv("RUINS_STARTING_STATE")
-			os.Unsetenv("RUINS_TARGET_FPS")
-			os.Unsetenv("RUINS_PROFILE_MEMORY")
-		}()
-
-		cfg, err := Load()
-		require.NoError(t, err)
-
-		assert.Equal(t, ProfileProduction, cfg.Profile)
-		assert.Equal(t, 1280, cfg.WindowWidth) // 環境変数で上書き
-		assert.Equal(t, 1024, cfg.WindowHeight) // 環境変数で上書き
-		assert.Equal(t, true, cfg.Debug) // 環境変数で上書き
-		assert.Equal(t, "debug_menu", cfg.StartingState) // 環境変数で上書き
-		assert.Equal(t, 120, cfg.TargetFPS) // 環境変数で上書き
-		// 他の設定は本番プロファイルのデフォルト
-		assert.Equal(t, false, cfg.DebugPProf)
-		assert.Equal(t, false, cfg.ProfileMemory)
-	})
-}
 
 func TestValidate(t *testing.T) {
 	t.Parallel()
 
 	t.Run("無効な値が修正される", func(t *testing.T) {
 		t.Parallel()
-		
+
 		cfg := &Config{
 			WindowWidth:  100,       // 最小値以下
 			WindowHeight: 50,        // 最小値以下
@@ -157,7 +32,7 @@ func TestValidate(t *testing.T) {
 
 	t.Run("有効な値は変更されない", func(t *testing.T) {
 		t.Parallel()
-		
+
 		cfg := &Config{
 			WindowWidth:  1920,
 			WindowHeight: 1080,
@@ -177,9 +52,8 @@ func TestValidate(t *testing.T) {
 	})
 }
 
+//nolint:paralleltest // シングルトンテストのため並列実行不可
 func TestManager(t *testing.T) {
-	t.Parallel()
-
 	t.Run("Get()がシングルトンとして動作する", func(t *testing.T) {
 		// 注意: これはパラレルテストできない（シングルトンのため）
 		Reset() // テスト用にリセット
@@ -191,40 +65,24 @@ func TestManager(t *testing.T) {
 	})
 
 	t.Run("MustGet()が設定を返す", func(t *testing.T) {
-		// 環境変数をクリア
-		os.Unsetenv("RUINS_PROFILE")
-		os.Unsetenv("RUINS_WINDOW_WIDTH")
-		os.Unsetenv("RUINS_WINDOW_HEIGHT")
-		os.Unsetenv("RUINS_DEBUG")
-		os.Unsetenv("RUINS_STARTING_STATE")
-		os.Unsetenv("RUINS_TARGET_FPS")
-		defer func() {
-			os.Unsetenv("RUINS_PROFILE")
-			os.Unsetenv("RUINS_WINDOW_WIDTH")
-			os.Unsetenv("RUINS_WINDOW_HEIGHT")
-			os.Unsetenv("RUINS_DEBUG")
-			os.Unsetenv("RUINS_STARTING_STATE")
-			os.Unsetenv("RUINS_TARGET_FPS")
-		}()
-		
 		Reset() // テスト用にリセット
 
 		cfg := MustGet()
 		assert.NotNil(t, cfg)
 		assert.Equal(t, ProfileProduction, cfg.Profile) // デフォルトは本番
-		assert.Equal(t, 960, cfg.WindowWidth) // 本番プロファイルのデフォルト値
+		assert.Equal(t, 960, cfg.WindowWidth)           // 本番プロファイルのデフォルト値
 	})
 }
 
 func TestString(t *testing.T) {
 	t.Parallel()
-
 	cfg := &Config{
 		Profile:       ProfileDevelopment,
 		WindowWidth:   1280,
 		WindowHeight:  720,
 		Debug:         true,
 		LogLevel:      "debug",
+		LogCategories: "battle=debug,render=warn",
 		StartingState: "debug_menu",
 	}
 
@@ -234,5 +92,6 @@ func TestString(t *testing.T) {
 	assert.Contains(t, str, "WindowHeight: 720")
 	assert.Contains(t, str, "Debug: true")
 	assert.Contains(t, str, "LogLevel: debug")
+	assert.Contains(t, str, "LogCategories: battle=debug,render=warn")
 	assert.Contains(t, str, "StartingState: debug_menu")
 }

--- a/lib/config/doc.go
+++ b/lib/config/doc.go
@@ -8,24 +8,26 @@
 //
 // ## プロファイル設定
 //   - RUINS_PROFILE: 環境プロファイル (デフォルト: production)
-//     - "production": 本番環境 (デバッグ機能無効、軽量設定)
-//     - "development": 開発環境 (デバッグ機能有効、開発効率重視)
+//   - "production": 本番環境 (デバッグ機能無効、軽量設定)
+//   - "development": 開発環境 (デバッグ機能有効、開発効率重視)
 //
 // ## ウィンドウ設定
 //   - RUINS_WINDOW_WIDTH: ウィンドウ幅 (デフォルト: 960)
-//   - RUINS_WINDOW_HEIGHT: ウィンドウ高さ (デフォルト: 720)  
+//   - RUINS_WINDOW_HEIGHT: ウィンドウ高さ (デフォルト: 720)
 //   - RUINS_FULLSCREEN: フルスクリーンモード (デフォルト: false)
 //
 // ## デバッグ設定
 //   - RUINS_DEBUG: デバッグモード (デフォルト: false)
+//   - RUINS_LOG_LEVEL: ログレベル (デフォルト: info)
+//   - "debug", "info", "warn", "error", "fatal"
 //   - RUINS_DEBUG_PPROF: pprofサーバー起動 (デフォルト: true)
 //   - RUINS_PPROF_PORT: pprofサーバーポート (デフォルト: 6060)
 //
 // ## ゲーム設定
 //   - RUINS_STARTING_STATE: 開始ステート (デフォルト: main_menu)
-//     - "main_menu": メインメニュー
-//     - "debug_menu": デバッグメニュー
-//     - "dungeon": ダンジョン
+//   - "main_menu": メインメニュー
+//   - "debug_menu": デバッグメニュー
+//   - "dungeon": ダンジョン
 //   - RUINS_SKIP_INTRO: イントロスキップ (デフォルト: false)
 //
 // ## パフォーマンス設定
@@ -40,16 +42,16 @@
 //
 //	// 設定の取得
 //	cfg := config.Get()
-//	
+//
 //	// プロファイルに基づく設定確認
 //	if cfg.Profile == config.ProfileDevelopment {
 //		log.Println("Development mode")
 //	}
-//	
+//
 //	// ウィンドウサイズの取得
 //	width := cfg.WindowWidth
 //	height := cfg.WindowHeight
-//	
+//
 //	// デバッグモードの確認
 //	if cfg.Debug {
 //		log.Println("Debug mode enabled")

--- a/lib/config/doc.go
+++ b/lib/config/doc.go
@@ -18,8 +18,8 @@
 //
 // ## デバッグ設定
 //   - RUINS_DEBUG: デバッグモード (デフォルト: false)
-//   - RUINS_LOG_LEVEL: ログレベル (デフォルト: info)
-//   - "debug", "info", "warn", "error", "fatal"
+//   - RUINS_LOG_LEVEL: ログレベル (デフォルト: info) "debug", "info", "warn", "error", "fatal"
+//   - RUINS_LOG_CATEGORIES: カテゴリ別ログレベル設定 (例: "battle=debug,render=warn")
 //   - RUINS_DEBUG_PPROF: pprofサーバー起動 (デフォルト: true)
 //   - RUINS_PPROF_PORT: pprofサーバーポート (デフォルト: 6060)
 //

--- a/lib/config/doc.go
+++ b/lib/config/doc.go
@@ -1,0 +1,63 @@
+// Package config はアプリケーションの設定管理を提供する
+//
+// このパッケージは github.com/caarlos0/env/v11 を使用して環境変数からの
+// 設定読み込みを行う。設定はシングルトンパターンで管理され、
+// アプリケーション全体で一貫した設定値へのアクセスを提供する。
+//
+// # 使用可能な環境変数
+//
+// ## プロファイル設定
+//   - RUINS_PROFILE: 環境プロファイル (デフォルト: production)
+//     - "production": 本番環境 (デバッグ機能無効、軽量設定)
+//     - "development": 開発環境 (デバッグ機能有効、開発効率重視)
+//
+// ## ウィンドウ設定
+//   - RUINS_WINDOW_WIDTH: ウィンドウ幅 (デフォルト: 960)
+//   - RUINS_WINDOW_HEIGHT: ウィンドウ高さ (デフォルト: 720)  
+//   - RUINS_FULLSCREEN: フルスクリーンモード (デフォルト: false)
+//
+// ## デバッグ設定
+//   - RUINS_DEBUG: デバッグモード (デフォルト: false)
+//   - RUINS_DEBUG_PPROF: pprofサーバー起動 (デフォルト: true)
+//   - RUINS_PPROF_PORT: pprofサーバーポート (デフォルト: 6060)
+//
+// ## ゲーム設定
+//   - RUINS_STARTING_STATE: 開始ステート (デフォルト: main_menu)
+//     - "main_menu": メインメニュー
+//     - "debug_menu": デバッグメニュー
+//     - "dungeon": ダンジョン
+//   - RUINS_SKIP_INTRO: イントロスキップ (デフォルト: false)
+//
+// ## パフォーマンス設定
+//   - RUINS_TARGET_FPS: 目標フレームレート (デフォルト: 60)
+//   - RUINS_PROFILE_MEMORY: メモリプロファイル (デフォルト: true)
+//   - RUINS_PROFILE_CPU: CPUプロファイル (デフォルト: false)
+//   - RUINS_PROFILE_MUTEX: Mutexプロファイル (デフォルト: false)
+//   - RUINS_PROFILE_TRACE: トレースプロファイル (デフォルト: false)
+//   - RUINS_PROFILE_PATH: プロファイル出力パス (デフォルト: ".")
+//
+// # 使用例
+//
+//	// 設定の取得
+//	cfg := config.Get()
+//	
+//	// プロファイルに基づく設定確認
+//	if cfg.Profile == config.ProfileDevelopment {
+//		log.Println("Development mode")
+//	}
+//	
+//	// ウィンドウサイズの取得
+//	width := cfg.WindowWidth
+//	height := cfg.WindowHeight
+//	
+//	// デバッグモードの確認
+//	if cfg.Debug {
+//		log.Println("Debug mode enabled")
+//	}
+//
+// # 設定値の妥当性検証
+//
+// 設定値は自動的に妥当性検証され、無効な値は安全なデフォルト値に
+// 修正される。例えば、ウィンドウサイズが320x240未満の場合は
+// 最小サイズに修正される。
+package config

--- a/lib/config/manager.go
+++ b/lib/config/manager.go
@@ -1,0 +1,59 @@
+package config
+
+import (
+	"fmt"
+	"log"
+	"sync"
+)
+
+var (
+	instance *Config
+	once     sync.Once
+)
+
+// Get はアプリケーション設定のシングルトンインスタンスを返す
+func Get() *Config {
+	once.Do(func() {
+		var err error
+		instance, err = Load()
+		if err != nil {
+			log.Fatalf("設定の読み込みに失敗しました: %v", err)
+		}
+
+		if err := instance.Validate(); err != nil {
+			log.Fatalf("設定の検証に失敗しました: %v", err)
+		}
+	})
+	return instance
+}
+
+// Reset は設定インスタンスをリセットする（主にテスト用）
+func Reset() {
+	once = sync.Once{}
+	instance = nil
+}
+
+// MustGet は設定を取得し、エラーがあればパニックする
+func MustGet() *Config {
+	return Get()
+}
+
+// String は設定の文字列表現を返す（デバッグ用）
+func (c *Config) String() string {
+	return fmt.Sprintf(`Config{
+	Profile: %s,
+	WindowWidth: %d, WindowHeight: %d, Fullscreen: %t,
+	Debug: %t, DebugPProf: %t, PProfPort: %d,
+	StartingState: %s,
+	TargetFPS: %d,
+	ProfileMemory: %t, ProfileCPU: %t, ProfileMutex: %t, ProfileTrace: %t,
+	ProfilePath: %s
+}`,
+		c.Profile,
+		c.WindowWidth, c.WindowHeight, c.Fullscreen,
+		c.Debug, c.DebugPProf, c.PProfPort,
+		c.StartingState,
+		c.TargetFPS,
+		c.ProfileMemory, c.ProfileCPU, c.ProfileMutex, c.ProfileTrace,
+		c.ProfilePath)
+}

--- a/lib/config/manager.go
+++ b/lib/config/manager.go
@@ -43,7 +43,7 @@ func (c *Config) String() string {
 	return fmt.Sprintf(`Config{
 	Profile: %s,
 	WindowWidth: %d, WindowHeight: %d, Fullscreen: %t,
-	Debug: %t, DebugPProf: %t, PProfPort: %d,
+	Debug: %t, LogLevel: %s, DebugPProf: %t, PProfPort: %d,
 	StartingState: %s,
 	TargetFPS: %d,
 	ProfileMemory: %t, ProfileCPU: %t, ProfileMutex: %t, ProfileTrace: %t,
@@ -51,7 +51,7 @@ func (c *Config) String() string {
 }`,
 		c.Profile,
 		c.WindowWidth, c.WindowHeight, c.Fullscreen,
-		c.Debug, c.DebugPProf, c.PProfPort,
+		c.Debug, c.LogLevel, c.DebugPProf, c.PProfPort,
 		c.StartingState,
 		c.TargetFPS,
 		c.ProfileMemory, c.ProfileCPU, c.ProfileMutex, c.ProfileTrace,

--- a/lib/config/manager.go
+++ b/lib/config/manager.go
@@ -43,7 +43,7 @@ func (c *Config) String() string {
 	return fmt.Sprintf(`Config{
 	Profile: %s,
 	WindowWidth: %d, WindowHeight: %d, Fullscreen: %t,
-	Debug: %t, LogLevel: %s, DebugPProf: %t, PProfPort: %d,
+	Debug: %t, LogLevel: %s, LogCategories: %s, DebugPProf: %t, PProfPort: %d,
 	StartingState: %s,
 	TargetFPS: %d,
 	ProfileMemory: %t, ProfileCPU: %t, ProfileMutex: %t, ProfileTrace: %t,
@@ -51,7 +51,7 @@ func (c *Config) String() string {
 }`,
 		c.Profile,
 		c.WindowWidth, c.WindowHeight, c.Fullscreen,
-		c.Debug, c.LogLevel, c.DebugPProf, c.PProfPort,
+		c.Debug, c.LogLevel, c.LogCategories, c.DebugPProf, c.PProfPort,
 		c.StartingState,
 		c.TargetFPS,
 		c.ProfileMemory, c.ProfileCPU, c.ProfileMutex, c.ProfileTrace,

--- a/lib/game/game.go
+++ b/lib/game/game.go
@@ -8,6 +8,7 @@ import (
 	"github.com/hajimehoshi/ebiten/v2/ebitenutil"
 	"github.com/hajimehoshi/ebiten/v2/text/v2"
 	gc "github.com/kijimaD/ruins/lib/components"
+	"github.com/kijimaD/ruins/lib/config"
 	er "github.com/kijimaD/ruins/lib/engine/resources"
 	es "github.com/kijimaD/ruins/lib/engine/states"
 	gr "github.com/kijimaD/ruins/lib/resources"
@@ -38,22 +39,25 @@ func (game *MainGame) Update() error {
 func (game *MainGame) Draw(screen *ebiten.Image) {
 	game.StateMachine.Draw(game.World, screen)
 
-	var mem runtime.MemStats
-	runtime.ReadMemStats(&mem)
-	msg := fmt.Sprintf(`FPS: %f
+	// config設定に基づいてデバッグ情報を表示
+	cfg := config.Get()
+	if cfg.Debug {
+		var mem runtime.MemStats
+		runtime.ReadMemStats(&mem)
+		msg := fmt.Sprintf(`FPS: %f
 Alloc: %.2fMB
 TotalAlloc: %.2fMB
 Mallocs: %.2fMB
 Frees: %.2fMB
 `,
-
-		ebiten.ActualFPS(),
-		float64(mem.Alloc/1024/1024),
-		float64(mem.TotalAlloc/1024/1024), // 起動後から割り当てられたヒープオブジェクトの数。freeされてもリセットされない
-		float64(mem.Mallocs/1024/1024),    // 割り当てられているヒープオブジェクトの数。freeされたら減る
-		float64(mem.Frees/1024/1024),      // 解放されたヒープオブジェクトの数
-	)
-	ebitenutil.DebugPrint(screen, msg)
+			ebiten.ActualFPS(),
+			float64(mem.Alloc/1024/1024),
+			float64(mem.TotalAlloc/1024/1024), // 起動後から割り当てられたヒープオブジェクトの数。freeされてもリセットされない
+			float64(mem.Mallocs/1024/1024),    // 割り当てられているヒープオブジェクトの数。freeされたら減る
+			float64(mem.Frees/1024/1024),      // 解放されたヒープオブジェクトの数
+		)
+		ebitenutil.DebugPrint(screen, msg)
+	}
 }
 
 // InitWorld はゲームワールドを初期化する

--- a/lib/logger/config.go
+++ b/lib/logger/config.go
@@ -4,6 +4,11 @@ import (
 	"strings"
 )
 
+const (
+	// TimeFormat はタイムスタンプ形式
+	TimeFormat = "2006-01-02T15:04:05.000Z"
+)
+
 // Config はログ設定
 type Config struct {
 	// デフォルトログレベル
@@ -11,15 +16,11 @@ type Config struct {
 
 	// カテゴリ別ログレベル
 	CategoryLevels map[Category]Level
-
-	// タイムスタンプ形式
-	TimeFormat string
 }
 
 // グローバル設定（初期化時は空の設定）
 var globalConfig = Config{
 	CategoryLevels: make(map[Category]Level),
-	TimeFormat:     "2006-01-02T15:04:05.000Z",
 }
 
 // parseCategoryLevels はカテゴリ別レベル設定を解析する
@@ -42,7 +43,6 @@ func LoadFromConfig(logLevel, logCategories string) {
 	config := Config{
 		DefaultLevel:   parseLevel(logLevel),
 		CategoryLevels: make(map[Category]Level),
-		TimeFormat:     "2006-01-02T15:04:05.000Z",
 	}
 
 	// configパッケージからのカテゴリ別ログレベル設定
@@ -62,6 +62,5 @@ func SetConfig(config Config) {
 func ResetConfig() {
 	globalConfig = Config{
 		CategoryLevels: make(map[Category]Level),
-		TimeFormat:     "2006-01-02T15:04:05.000Z",
 	}
 }

--- a/lib/logger/config.go
+++ b/lib/logger/config.go
@@ -17,32 +17,12 @@ type Config struct {
 	TimeFormat string
 }
 
-// デフォルト設定
-var defaultConfig = Config{
-	DefaultLevel:   LevelInfo,
+// グローバル設定（初期化時は空の設定）
+var globalConfig = Config{
 	CategoryLevels: make(map[Category]Level),
 	TimeFormat:     "2006-01-02T15:04:05.000Z",
 }
 
-// グローバル設定（初期化時に環境変数から読み込み）
-var globalConfig = loadConfig()
-
-// loadConfig は環境変数から設定を読み込む
-func loadConfig() Config {
-	config := defaultConfig
-
-	// LOG_LEVEL環境変数
-	if level := os.Getenv("LOG_LEVEL"); level != "" {
-		config.DefaultLevel = parseLevel(level)
-	}
-
-	// LOG_CATEGORIES環境変数 (例: "battle=debug,render=warn")
-	if categories := os.Getenv("LOG_CATEGORIES"); categories != "" {
-		config.CategoryLevels = parseCategoryLevels(categories)
-	}
-
-	return config
-}
 
 // parseCategoryLevels はカテゴリ別レベル設定を解析する
 func parseCategoryLevels(s string) map[Category]Level {
@@ -64,7 +44,33 @@ func SetConfig(config Config) {
 	globalConfig = config
 }
 
-// ResetConfig は設定をデフォルトに戻す（主にテスト用）
+// ResetConfig は設定をリセットする（主にテスト用）
 func ResetConfig() {
-	globalConfig = loadConfig()
+	globalConfig = Config{
+		CategoryLevels: make(map[Category]Level),
+		TimeFormat:     "2006-01-02T15:04:05.000Z",
+	}
+}
+
+// SetLogLevelFromConfig はconfigパッケージの設定からログレベルを設定する
+func SetLogLevelFromConfig(logLevel string) {
+	config := globalConfig
+	config.DefaultLevel = parseLevel(logLevel)
+	globalConfig = config
+}
+
+// LoadFromConfig はconfigパッケージの設定を読み込む
+func LoadFromConfig(logLevel string) {
+	config := Config{
+		DefaultLevel:   parseLevel(logLevel),
+		CategoryLevels: make(map[Category]Level),
+		TimeFormat:     "2006-01-02T15:04:05.000Z",
+	}
+	
+	// LOG_CATEGORIES環境変数 (例: "battle=debug,render=warn") 
+	if categories := os.Getenv("LOG_CATEGORIES"); categories != "" {
+		config.CategoryLevels = parseCategoryLevels(categories)
+	}
+
+	globalConfig = config
 }

--- a/lib/logger/config.go
+++ b/lib/logger/config.go
@@ -1,7 +1,6 @@
 package logger
 
 import (
-	"os"
 	"strings"
 )
 
@@ -23,7 +22,6 @@ var globalConfig = Config{
 	TimeFormat:     "2006-01-02T15:04:05.000Z",
 }
 
-
 // parseCategoryLevels はカテゴリ別レベル設定を解析する
 func parseCategoryLevels(s string) map[Category]Level {
 	result := make(map[Category]Level)
@@ -39,38 +37,31 @@ func parseCategoryLevels(s string) map[Category]Level {
 	return result
 }
 
-// SetConfig はグローバル設定を更新する（主にテスト用）
-func SetConfig(config Config) {
-	globalConfig = config
-}
-
-// ResetConfig は設定をリセットする（主にテスト用）
-func ResetConfig() {
-	globalConfig = Config{
-		CategoryLevels: make(map[Category]Level),
-		TimeFormat:     "2006-01-02T15:04:05.000Z",
-	}
-}
-
-// SetLogLevelFromConfig はconfigパッケージの設定からログレベルを設定する
-func SetLogLevelFromConfig(logLevel string) {
-	config := globalConfig
-	config.DefaultLevel = parseLevel(logLevel)
-	globalConfig = config
-}
-
 // LoadFromConfig はconfigパッケージの設定を読み込む
-func LoadFromConfig(logLevel string) {
+func LoadFromConfig(logLevel, logCategories string) {
 	config := Config{
 		DefaultLevel:   parseLevel(logLevel),
 		CategoryLevels: make(map[Category]Level),
 		TimeFormat:     "2006-01-02T15:04:05.000Z",
 	}
-	
-	// LOG_CATEGORIES環境変数 (例: "battle=debug,render=warn") 
-	if categories := os.Getenv("LOG_CATEGORIES"); categories != "" {
-		config.CategoryLevels = parseCategoryLevels(categories)
+
+	// configパッケージからのカテゴリ別ログレベル設定
+	if logCategories != "" {
+		config.CategoryLevels = parseCategoryLevels(logCategories)
 	}
 
 	globalConfig = config
+}
+
+// SetConfig はグローバル設定を更新する（テスト用）
+func SetConfig(config Config) {
+	globalConfig = config
+}
+
+// ResetConfig は設定をリセットする（テスト用）
+func ResetConfig() {
+	globalConfig = Config{
+		CategoryLevels: make(map[Category]Level),
+		TimeFormat:     "2006-01-02T15:04:05.000Z",
+	}
 }

--- a/lib/logger/doc.go
+++ b/lib/logger/doc.go
@@ -1,7 +1,7 @@
 // Package logger はゲーム内の構造化ログを提供する
 //
 // 機能別にカテゴリを分けて、デバッグしやすいログ出力を実現する。
-// 環境変数でログレベルやカテゴリ別の出力制御が可能。
+// configパッケージからログレベル設定を受け取り、カテゴリ別の出力制御が可能。
 //
 // 使用例:
 //
@@ -9,7 +9,7 @@
 //	log.Info("戦闘開始", "enemy", "スライム", "hp", 100)
 //	log.Debug("ダメージ計算", "base", 10, "bonus", 5)
 //
-// 環境変数:
-//   - LOG_LEVEL: デフォルトログレベル (debug, info, warn, error, fatal)
+// 設定:
+//   - ログレベル: configパッケージのRUINS_LOG_LEVELから取得
 //   - LOG_CATEGORIES: カテゴリ別ログレベル (例: "battle=debug,render=warn")
 package logger

--- a/lib/logger/doc.go
+++ b/lib/logger/doc.go
@@ -11,5 +11,5 @@
 //
 // 設定:
 //   - ログレベル: configパッケージのRUINS_LOG_LEVELから取得
-//   - LOG_CATEGORIES: カテゴリ別ログレベル (例: "battle=debug,render=warn")
+//   - カテゴリ別ログレベル: configパッケージのRUINS_LOG_CATEGORIESから取得 (例: "battle=debug,render=warn")
 package logger

--- a/lib/logger/logger.go
+++ b/lib/logger/logger.go
@@ -100,7 +100,7 @@ func (l *Logger) log(level Level, msg string, keysAndValues ...interface{}) {
 
 	// ログエントリを構築
 	entry := make(map[string]interface{})
-	entry["timestamp"] = time.Now().Format(globalConfig.TimeFormat)
+	entry["timestamp"] = time.Now().Format(TimeFormat)
 	entry["level"] = level.String()
 	entry["category"] = string(l.category)
 	entry["message"] = msg

--- a/lib/logger/logger_test.go
+++ b/lib/logger/logger_test.go
@@ -72,7 +72,6 @@ func TestLogLevelFiltering(t *testing.T) {
 	SetConfig(Config{
 		DefaultLevel:   LevelInfo,
 		CategoryLevels: make(map[Category]Level),
-		TimeFormat:     "2006-01-02T15:04:05.000Z",
 	})
 	defer ResetConfig()
 
@@ -103,7 +102,6 @@ func TestContextLevelFiltering(t *testing.T) {
 		CategoryLevels: map[Category]Level{
 			CategoryBattle: LevelDebug,
 		},
-		TimeFormat: "2006-01-02T15:04:05.000Z",
 	})
 	defer ResetConfig()
 
@@ -131,7 +129,6 @@ func TestJSONOutput(t *testing.T) {
 	SetConfig(Config{
 		DefaultLevel:   LevelDebug,
 		CategoryLevels: make(map[Category]Level),
-		TimeFormat:     "2006-01-02T15:04:05.000Z",
 	})
 	defer ResetConfig()
 
@@ -271,7 +268,6 @@ func TestLoggerOutput(t *testing.T) {
 	SetConfig(Config{
 		DefaultLevel:   LevelDebug,
 		CategoryLevels: make(map[Category]Level),
-		TimeFormat:     "2006-01-02T15:04:05.000Z",
 	})
 	t.Cleanup(ResetConfig)
 


### PR DESCRIPTION
- 環境変数で設定できる
- プリセットで開発用/本番用を簡単に切り替えられる
- 個別に環境変数で設定を上書きできる