### PR TITLE
Potential fix for code scanning alert no. 14: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/wasm_build.yml
+++ b/.github/workflows/wasm_build.yml
@@ -5,6 +5,8 @@ on:
 
 jobs:
   build:
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     steps:
       - name: Check out


### PR DESCRIPTION
Potential fix for [https://github.com/kijimaD/ruins/security/code-scanning/14](https://github.com/kijimaD/ruins/security/code-scanning/14)

To fix the problem, add a `permissions` block to the `build` job in `.github/workflows/wasm_build.yml`. The minimal required permission for most steps is `contents: read`, but the deploy step (`JamesIves/github-pages-deploy-action`) requires `contents: write` to push to the `gh-pages` branch. Therefore, set `contents: write` for the job. If you want to be even more restrictive, you could split the workflow into separate jobs (one for build, one for deploy) and only grant `contents: write` to the deploy job, but with the current structure, the best fix is to add `permissions: contents: write` to the `build` job.

Edit the `.github/workflows/wasm_build.yml` file, adding the following block under the `build:` job definition (after line 7):

```yaml
permissions:
  contents: write
```

No additional imports or definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
