### PR TITLE
Potential fix for code scanning alert no. 18: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -9,6 +9,8 @@ env:
 jobs:
   # 共通処理
   setup:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - name: set up
@@ -26,6 +28,8 @@ jobs:
 
   build:
     needs: setup
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
@@ -34,6 +38,8 @@ jobs:
 
   crosscomple:
     needs: setup
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
@@ -44,6 +50,8 @@ jobs:
 
   test:
     needs: setup
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5


### PR DESCRIPTION
Potential fix for [https://github.com/kijimaD/ruins/security/code-scanning/18](https://github.com/kijimaD/ruins/security/code-scanning/18)

To fix the problem, we should add an explicit `permissions` block to each job in the workflow, specifying the minimum required permissions. For jobs that only need to read the repository contents (such as `setup`, `build`, and `crosscomple`), set `permissions: contents: read`. For the `test` job, which performs a `git push`, set `permissions: contents: write`. The `image` job already has `permissions: contents: read`, so no change is needed there.

The changes should be made in `.github/workflows/check.yml`:
- Add `permissions: contents: read` to the `setup`, `build`, and `crosscomple` jobs.
- Add `permissions: contents: write` to the `test` job.

No new methods, imports, or definitions are needed; only the YAML configuration needs to be updated.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
