### PR TITLE
handle store review

### DIFF
--- a/docs/steam/store.md
+++ b/docs/steam/store.md
@@ -172,11 +172,11 @@ The following features are implemented and the full gameplay loop is playable:
 
 #### 日本語
 
-正式リリース時にコンテンツ量に応じて価格を見直す可能性がありますが、アーリーアクセス中に購入された方は追加費用なく正式版をプレイできます。
+はい、変わる予定です。アーリーアクセス期間中もコンテンツや機能の追加に合わせて段階的に価格を引き上げていく予定で、正式リリース時にはさらに引き上げる可能性があります。アーリーアクセス中に購入された方は、追加費用なく正式版をプレイできます。
 
 #### 英語
 
-The price may be adjusted at full release depending on the amount of content added. Players who purchase during Early Access will receive the full version at no additional cost.
+Yes. We plan to gradually raise the price during Early Access as we ship new content and features, and it may increase further at full release. Players who purchase during Early Access will receive the full version at no additional cost.
 
 ### 開発にコミュニティをどう参加させる予定ですか？ / How are you planning on involving the Community in your development process?
 

--- a/docs/steam/store.md
+++ b/docs/steam/store.md
@@ -172,11 +172,11 @@ The following features are implemented and the full gameplay loop is playable:
 
 #### 日本語
 
-はい、変わる予定です。アーリーアクセス期間中もコンテンツや機能の追加に合わせて段階的に価格を引き上げていく予定で、正式リリース時にはさらに引き上げる可能性があります。アーリーアクセス中に購入された方は、追加費用なく正式版をプレイできます。
+はい、変わる予定です。コンテンツや機能の追加に合わせて段階的に価格を引き上げていく予定です。
 
 #### 英語
 
-Yes. We plan to gradually raise the price during Early Access as we ship new content and features, and it may increase further at full release. Players who purchase during Early Access will receive the full version at no additional cost.
+Yes. We plan to gradually raise the price as we ship new content and features.
 
 ### 開発にコミュニティをどう参加させる予定ですか？ / How are you planning on involving the Community in your development process?
 


### PR DESCRIPTION
>Failure: Your store page has failed review because your Early Access answer doesn't explain how the pricing will change during and after Early Access. "The price may be adjusted at full release depending on the amount of content added. Players who purchase during Early Access will receive the full version at no additional cost." Even if you haven't decided yet, we suggest making some indication of which way you're leaning (e.g. "We plan to gradually raise the price as we ship new content and features", or "We don't plan to change the price"). For more info about Early Access, please see our documentation: https://partner.steamgames.com/doc/store/earlyaccess#qanda