### PR TITLE
Go setupより先にdockerを実行した場合、キャッシュの権限がrootで作られて後続のGo setupで失敗するのを直した

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -43,10 +43,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0  # タグ情報を取得するために全履歴を取得
       - name: build
-        run: |
-          git fetch --prune --unshallow
-          make build
+        run: make build
 
   test:
     needs: setup

--- a/.github/workflows/wasm_build.yml
+++ b/.github/workflows/wasm_build.yml
@@ -9,14 +9,12 @@ jobs:
       contents: write
     runs-on: ubuntu-latest
     steps:
-      - name: Check out
-        uses: actions/checkout@v5
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0  # タグ情報を取得するために全履歴を取得
 
       - name: Build
-        run: |
-          ./scripts/build.sh
+        run: ./scripts/build.sh
 
       - name: Set up Go
         uses: actions/setup-go@v6

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -41,10 +41,12 @@ cmd() {
 
     docker run \
            --rm \
+           -u "$(id -u):$(id -g)" \
            -w /work \
            -v $PWD:/work \
            -v $HOME/go/pkg/mod:/go/pkg/mod \
-           -v $HOME/.cache/go-build:/root/.cache/go-build \
+           -v $HOME/.cache/go-build:/tmp/go-build \
+           --env GOCACHE=/tmp/go-build \
            --env GOOS=$goos \
            --env GOARCH=$goarch \
            --env CGO_ENABLED=$cgo \
@@ -53,6 +55,10 @@ cmd() {
 }
 
 start() {
+    # Docker内でコンパイルするのでホストマシンにGo処理系は必要ではないのだが、キャッシュディレクトリをマウントするので先に存在する必要がある
+    mkdir -p $HOME/go/pkg/mod
+    mkdir -p $HOME/.cache/go-build
+
     docker build . --target $BUILD_STAGE_TARGET -t $BUILDER_IMAGE_NAME
 
     cmd "bin/${APP_NAME}_linux_amd64" linux amd64 1


### PR DESCRIPTION
follow #244 PR権限の問題かと思って雑にマージしたが、実際はキャッシュディレクトリの権限の問題だった。
Goより先にdockerを実行すると、キャッシュディレクトリがないうちにマウントして所有者がrootで作成され、後続のGoがキャッシュを読み込めなくなって失敗していた