### PR TITLE
ActionParamsを廃止し各Behaviorにパラメータを持たせる

### DIFF
--- a/docs/design/20260705_46.md
+++ b/docs/design/20260705_46.md
@@ -1,0 +1,254 @@
+# ActionParams を廃止し Behavior にパラメータを持たせる
+
+## 背景
+
+現在 `ActionParams` は全アクションが共用する構造体で、6フィールドを持つ。しかしどのアクションがどのフィールドを使うかは実装を読まないとわからない。
+
+```go
+type ActionParams struct {
+    Actor       ecs.Entity
+    Target      *ecs.Entity
+    Recipient   *ecs.Entity
+    Destination *gc.GridElement
+    Duration    int
+    Reason      string
+}
+```
+
+たとえば `MoveActivity` は `Actor` と `Destination` だけ使い、`TransferActivity` は `Actor`, `Target`, `Recipient` を使う。不要なフィールドが常に存在し、ポインタの nil チェックを各 Behavior が自力で行っている。
+
+## 要件
+
+- 各アクションが必要とするパラメータだけを持つ
+- 不要なフィールドが存在しない
+- 呼び出し側で間違ったパラメータの組み合わせをコンパイル時に防ぐ
+- `ProcessTurn` による継続アクション処理を壊さない
+
+## 設計
+
+### Behavior 構造体にパラメータを持たせる
+
+各 Behavior の構造体（現在は `struct{}`）にアクション固有のパラメータを追加する。`ActionParams` と `Execute` の `params` 引数を廃止する。
+
+```go
+// 変更前
+Execute(&MoveActivity{}, ActionParams{Actor: entity, Destination: &dest}, world)
+
+// 変更後
+Execute(&MoveActivity{Actor: entity, Destination: dest}, world)
+```
+
+### Behavior インターフェースの変更
+
+```go
+// 変更前
+type Behavior interface {
+    Info() Info
+    Name() gc.BehaviorName
+    Validate(comp *gc.Activity, actor ecs.Entity, world w.World) error
+    Start(comp *gc.Activity, actor ecs.Entity, world w.World) error
+    DoTurn(comp *gc.Activity, actor ecs.Entity, world w.World) error
+    Finish(comp *gc.Activity, actor ecs.Entity, world w.World) error
+    Canceled(comp *gc.Activity, actor ecs.Entity, world w.World) error
+}
+
+// 変更後
+type Behavior interface {
+    Info() Info
+    Name() gc.BehaviorName
+    Validate(comp *gc.Activity, actor ecs.Entity, world w.World) error
+    Start(comp *gc.Activity, actor ecs.Entity, world w.World) error
+    DoTurn(comp *gc.Activity, actor ecs.Entity, world w.World) error
+    Finish(comp *gc.Activity, actor ecs.Entity, world w.World) error
+    Canceled(comp *gc.Activity, actor ecs.Entity, world w.World) error
+    BuildActivity(actor ecs.Entity, world w.World) (*gc.Activity, error)
+}
+```
+
+`Validate` / `Start` / `DoTurn` / `Finish` / `Canceled` のシグネチャは変更しない。これらは `ProcessTurn` 経路でシングルトン Behavior + `entity` 引数で呼ばれるため、`actor` 引数を残す必要がある。
+
+`BuildActivity` を追加して、`buildActivity` + `ActionParams` の責務を吸収する。各 Behavior が自分のフィールドから `gc.Activity` を構築する。
+
+### Execute の変更
+
+```go
+// 変更前
+func Execute(behavior Behavior, params ActionParams, world w.World) (*ActionResult, error)
+
+// 変更後
+func Execute(behavior Behavior, actor ecs.Entity, world w.World) (*ActionResult, error)
+```
+
+`actor` は `ActionParams` から取り出していたものを直接引数にする。`behavior.BuildActivity(actor, world)` で Activity を構築する。
+
+### 各 Behavior 構造体
+
+必要なフィールドだけを持つ。ポインタだった `*ecs.Entity` は必須パラメータなので値型 `ecs.Entity` にする。
+
+```go
+type MoveActivity struct {
+    Destination gc.GridElement
+}
+
+type AttackActivity struct {
+    Target ecs.Entity
+}
+
+type ShootActivity struct {
+    Target ecs.Entity
+}
+
+type WaitActivity struct {
+    Duration int
+    Reason   string
+}
+
+type RestActivity struct {
+    Duration int
+}
+
+type PickupActivity struct {
+    Target      *ecs.Entity     // 対象アイテム。nilなら足元を拾う
+    Destination *gc.GridElement  // 拾う座標。Targetがnilのとき使用
+}
+
+type DropActivity struct {
+    Target      ecs.Entity
+    Destination gc.GridElement
+}
+
+type UseItemActivity struct {
+    Target ecs.Entity
+}
+
+type TalkActivity struct {
+    Target ecs.Entity
+}
+
+type OpenDoorActivity struct {
+    Target ecs.Entity
+}
+
+type CloseDoorActivity struct {
+    Target ecs.Entity
+}
+
+type ReadActivity struct {
+    Target   ecs.Entity
+    Duration int
+}
+
+type ReloadActivity struct {
+    effortAccum int
+}
+
+type TransferActivity struct {
+    Target    ecs.Entity
+    Recipient ecs.Entity
+}
+```
+
+### Planner インターフェースの変更
+
+```go
+// 変更前
+type Planner interface {
+    Plan(world w.World, entity ecs.Entity) (activity.Behavior, activity.ActionParams)
+}
+
+// 変更後
+type Planner interface {
+    Plan(world w.World, entity ecs.Entity) activity.Behavior
+}
+```
+
+`runAPLoop` も Behavior だけを受け取り、`Execute(behavior, entity, world)` を呼ぶ。
+
+### behaviors マップ
+
+`ProcessTurn` で `GetBehavior` を使ってシングルトンから `DoTurn` 等を呼ぶ経路は変更なし。`BuildActivity` は `Execute` 経路でのみ呼ばれ、`ProcessTurn` 経路では呼ばれない。シングルトンの `BuildActivity` が呼ばれることはないが、インターフェースを満たすためにデフォルト実装を持たせる。
+
+### gc.Activity は変更しない
+
+`gc.Activity` の `Target`, `Recipient`, `Destination` フィールドは `DoTurn` / `Finish` 等で参照されるため、今回は維持する。`BuildActivity` でこれらのフィールドに値を設定する。将来的に `gc.Activity` からも削除する余地はあるが、今回のスコープ外とする。
+
+### consumePassCost の変更
+
+```go
+// 変更前
+consumePassCost(world, behavior, params.Actor, params.Destination)
+
+// 変更後
+consumePassCost(world, behavior, actor, comp.Destination)
+```
+
+`comp` は `BuildActivity` で構築済みの `gc.Activity` から取得する。
+
+## 変更箇所
+
+| ファイル | 変更内容 |
+|---------|---------|
+| `internal/activity/activity.go` | `Behavior` インターフェースに `BuildActivity` を追加 |
+| `internal/activity/activity_manager.go` | `ActionParams` を削除。`Execute` のシグネチャ変更。`buildActivity` を削除 |
+| `internal/activity/move.go` | `MoveActivity` に `Destination` フィールド追加。`BuildActivity` 実装 |
+| `internal/activity/attack.go` | `AttackActivity` に `Target` フィールド追加。`BuildActivity` 実装 |
+| `internal/activity/shoot.go` | `ShootActivity` に `Target` フィールド追加。`BuildActivity` 実装 |
+| `internal/activity/wait.go` | `WaitActivity` に `Duration`, `Reason` フィールド追加。`BuildActivity` 実装 |
+| `internal/activity/rest.go` | `RestActivity` に `Duration` フィールド追加。`BuildActivity` 実装 |
+| `internal/activity/pickup.go` | `PickupActivity` に `Target`, `Destination` フィールド追加。`BuildActivity` 実装 |
+| `internal/activity/drop.go` | `DropActivity` に `Target`, `Destination` フィールド追加。`BuildActivity` 実装 |
+| `internal/activity/use_item.go` | `UseItemActivity` に `Target` フィールド追加。`BuildActivity` 実装 |
+| `internal/activity/talk.go` | `TalkActivity` に `Target` フィールド追加。`BuildActivity` 実装 |
+| `internal/activity/door.go` | `OpenDoorActivity`, `CloseDoorActivity` に `Target` フィールド追加。`BuildActivity` 実装 |
+| `internal/activity/read.go` | `ReadActivity` に `Target`, `Duration` フィールド追加。`BuildActivity` 実装 |
+| `internal/activity/reload.go` | `BuildActivity` 実装 |
+| `internal/activity/transfer.go` | `TransferActivity` に `Target`, `Recipient` フィールド追加。`BuildActivity` 実装 |
+| `internal/activity/player_actions.go` | `ActionParams` を使わない形に書き換え |
+| `internal/activity/execute_interaction.go` | `ActionParams` を使わない形に書き換え |
+| `internal/activity/doc.go` | ドキュメント更新 |
+| `internal/aiinput/planner.go` | `Planner` インターフェースの返り値から `ActionParams` を削除。`moveAction`, `waitAction` を更新 |
+| `internal/aiinput/planner_solo.go` | `Plan` の返り値変更。各メソッドの返り値変更 |
+| `internal/aiinput/planner_squad.go` | `Plan` の返り値変更。各メソッドの返り値変更 |
+| `internal/states/pickup_state.go` | `ActionParams` を使わない形に書き換え |
+| `internal/states/place_state.go` | `ActionParams` を使わない形に書き換え |
+| `internal/states/inventory_menu.go` | `ActionParams` を使わない形に書き換え |
+
+## 採用しなかった方法
+
+- **案A: アクションごとに専用の Params 型を定義する**: `MoveParams`, `AttackParams` 等を別途定義する方法。型が倍増し、Behavior と Params が分離したまま管理が煩雑になる。Behavior に直接持たせた方がシンプル
+- **案C: コンストラクタ関数で ActionParams を生成する**: `MoveParams(actor, dest)` のような関数を用意する方法。構造体自体は共用のままなので根本的な解決にならない。直接構築を防げない
+- **Behavior インターフェースから actor 引数を削除する案**: `ProcessTurn` がシングルトン Behavior 経由で `DoTurn` を呼ぶため、actor を Behavior のフィールドから取得する形にすると、シングルトンの状態が汚染される。actor は引数で渡す必要がある
+
+## コメント
+
+- `gc.Activity` の `Target`, `Recipient`, `Destination` フィールドは今回残す。`BuildActivity` で設定し、`DoTurn` 等で参照する構造は変わらない。これらの削除は将来の別リファクタで行う
+- `PickupActivity` は Target（直接拾う）と Destination（座標から拾う）の2つの経路があるため、両方オプショナルで残す
+
+## 進捗
+
+- [x] `internal/activity/activity.go`: Behavior に BuildActivity を追加
+- [x] `internal/activity/activity_manager.go`: ActionParams 削除、Execute シグネチャ変更、buildActivity 削除
+- [x] `internal/activity/move.go`: MoveActivity にフィールド追加、BuildActivity 実装
+- [x] `internal/activity/attack.go`: AttackActivity にフィールド追加、BuildActivity 実装
+- [x] `internal/activity/shoot.go`: ShootActivity にフィールド追加、BuildActivity 実装
+- [x] `internal/activity/wait.go`: WaitActivity にフィールド追加、BuildActivity 実装
+- [x] `internal/activity/rest.go`: RestActivity にフィールド追加、BuildActivity 実装
+- [x] `internal/activity/pickup.go`: PickupActivity にフィールド追加、BuildActivity 実装
+- [x] `internal/activity/drop.go`: DropActivity にフィールド追加、BuildActivity 実装
+- [x] `internal/activity/use_item.go`: UseItemActivity にフィールド追加、BuildActivity 実装
+- [x] `internal/activity/talk.go`: TalkActivity にフィールド追加、BuildActivity 実装
+- [x] `internal/activity/door.go`: OpenDoor/CloseDoor にフィールド追加、BuildActivity 実装
+- [x] `internal/activity/read.go`: ReadActivity にフィールド追加、BuildActivity 実装
+- [x] `internal/activity/reload.go`: BuildActivity 実装
+- [x] `internal/activity/transfer.go`: TransferActivity にフィールド追加、BuildActivity 実装
+- [x] `internal/activity/player_actions.go`: ActionParams 除去
+- [x] `internal/activity/execute_interaction.go`: ActionParams 除去
+- [x] `internal/activity/doc.go`: ドキュメント更新
+- [x] `internal/aiinput/planner.go`: Planner 返り値変更、ヘルパー関数更新
+- [x] `internal/aiinput/planner_solo.go`: 返り値変更
+- [x] `internal/aiinput/planner_squad.go`: 返り値変更
+- [x] `internal/states/pickup_state.go`: ActionParams 除去
+- [x] `internal/states/place_state.go`: ActionParams 除去
+- [x] `internal/states/inventory_menu.go`: ActionParams 除去
+- [x] テスト更新
+- [x] `make check` 通過

--- a/internal/activity/activity.go
+++ b/internal/activity/activity.go
@@ -14,7 +14,8 @@ import (
 // log はactivityパッケージ用のロガー
 var log = logger.New(logger.CategoryAction)
 
-// behaviors は登録されたBehavior実装のマップ
+// behaviors はProcessTurn経由の継続アクション処理で使うシングルトンBehaviorのマップ。
+// Execute経路で使うBuildActivityはこのマップのインスタンスでは呼ばれない
 var behaviors = map[gc.BehaviorName]Behavior{
 	gc.BehaviorMove:      &MoveActivity{},
 	gc.BehaviorAttack:    &AttackActivity{},

--- a/internal/activity/activity.go
+++ b/internal/activity/activity.go
@@ -45,6 +45,7 @@ func GetBehavior(name gc.BehaviorName) (Behavior, error) {
 type Behavior interface {
 	Info() Info
 	Name() gc.BehaviorName
+	BuildActivity(actor ecs.Entity, world w.World) (*gc.Activity, error)
 	Validate(comp *gc.Activity, actor ecs.Entity, world w.World) error
 	Start(comp *gc.Activity, actor ecs.Entity, world w.World) error
 	DoTurn(comp *gc.Activity, actor ecs.Entity, world w.World) error

--- a/internal/activity/activity_manager.go
+++ b/internal/activity/activity_manager.go
@@ -10,16 +10,6 @@ import (
 	ecs "github.com/x-hgg-x/goecs/v2"
 )
 
-// ActionParams はアクション実行時のパラメータを表す
-type ActionParams struct {
-	Actor       ecs.Entity      // アクションを実行するエンティティ
-	Target      *ecs.Entity     // 対象エンティティ（攻撃等で使用）
-	Recipient   *ecs.Entity     // 受取人エンティティ（アイテム転送等で使用）
-	Destination *gc.GridElement // 移動先のグリッド座標（移動等で使用）
-	Duration    int             // 継続時間（休息、待機等で使用）
-	Reason      string          // 理由（待機等で使用）
-}
-
 // ActionResult はアクション実行結果を表す
 type ActionResult struct {
 	Success      bool             // 実行成功/失敗
@@ -30,14 +20,14 @@ type ActionResult struct {
 
 // Execute は指定されたアクティビティを実行する
 // 即座実行アクション（移動、攻撃等）も継続アクション（休息等）も統一的に処理する
-func Execute(behavior Behavior, params ActionParams, world w.World) (*ActionResult, error) {
+func Execute(behavior Behavior, actor ecs.Entity, world w.World) (*ActionResult, error) {
 	behaviorName := behavior.Name()
 	log.Debug("アクション実行開始",
 		"type", behaviorName,
-		"actor", params.Actor)
+		"actor", actor)
 
 	// アクティビティを作成
-	comp, err := buildActivity(behavior, params, world)
+	comp, err := behavior.BuildActivity(actor, world)
 	if err != nil {
 		result := &ActionResult{
 			Success:      false,
@@ -45,19 +35,19 @@ func Execute(behavior Behavior, params ActionParams, world w.World) (*ActionResu
 			ActivityName: behaviorName,
 			Message:      err.Error(),
 		}
-		setLastResult(params.Actor, result, world)
+		setLastResult(actor, result, world)
 		return result, err
 	}
 
 	// アクティビティを開始
-	if err := StartActivity(comp, params.Actor, world); err != nil {
+	if err := StartActivity(comp, actor, world); err != nil {
 		result := &ActionResult{
 			Success:      false,
 			State:        gc.ActivityStateCanceled,
 			ActivityName: behaviorName,
 			Message:      err.Error(),
 		}
-		setLastResult(params.Actor, result, world)
+		setLastResult(actor, result, world)
 		return result, err
 	}
 
@@ -67,10 +57,10 @@ func Execute(behavior Behavior, params ActionParams, world w.World) (*ActionResu
 		ProcessTurn(world)
 
 		// ターン管理システムに移動コストを通知
-		consumePassCost(world, behavior, params.Actor, params.Destination)
+		consumePassCost(world, behavior, actor, comp.Destination)
 
 		// 結果を確認
-		currentActivity := query.GetActivity(world, params.Actor)
+		currentActivity := query.GetActivity(world, actor)
 		if currentActivity == nil || IsCompleted(currentActivity) {
 			result := &ActionResult{
 				Success:      true,
@@ -78,7 +68,7 @@ func Execute(behavior Behavior, params ActionParams, world w.World) (*ActionResu
 				ActivityName: behaviorName,
 				Message:      "アクション完了",
 			}
-			setLastResult(params.Actor, result, world)
+			setLastResult(actor, result, world)
 			return result, nil
 		} else if IsCanceled(currentActivity) {
 			result := &ActionResult{
@@ -87,7 +77,7 @@ func Execute(behavior Behavior, params ActionParams, world w.World) (*ActionResu
 				ActivityName: behaviorName,
 				Message:      currentActivity.CancelReason,
 			}
-			setLastResult(params.Actor, result, world)
+			setLastResult(actor, result, world)
 			return result, nil
 		}
 	}
@@ -99,7 +89,7 @@ func Execute(behavior Behavior, params ActionParams, world w.World) (*ActionResu
 		ActivityName: behaviorName,
 		Message:      "アクション開始",
 	}
-	setLastResult(params.Actor, result, world)
+	setLastResult(actor, result, world)
 	return result, nil
 }
 
@@ -304,38 +294,6 @@ func ProcessTurn(world w.World) {
 	}
 
 	log.Debug("アクティビティターン処理完了", "removed", len(toRemove))
-}
-
-// buildActivity はアクティビティ実装とパラメータからアクティビティを作成する
-func buildActivity(behavior Behavior, params ActionParams, world w.World) (*gc.Activity, error) {
-	// 基本のdurationを計算
-	duration := params.Duration
-	if duration <= 0 {
-		characterAP, err := getEntityMaxAP(params.Actor, world)
-		if err != nil {
-			return nil, err
-		}
-		duration = CalculateRequiredTurns(behavior, characterAP)
-	}
-
-	// アクティビティを作成
-	comp, err := NewActivity(behavior, duration)
-	if err != nil {
-		return nil, err
-	}
-
-	// パラメータを設定
-	if params.Destination != nil {
-		comp.Destination = params.Destination
-	}
-	if params.Target != nil {
-		comp.Target = params.Target
-	}
-	if params.Recipient != nil {
-		comp.Recipient = params.Recipient
-	}
-
-	return comp, nil
 }
 
 // consumePassCost はアクションのAPコストを消費する

--- a/internal/activity/activity_manager_test.go
+++ b/internal/activity/activity_manager_test.go
@@ -333,8 +333,7 @@ func TestConsumePassCostWithPassCost(t *testing.T) {
 		tbBefore := world.Components.TurnBased.Get(player).(*gc.TurnBased)
 		apBefore := tbBefore.AP.Current
 
-		params := ActionParams{Actor: player, Destination: &gc.GridElement{X: 11, Y: 10}}
-		_, err = Execute(&MoveActivity{}, params, world)
+		_, err = Execute(&MoveActivity{Destination: gc.GridElement{X: 11, Y: 10}}, player, world)
 		require.NoError(t, err)
 
 		normalCost := apBefore - tbBefore.AP.Current
@@ -347,8 +346,7 @@ func TestConsumePassCostWithPassCost(t *testing.T) {
 		prop.AddComponent(world.Components.GridElement, &gc.GridElement{X: 12, Y: 10})
 		prop.AddComponent(world.Components.PassCost, &gc.PassCost{Value: 50})
 
-		params = ActionParams{Actor: player, Destination: &gc.GridElement{X: 12, Y: 10}}
-		_, err = Execute(&MoveActivity{}, params, world)
+		_, err = Execute(&MoveActivity{Destination: gc.GridElement{X: 12, Y: 10}}, player, world)
 		require.NoError(t, err)
 
 		modCost := apBefore - tbBefore.AP.Current
@@ -367,12 +365,7 @@ func TestLastActivity(t *testing.T) {
 		player, err := lifecycle.SpawnPlayer(world, 5, 5, "Ash")
 		require.NoError(t, err)
 
-		params := ActionParams{
-			Actor:    player,
-			Duration: 1,
-			Reason:   "テスト",
-		}
-		_, err = Execute(&WaitActivity{}, params, world)
+		_, err = Execute(&WaitActivity{Duration: 1, Reason: "テスト"}, player, world)
 		require.NoError(t, err)
 
 		result := GetLastResult(player, world)
@@ -393,8 +386,7 @@ func TestLastActivity(t *testing.T) {
 		require.NoError(t, err)
 
 		// 待機
-		params := ActionParams{Actor: player, Duration: 1, Reason: "待機"}
-		_, err = Execute(&WaitActivity{}, params, world)
+		_, err = Execute(&WaitActivity{Duration: 1, Reason: "待機"}, player, world)
 		require.NoError(t, err)
 
 		result := GetLastResult(player, world)
@@ -407,8 +399,7 @@ func TestLastActivity(t *testing.T) {
 		assert.Equal(t, expected, result)
 
 		// 移動
-		params = ActionParams{Actor: player, Destination: &gc.GridElement{X: 10, Y: 9}}
-		_, err = Execute(&MoveActivity{}, params, world)
+		_, err = Execute(&MoveActivity{Destination: gc.GridElement{X: 10, Y: 9}}, player, world)
 		require.NoError(t, err)
 
 		result = GetLastResult(player, world)
@@ -430,8 +421,7 @@ func TestLastActivity(t *testing.T) {
 
 		// 存在しないターゲットへの攻撃（失敗する）
 		nonExistentEntity := consts.InvalidEntity
-		params := ActionParams{Actor: player, Target: &nonExistentEntity}
-		_, _ = Execute(&AttackActivity{}, params, world)
+		_, _ = Execute(&AttackActivity{Target: nonExistentEntity}, player, world)
 
 		result := GetLastResult(player, world)
 		expected := &gc.LastActivity{

--- a/internal/activity/attack.go
+++ b/internal/activity/attack.go
@@ -24,7 +24,9 @@ const (
 )
 
 // AttackActivity はBehaviorの実装
-type AttackActivity struct{}
+type AttackActivity struct {
+	Target ecs.Entity
+}
 
 // Info はBehaviorの実装
 func (aa *AttackActivity) Info() Info {
@@ -41,6 +43,16 @@ func (aa *AttackActivity) Info() Info {
 // Name はBehaviorの実装
 func (aa *AttackActivity) Name() gc.BehaviorName {
 	return gc.BehaviorAttack
+}
+
+// BuildActivity はBehaviorの実装
+func (aa *AttackActivity) BuildActivity(_ ecs.Entity, _ w.World) (*gc.Activity, error) {
+	comp, err := NewActivity(aa, 1)
+	if err != nil {
+		return nil, err
+	}
+	comp.Target = &aa.Target
+	return comp, nil
 }
 
 // Validate はBehaviorの実装

--- a/internal/activity/attack.go
+++ b/internal/activity/attack.go
@@ -301,7 +301,11 @@ func applyAttackDamage(actor, target ecs.Entity, world w.World, attack gc.Attack
 
 // calculateHitRate は命中率を算出する。ダイスロールなしの純粋な計算で、UI表示と命中判定の両方で使用する
 func calculateHitRate(attacker, target ecs.Entity, world w.World, attack gc.Attacker, modifier int) int {
-	attackerAbils := world.Components.Abilities.Get(attacker).(*gc.Abilities)
+	attackerAbilsComp := world.Components.Abilities.Get(attacker)
+	if attackerAbilsComp == nil {
+		return formula.BaseHitRate
+	}
+	attackerAbils := attackerAbilsComp.(*gc.Abilities)
 
 	// Abilitiesを持たないターゲットには自動命中する
 	targetAgility := 0

--- a/internal/activity/attack.go
+++ b/internal/activity/attack.go
@@ -346,7 +346,11 @@ func getWeaponAccuracyFromAttack(attack gc.Attacker) int {
 
 // calculateDamage はダメージ計算を行う
 func calculateDamage(attacker, target ecs.Entity, world w.World, attack gc.Attacker, critical bool, damageModifier int) int {
-	attackerAbils := world.Components.Abilities.Get(attacker).(*gc.Abilities)
+	attackerAbilsComp := world.Components.Abilities.Get(attacker)
+	if attackerAbilsComp == nil {
+		return 0
+	}
+	attackerAbils := attackerAbilsComp.(*gc.Abilities)
 
 	baseAbil := attackerAbils.Strength.Total
 	if attack.GetAttackCategory().Range == gc.AttackRangeRanged {

--- a/internal/activity/doc.go
+++ b/internal/activity/doc.go
@@ -123,12 +123,10 @@
 //	// パッケージレベル関数を通じた統一的なアクション実行
 //
 //	// 即座実行アクション（移動）
-//	params := activity.ActionParams{Actor: player, Destination: &dest}
-//	result, err := activity.Execute(&activity.MoveActivity{}, params, world)
+//	result, err := activity.Execute(&activity.MoveActivity{Destination: dest}, player, world)
 //
 //	// 継続実行アクション（休息）
-//	params := activity.ActionParams{Actor: player, Duration: 10}
-//	result, err := activity.Execute(&activity.RestActivity{}, params, world)
+//	result, err := activity.Execute(&activity.RestActivity{Duration: 10}, player, world)
 //
 //	// アクティビティの管理
 //	activity.InterruptActivity(player, "戦闘開始", world)

--- a/internal/activity/doc.go
+++ b/internal/activity/doc.go
@@ -103,10 +103,10 @@
 // 全てのアクションは`Activity`構造体を通じて統一的に管理される：
 //
 //	type Activity struct {
-//		Type       ActivityType  // アクション種別
-//		State      State // 実行状態
-//		TurnsTotal int          // 必要ターン数
-//		TurnsLeft  int          // 残りターン数
+//		BehaviorName gc.BehaviorName // アクション種別
+//		State        gc.ActivityState // 実行状態
+//		TurnsTotal   int              // 必要ターン数
+//		TurnsLeft    int              // 残りターン数
 //		// ...
 //	}
 //

--- a/internal/activity/doc.go
+++ b/internal/activity/doc.go
@@ -39,7 +39,7 @@
 // - aiinput/processor.go から使用（AI行動処理）
 //
 // ```go
-// result, err := activity.Execute(activityImpl, params, world)
+// result, err := activity.Execute(behavior, actor, world)
 // ```
 //
 // ### 個別Activity実装

--- a/internal/activity/doc.go
+++ b/internal/activity/doc.go
@@ -152,9 +152,7 @@
 //
 // 新しいアクションを追加する場合：
 //
-// 1. ActivityTypeに新しい定数を追加
-// 2. activityInfosに情報を追加
-// 3. 具体的な実装ファイルを作成（例：new_action.go）
-// 4. Activity インターフェースを実装
-// 5. 必要に応じてActivity.DoTurnに処理を追加
+// 1. gc.BehaviorNameに新しい定数を追加
+// 2. Behaviorインターフェースを実装した構造体を作成
+// 3. behaviorsマップに登録
 package activity

--- a/internal/activity/door.go
+++ b/internal/activity/door.go
@@ -14,7 +14,9 @@ import (
 )
 
 // OpenDoorActivity はBehaviorの実装
-type OpenDoorActivity struct{}
+type OpenDoorActivity struct {
+	Target ecs.Entity
+}
 
 // Info はBehaviorの実装
 func (oda *OpenDoorActivity) Info() Info {
@@ -31,6 +33,16 @@ func (oda *OpenDoorActivity) Info() Info {
 // Name はBehaviorの実装
 func (oda *OpenDoorActivity) Name() gc.BehaviorName {
 	return gc.BehaviorOpenDoor
+}
+
+// BuildActivity はBehaviorの実装
+func (oda *OpenDoorActivity) BuildActivity(_ ecs.Entity, _ w.World) (*gc.Activity, error) {
+	comp, err := NewActivity(oda, 1)
+	if err != nil {
+		return nil, err
+	}
+	comp.Target = &oda.Target
+	return comp, nil
 }
 
 // Validate は扉開閉アクティビティの検証を行う
@@ -111,7 +123,9 @@ func (oda *OpenDoorActivity) Canceled(comp *gc.Activity, actor ecs.Entity, _ w.W
 }
 
 // CloseDoorActivity はBehaviorの実装
-type CloseDoorActivity struct{}
+type CloseDoorActivity struct {
+	Target ecs.Entity
+}
 
 // Info はBehaviorの実装
 func (cda *CloseDoorActivity) Info() Info {
@@ -128,6 +142,16 @@ func (cda *CloseDoorActivity) Info() Info {
 // Name はBehaviorの実装
 func (cda *CloseDoorActivity) Name() gc.BehaviorName {
 	return gc.BehaviorCloseDoor
+}
+
+// BuildActivity はBehaviorの実装
+func (cda *CloseDoorActivity) BuildActivity(_ ecs.Entity, _ w.World) (*gc.Activity, error) {
+	comp, err := NewActivity(cda, 1)
+	if err != nil {
+		return nil, err
+	}
+	comp.Target = &cda.Target
+	return comp, nil
 }
 
 // Validate は扉閉鎖アクティビティの検証を行う

--- a/internal/activity/door.go
+++ b/internal/activity/door.go
@@ -71,11 +71,12 @@ func (oda *OpenDoorActivity) Start(_ *gc.Activity, actor ecs.Entity, _ w.World) 
 func (oda *OpenDoorActivity) DoTurn(comp *gc.Activity, _ ecs.Entity, world w.World) error {
 	targetEntity := *comp.Target
 
-	doorComp := world.Components.Door.Get(targetEntity).(*gc.Door)
-	if doorComp == nil {
+	raw := world.Components.Door.Get(targetEntity)
+	if raw == nil {
 		Cancel(comp, "扉コンポーネントが取得できません")
 		return fmt.Errorf("扉コンポーネントが取得できません")
 	}
+	doorComp := raw.(*gc.Door)
 
 	if doorComp.Locked {
 		gamelog.New(query.GetGameLog(world)).
@@ -180,11 +181,12 @@ func (cda *CloseDoorActivity) Start(_ *gc.Activity, actor ecs.Entity, _ w.World)
 func (cda *CloseDoorActivity) DoTurn(comp *gc.Activity, _ ecs.Entity, world w.World) error {
 	targetEntity := *comp.Target
 
-	doorComp := world.Components.Door.Get(targetEntity).(*gc.Door)
-	if doorComp == nil {
+	raw := world.Components.Door.Get(targetEntity)
+	if raw == nil {
 		Cancel(comp, "扉コンポーネントが取得できません")
 		return fmt.Errorf("扉コンポーネントが取得できません")
 	}
+	doorComp := raw.(*gc.Door)
 
 	if doorComp.Locked {
 		Cancel(comp, "扉はロックされている")

--- a/internal/activity/door_test.go
+++ b/internal/activity/door_test.go
@@ -32,11 +32,7 @@ func TestOpenDoorActivity(t *testing.T) {
 		door.AddComponent(world.Components.BlockView, &gc.BlockView{})
 
 		// OpenDoorActivityを実行
-		params := ActionParams{
-			Actor:  player,
-			Target: &door,
-		}
-		result, err := Execute(&OpenDoorActivity{}, params, world)
+		result, err := Execute(&OpenDoorActivity{Target: door}, player, world)
 
 		require.NoError(t, err)
 		require.NotNil(t, result)
@@ -69,11 +65,7 @@ func TestOpenDoorActivity(t *testing.T) {
 		wall.AddComponent(world.Components.BlockPass, &gc.BlockPass{})
 
 		// OpenDoorActivityを実行
-		params := ActionParams{
-			Actor:  player,
-			Target: &wall,
-		}
-		result, err := Execute(&OpenDoorActivity{}, params, world)
+		result, err := Execute(&OpenDoorActivity{Target: wall}, player, world)
 
 		require.Error(t, err)
 		require.NotNil(t, result)
@@ -99,11 +91,7 @@ func TestOpenDoorActivity(t *testing.T) {
 		door.AddComponent(world.Components.BlockPass, &gc.BlockPass{})
 		door.AddComponent(world.Components.BlockView, &gc.BlockView{})
 
-		params := ActionParams{
-			Actor:  player,
-			Target: &door,
-		}
-		result, err := Execute(&OpenDoorActivity{}, params, world)
+		result, err := Execute(&OpenDoorActivity{Target: door}, player, world)
 
 		require.NoError(t, err, "ロック済み扉のキャンセルは致命的エラーではない")
 		require.NotNil(t, result)
@@ -134,16 +122,13 @@ func TestOpenDoorActivity(t *testing.T) {
 		player.AddComponent(world.Components.Player, &gc.Player{})
 		player.AddComponent(world.Components.TurnBased, &gc.TurnBased{})
 
-		// OpenDoorActivityを実行（Targetなし）
-		params := ActionParams{
-			Actor: player,
-		}
-		result, err := Execute(&OpenDoorActivity{}, params, world)
+		// OpenDoorActivityを実行（Targetなし → ゼロ値Entityは扉ではない）
+		result, err := Execute(&OpenDoorActivity{}, player, world)
 
 		require.Error(t, err)
 		require.NotNil(t, result)
 		assert.False(t, result.Success, "検証失敗で成功フラグがfalseであるべき")
-		assert.Contains(t, result.Message, "扉エンティティが指定されていません")
+		assert.Contains(t, result.Message, "対象エンティティは扉ではありません")
 
 		world.Manager.DeleteEntity(player)
 	})

--- a/internal/activity/drop.go
+++ b/internal/activity/drop.go
@@ -14,7 +14,10 @@ import (
 )
 
 // DropActivity はBehaviorの実装
-type DropActivity struct{}
+type DropActivity struct {
+	Target      ecs.Entity
+	Destination gc.GridElement
+}
 
 // Info はBehaviorの実装
 func (da *DropActivity) Info() Info {
@@ -31,6 +34,17 @@ func (da *DropActivity) Info() Info {
 // Name はBehaviorの実装
 func (da *DropActivity) Name() gc.BehaviorName {
 	return gc.BehaviorDrop
+}
+
+// BuildActivity はBehaviorの実装
+func (da *DropActivity) BuildActivity(_ ecs.Entity, _ w.World) (*gc.Activity, error) {
+	comp, err := NewActivity(da, 1)
+	if err != nil {
+		return nil, err
+	}
+	comp.Target = &da.Target
+	comp.Destination = &da.Destination
+	return comp, nil
 }
 
 // Validate はアイテムドロップアクティビティの検証を行う

--- a/internal/activity/errors.go
+++ b/internal/activity/errors.go
@@ -36,6 +36,7 @@ var (
 	ErrMoveTargetInvalid      = errors.New("移動先が無効です")
 	ErrMoveTargetCoordInvalid = errors.New("移動先の座標が無効です")
 	ErrMoveNoGridElement      = errors.New("移動するエンティティにGridElementが見つかりません")
+	ErrMoveOverweight         = errors.New("重すぎて動けません")
 	ErrGridElementNotFound    = errors.New("GridElementコンポーネントが見つかりません")
 
 	// アイテム関連エラー

--- a/internal/activity/execute_interaction.go
+++ b/internal/activity/execute_interaction.go
@@ -77,15 +77,11 @@ func executeDoor(actor ecs.Entity, doorEntity ecs.Entity, world w.World) (*Actio
 	}
 
 	door := world.Components.Door.Get(doorEntity).(*gc.Door)
-	params := ActionParams{
-		Actor:  actor,
-		Target: &doorEntity,
-	}
 
 	if door.IsOpen {
-		return Execute(&CloseDoorActivity{}, params, world)
+		return Execute(&CloseDoorActivity{Target: doorEntity}, actor, world)
 	}
-	return Execute(&OpenDoorActivity{}, params, world)
+	return Execute(&OpenDoorActivity{Target: doorEntity}, actor, world)
 }
 
 func executeDoorLock(world w.World) (*ActionResult, error) {
@@ -102,12 +98,7 @@ func executeTalk(actor ecs.Entity, npcEntity ecs.Entity, world w.World) (*Action
 		return nil, fmt.Errorf("TalkInteractionですがDialogコンポーネントがありません")
 	}
 
-	params := ActionParams{
-		Actor:  actor,
-		Target: &npcEntity,
-	}
-
-	result, err := Execute(&TalkActivity{}, params, world)
+	result, err := Execute(&TalkActivity{Target: npcEntity}, actor, world)
 	if err != nil {
 		return nil, fmt.Errorf("会話アクション失敗: %w", err)
 	}
@@ -116,11 +107,7 @@ func executeTalk(actor ecs.Entity, npcEntity ecs.Entity, world w.World) (*Action
 }
 
 func executeItem(actor ecs.Entity, target ecs.Entity, world w.World) (*ActionResult, error) {
-	params := ActionParams{
-		Actor:  actor,
-		Target: &target,
-	}
-	return Execute(&PickupActivity{}, params, world)
+	return Execute(&PickupActivity{Target: &target}, actor, world)
 }
 
 func executeItemAll(actor ecs.Entity, world w.World) (*ActionResult, error) {
@@ -130,11 +117,7 @@ func executeItemAll(actor ecs.Entity, world w.World) (*ActionResult, error) {
 	}
 	playerGrid := gridElement.(*gc.GridElement)
 	destination := gc.GridElement{X: playerGrid.X, Y: playerGrid.Y}
-	params := ActionParams{
-		Actor:       actor,
-		Destination: &destination,
-	}
-	return Execute(&PickupActivity{}, params, world)
+	return Execute(&PickupActivity{Destination: &destination}, actor, world)
 }
 
 func executeStorage(storageEntity ecs.Entity, world w.World) (*ActionResult, error) {
@@ -145,9 +128,5 @@ func executeStorage(storageEntity ecs.Entity, world w.World) (*ActionResult, err
 }
 
 func executeMelee(actor ecs.Entity, target ecs.Entity, world w.World) (*ActionResult, error) {
-	params := ActionParams{
-		Actor:  actor,
-		Target: &target,
-	}
-	return Execute(&AttackActivity{}, params, world)
+	return Execute(&AttackActivity{Target: target}, actor, world)
 }

--- a/internal/activity/move.go
+++ b/internal/activity/move.go
@@ -57,7 +57,9 @@ func CanSwapPosition(world w.World, mover, target ecs.Entity) bool {
 }
 
 // MoveActivity はBehaviorの実装
-type MoveActivity struct{}
+type MoveActivity struct {
+	Destination gc.GridElement
+}
 
 // Info はBehaviorの実装
 func (ma *MoveActivity) Info() Info {
@@ -74,6 +76,16 @@ func (ma *MoveActivity) Info() Info {
 // Name はBehaviorの実装
 func (ma *MoveActivity) Name() gc.BehaviorName {
 	return gc.BehaviorMove
+}
+
+// BuildActivity はBehaviorの実装
+func (ma *MoveActivity) BuildActivity(_ ecs.Entity, _ w.World) (*gc.Activity, error) {
+	comp, err := NewActivity(ma, 1)
+	if err != nil {
+		return nil, err
+	}
+	comp.Destination = &ma.Destination
+	return comp, nil
 }
 
 // Validate はBehaviorの実装

--- a/internal/activity/move.go
+++ b/internal/activity/move.go
@@ -119,8 +119,7 @@ func (ma *MoveActivity) Validate(comp *gc.Activity, actor ecs.Entity, world w.Wo
 					Warning("重すぎて動けない").
 					Log()
 			}
-			// エラーではない
-			return nil
+			return ErrMoveOverweight
 		}
 	}
 

--- a/internal/activity/move.go
+++ b/internal/activity/move.go
@@ -225,7 +225,11 @@ func swapAllyIfNeeded(world w.World, actor ecs.Entity, fromX, fromY, toX, toY in
 	if !CanSwapPosition(world, actor, target) {
 		return
 	}
-	targetGrid := world.Components.GridElement.Get(target).(*gc.GridElement)
+	targetGridComp := world.Components.GridElement.Get(target)
+	if targetGridComp == nil {
+		return
+	}
+	targetGrid := targetGridComp.(*gc.GridElement)
 	targetGrid.X = consts.Tile(fromX)
 	targetGrid.Y = consts.Tile(fromY)
 

--- a/internal/activity/pickup.go
+++ b/internal/activity/pickup.go
@@ -15,7 +15,10 @@ import (
 )
 
 // PickupActivity はBehaviorの実装
-type PickupActivity struct{}
+type PickupActivity struct {
+	Target      *ecs.Entity
+	Destination *gc.GridElement
+}
 
 // Info はBehaviorの実装
 func (pa *PickupActivity) Info() Info {
@@ -32,6 +35,21 @@ func (pa *PickupActivity) Info() Info {
 // Name はBehaviorの実装
 func (pa *PickupActivity) Name() gc.BehaviorName {
 	return gc.BehaviorPickup
+}
+
+// BuildActivity はBehaviorの実装
+func (pa *PickupActivity) BuildActivity(_ ecs.Entity, _ w.World) (*gc.Activity, error) {
+	comp, err := NewActivity(pa, 1)
+	if err != nil {
+		return nil, err
+	}
+	if pa.Target != nil {
+		comp.Target = pa.Target
+	}
+	if pa.Destination != nil {
+		comp.Destination = pa.Destination
+	}
+	return comp, nil
 }
 
 // Validate はアイテム拾得アクティビティの検証を行う

--- a/internal/activity/player_actions.go
+++ b/internal/activity/player_actions.go
@@ -69,11 +69,7 @@ func ExecuteMoveAction(world w.World, direction gc.Direction) error {
 	canMove := CanMoveTo(world, consts.Coord[int]{X: newX, Y: newY}, consts.Coord[int]{X: currentX, Y: currentY}, entity)
 	if canMove {
 		destination := gc.GridElement{X: consts.Tile(newX), Y: consts.Tile(newY)}
-		params := ActionParams{
-			Actor:       entity,
-			Destination: &destination,
-		}
-		_, err := Execute(&MoveActivity{}, params, world)
+		_, err := Execute(&MoveActivity{Destination: destination}, entity, world)
 		return err
 	}
 
@@ -87,12 +83,7 @@ func ExecuteWaitAction(world w.World) error {
 		return err
 	}
 
-	params := ActionParams{
-		Actor:    entity,
-		Duration: 1,
-		Reason:   "プレイヤー待機",
-	}
-	_, err = Execute(&WaitActivity{}, params, world)
+	_, err = Execute(&WaitActivity{Duration: 1, Reason: "プレイヤー待機"}, entity, world)
 	return err
 }
 

--- a/internal/activity/read.go
+++ b/internal/activity/read.go
@@ -82,6 +82,10 @@ func (ra *ReadActivity) Validate(comp *gc.Activity, actor ecs.Entity, world w.Wo
 
 // Start は読書開始時の処理を実行する
 func (ra *ReadActivity) Start(comp *gc.Activity, actor ecs.Entity, world w.World) error {
+	if comp.Target == nil {
+		return ErrReadTargetNotSet
+	}
+
 	book := ra.getBook(*comp.Target, world)
 	if book == nil {
 		return fmt.Errorf("Bookコンポーネントが見つかりません")

--- a/internal/activity/read.go
+++ b/internal/activity/read.go
@@ -15,7 +15,10 @@ import (
 )
 
 // ReadActivity は読書アクティビティの実装
-type ReadActivity struct{}
+type ReadActivity struct {
+	Target   ecs.Entity
+	Duration int
+}
 
 // Info はBehaviorの実装
 func (ra *ReadActivity) Info() Info {
@@ -31,6 +34,24 @@ func (ra *ReadActivity) Info() Info {
 // Name はBehaviorの実装
 func (ra *ReadActivity) Name() gc.BehaviorName {
 	return gc.BehaviorRead
+}
+
+// BuildActivity はBehaviorの実装
+func (ra *ReadActivity) BuildActivity(actor ecs.Entity, world w.World) (*gc.Activity, error) {
+	duration := ra.Duration
+	if duration <= 0 {
+		characterAP, err := getEntityMaxAP(actor, world)
+		if err != nil {
+			return nil, err
+		}
+		duration = CalculateRequiredTurns(ra, characterAP)
+	}
+	comp, err := NewActivity(ra, duration)
+	if err != nil {
+		return nil, err
+	}
+	comp.Target = &ra.Target
+	return comp, nil
 }
 
 // Validate は読書アクティビティの検証を行う

--- a/internal/activity/reload.go
+++ b/internal/activity/reload.go
@@ -186,10 +186,7 @@ func (ra *ReloadActivity) calcEffortPerTurn(actor ecs.Entity, fire *gc.Fire, wor
 func ExecuteReloadAction(actor ecs.Entity, world w.World) error {
 	_, err := Execute(&ReloadActivity{}, actor, world)
 	if err != nil {
-		gamelog.New(query.GetGameLog(world)).
-			Append(err.Error()).
-			Log()
-		return nil
+		return err
 	}
 	return nil
 }

--- a/internal/activity/reload.go
+++ b/internal/activity/reload.go
@@ -184,19 +184,12 @@ func (ra *ReloadActivity) calcEffortPerTurn(actor ecs.Entity, fire *gc.Fire, wor
 
 // ExecuteReloadAction はリロードアクションを実行する
 func ExecuteReloadAction(actor ecs.Entity, world w.World) error {
-	behavior := &ReloadActivity{}
-	activity, err := NewActivity(behavior, 1) // 初期値。Startで更新される
+	_, err := Execute(&ReloadActivity{}, actor, world)
 	if err != nil {
-		return fmt.Errorf("リロードアクティビティの作成に失敗: %w", err)
-	}
-
-	if err := behavior.Validate(activity, actor, world); err != nil {
 		gamelog.New(query.GetGameLog(world)).
 			Append(err.Error()).
 			Log()
 		return nil
 	}
-
-	actor.AddComponent(world.Components.Activity, activity)
 	return nil
 }

--- a/internal/activity/reload.go
+++ b/internal/activity/reload.go
@@ -39,6 +39,15 @@ func (ra *ReloadActivity) Name() gc.BehaviorName {
 	return gc.BehaviorReload
 }
 
+// BuildActivity はBehaviorの実装
+func (ra *ReloadActivity) BuildActivity(_ ecs.Entity, _ w.World) (*gc.Activity, error) {
+	comp, err := NewActivity(ra, 1)
+	if err != nil {
+		return nil, err
+	}
+	return comp, nil
+}
+
 // Validate はリロードの検証を行う
 func (ra *ReloadActivity) Validate(_ *gc.Activity, actor ecs.Entity, world w.World) error {
 	fire, _, err := getEquippedFire(actor, world)

--- a/internal/activity/reload_test.go
+++ b/internal/activity/reload_test.go
@@ -244,9 +244,8 @@ func TestExecuteReloadAction(t *testing.T) {
 		world, player, _, _ := setupShootingWorld(t)
 
 		err := ExecuteReloadAction(player, world)
-		require.NoError(t, err)
+		assert.Error(t, err)
 
-		// Activityは設定されない（検証失敗でログに記録される）
 		assert.False(t, player.HasComponent(world.Components.Activity))
 	})
 }

--- a/internal/activity/rest.go
+++ b/internal/activity/rest.go
@@ -13,7 +13,9 @@ import (
 )
 
 // RestActivity はBehaviorの実装
-type RestActivity struct{}
+type RestActivity struct {
+	Duration int
+}
 
 // Info はBehaviorの実装
 func (ra *RestActivity) Info() Info {
@@ -30,6 +32,23 @@ func (ra *RestActivity) Info() Info {
 // Name はBehaviorの実装
 func (ra *RestActivity) Name() gc.BehaviorName {
 	return gc.BehaviorRest
+}
+
+// BuildActivity はBehaviorの実装
+func (ra *RestActivity) BuildActivity(actor ecs.Entity, world w.World) (*gc.Activity, error) {
+	duration := ra.Duration
+	if duration <= 0 {
+		characterAP, err := getEntityMaxAP(actor, world)
+		if err != nil {
+			return nil, err
+		}
+		duration = CalculateRequiredTurns(ra, characterAP)
+	}
+	comp, err := NewActivity(ra, duration)
+	if err != nil {
+		return nil, err
+	}
+	return comp, nil
 }
 
 // Validate は休息アクティビティの検証を行う

--- a/internal/activity/rest.go
+++ b/internal/activity/rest.go
@@ -122,7 +122,7 @@ func (ra *RestActivity) Finish(_ *gc.Activity, actor ecs.Entity, world w.World) 
 	if hpComponent != nil {
 		hp := hpComponent.(*gc.HP)
 		if hp.Current < hp.Max {
-			bonusHealing := 5 / 2 // 完了ボーナス
+			bonusHealing := 2
 			hp.Current += bonusHealing
 			if hp.Current > hp.Max {
 				hp.Current = hp.Max

--- a/internal/activity/shoot.go
+++ b/internal/activity/shoot.go
@@ -201,8 +201,13 @@ func EntityDistance(a, b ecs.Entity, world w.World) float64 {
 // checkLineOfSight は射線上の壁と遮蔽物を1パスでチェックする。
 // 壁（BlockView=true）があればblocked=true、遮蔽物（BlockPass=true, BlockView=false）の数をcoverCountで返す
 func checkLineOfSight(actor, target ecs.Entity, world w.World) (blocked bool, coverCount int) {
-	aPos := world.Components.GridElement.Get(actor).(*gc.GridElement)
-	tPos := world.Components.GridElement.Get(target).(*gc.GridElement)
+	aGrid := world.Components.GridElement.Get(actor)
+	tGrid := world.Components.GridElement.Get(target)
+	if aGrid == nil || tGrid == nil {
+		return true, 0
+	}
+	aPos := aGrid.(*gc.GridElement)
+	tPos := tGrid.(*gc.GridElement)
 
 	points := geometry.BresenhamLine(int(aPos.X), int(aPos.Y), int(tPos.X), int(tPos.Y))
 	for _, p := range points {

--- a/internal/activity/shoot.go
+++ b/internal/activity/shoot.go
@@ -6,7 +6,6 @@ import (
 
 	gc "github.com/kijimaD/ruins/internal/components"
 	"github.com/kijimaD/ruins/internal/consts"
-	"github.com/kijimaD/ruins/internal/gamelog"
 	"github.com/kijimaD/ruins/internal/geometry"
 	w "github.com/kijimaD/ruins/internal/world"
 
@@ -249,10 +248,7 @@ func CalculateShootHitRate(actor, target ecs.Entity, world w.World) int {
 func ExecuteShootAction(actor ecs.Entity, target ecs.Entity, world w.World) error {
 	_, err := Execute(&ShootActivity{Target: target}, actor, world)
 	if err != nil {
-		gamelog.New(query.GetGameLog(world)).
-			Append(err.Error()).
-			Log()
-		return nil
+		return err
 	}
 	return nil
 }

--- a/internal/activity/shoot.go
+++ b/internal/activity/shoot.go
@@ -20,7 +20,9 @@ const (
 )
 
 // ShootActivity は射撃アクティビティの実装
-type ShootActivity struct{}
+type ShootActivity struct {
+	Target ecs.Entity
+}
 
 // Info はBehaviorの実装
 func (sa *ShootActivity) Info() Info {
@@ -36,6 +38,16 @@ func (sa *ShootActivity) Info() Info {
 // Name はBehaviorの実装
 func (sa *ShootActivity) Name() gc.BehaviorName {
 	return gc.BehaviorShoot
+}
+
+// BuildActivity はBehaviorの実装
+func (sa *ShootActivity) BuildActivity(_ ecs.Entity, _ w.World) (*gc.Activity, error) {
+	comp, err := NewActivity(sa, 1)
+	if err != nil {
+		return nil, err
+	}
+	comp.Target = &sa.Target
+	return comp, nil
 }
 
 // Validate は射撃の検証を行う
@@ -235,11 +247,7 @@ func CalculateShootHitRate(actor, target ecs.Entity, world w.World) int {
 
 // ExecuteShootAction は射撃アクションを実行する
 func ExecuteShootAction(actor ecs.Entity, target ecs.Entity, world w.World) error {
-	params := ActionParams{
-		Actor:  actor,
-		Target: &target,
-	}
-	_, err := Execute(&ShootActivity{}, params, world)
+	_, err := Execute(&ShootActivity{Target: target}, actor, world)
 	if err != nil {
 		gamelog.New(query.GetGameLog(world)).
 			Append(err.Error()).

--- a/internal/activity/shoot_test.go
+++ b/internal/activity/shoot_test.go
@@ -270,9 +270,8 @@ func TestExecuteShootAction(t *testing.T) {
 		require.NoError(t, err)
 
 		err = ExecuteShootAction(player, enemy, world)
-		require.NoError(t, err) // エラーではなくログに記録される
+		assert.Error(t, err)
 
-		// Activityは設定されない
 		assert.False(t, player.HasComponent(world.Components.Activity))
 	})
 }

--- a/internal/activity/talk.go
+++ b/internal/activity/talk.go
@@ -14,7 +14,9 @@ import (
 )
 
 // TalkActivity は会話アクティビティ
-type TalkActivity struct{}
+type TalkActivity struct {
+	Target ecs.Entity
+}
 
 // Info はBehaviorの実装
 func (ta *TalkActivity) Info() Info {
@@ -31,6 +33,16 @@ func (ta *TalkActivity) Info() Info {
 // Name はBehaviorの実装
 func (ta *TalkActivity) Name() gc.BehaviorName {
 	return gc.BehaviorTalk
+}
+
+// BuildActivity はBehaviorの実装
+func (ta *TalkActivity) BuildActivity(_ ecs.Entity, _ w.World) (*gc.Activity, error) {
+	comp, err := NewActivity(ta, 1)
+	if err != nil {
+		return nil, err
+	}
+	comp.Target = &ta.Target
+	return comp, nil
 }
 
 // Validate は会話アクティビティの検証を行う

--- a/internal/activity/transfer.go
+++ b/internal/activity/transfer.go
@@ -15,7 +15,10 @@ import (
 
 // TransferActivity はエンティティ間でアイテムを転送するBehavior実装。
 // Targetに転送するアイテム、Recipientに受取人を指定する
-type TransferActivity struct{}
+type TransferActivity struct {
+	Target    ecs.Entity
+	Recipient ecs.Entity
+}
 
 // Info はBehaviorの実装
 func (ta *TransferActivity) Info() Info {
@@ -32,6 +35,17 @@ func (ta *TransferActivity) Info() Info {
 // Name はBehaviorの実装
 func (ta *TransferActivity) Name() gc.BehaviorName {
 	return gc.BehaviorTransfer
+}
+
+// BuildActivity はBehaviorの実装
+func (ta *TransferActivity) BuildActivity(_ ecs.Entity, _ w.World) (*gc.Activity, error) {
+	comp, err := NewActivity(ta, 1)
+	if err != nil {
+		return nil, err
+	}
+	comp.Target = &ta.Target
+	comp.Recipient = &ta.Recipient
+	return comp, nil
 }
 
 // Validate はアイテム転送アクティビティの検証を行う

--- a/internal/activity/use_item.go
+++ b/internal/activity/use_item.go
@@ -15,7 +15,9 @@ import (
 )
 
 // UseItemActivity はBehaviorの実装
-type UseItemActivity struct{}
+type UseItemActivity struct {
+	Target ecs.Entity
+}
 
 // Info はBehaviorの実装
 func (u *UseItemActivity) Info() Info {
@@ -32,6 +34,16 @@ func (u *UseItemActivity) Info() Info {
 // Name はBehaviorの実装
 func (u *UseItemActivity) Name() gc.BehaviorName {
 	return gc.BehaviorUseItem
+}
+
+// BuildActivity はBehaviorの実装
+func (u *UseItemActivity) BuildActivity(_ ecs.Entity, _ w.World) (*gc.Activity, error) {
+	comp, err := NewActivity(u, 1)
+	if err != nil {
+		return nil, err
+	}
+	comp.Target = &u.Target
+	return comp, nil
 }
 
 // Validate はBehaviorの実装

--- a/internal/activity/wait.go
+++ b/internal/activity/wait.go
@@ -13,7 +13,10 @@ import (
 )
 
 // WaitActivity はBehaviorの実装
-type WaitActivity struct{}
+type WaitActivity struct {
+	Duration int
+	Reason   string
+}
 
 // Info はBehaviorの実装
 func (wa *WaitActivity) Info() Info {
@@ -30,6 +33,19 @@ func (wa *WaitActivity) Info() Info {
 // Name はBehaviorの実装
 func (wa *WaitActivity) Name() gc.BehaviorName {
 	return gc.BehaviorWait
+}
+
+// BuildActivity はBehaviorの実装
+func (wa *WaitActivity) BuildActivity(_ ecs.Entity, _ w.World) (*gc.Activity, error) {
+	duration := wa.Duration
+	if duration <= 0 {
+		duration = 1
+	}
+	comp, err := NewActivity(wa, duration)
+	if err != nil {
+		return nil, err
+	}
+	return comp, nil
 }
 
 // Validate は待機アクティビティの検証を行う

--- a/internal/activity/wait.go
+++ b/internal/activity/wait.go
@@ -63,8 +63,7 @@ func (wa *WaitActivity) Validate(comp *gc.Activity, _ ecs.Entity, _ w.World) err
 
 // Start は待機開始時の処理を実行する
 func (wa *WaitActivity) Start(comp *gc.Activity, actor ecs.Entity, _ w.World) error {
-	reason := "時間を過ごすため"
-	log.Debug("待機開始", "actor", actor, "reason", reason, "duration", comp.TurnsLeft)
+	log.Debug("待機開始", "actor", actor, "reason", wa.Reason, "duration", comp.TurnsLeft)
 	return nil
 }
 

--- a/internal/aiinput/action_planner_test.go
+++ b/internal/aiinput/action_planner_test.go
@@ -4,6 +4,7 @@ import (
 	"math/rand/v2"
 	"testing"
 
+	"github.com/kijimaD/ruins/internal/activity"
 	gc "github.com/kijimaD/ruins/internal/components"
 	"github.com/kijimaD/ruins/internal/consts"
 	"github.com/kijimaD/ruins/internal/testutil"
@@ -56,9 +57,8 @@ func TestPlanAction_WaitingState(t *testing.T) {
 
 	// Waiting状態では待機を返す（視界外のプレイヤーでは遷移しない）
 	// Plan()経由でテスト。状態遷移も含む
-	behavior, params := rp.Plan(world, entity)
+	behavior := rp.Plan(world, entity)
 	assert.Equal(t, gc.BehaviorWait, behavior.Name())
-	assert.Equal(t, entity, params.Actor)
 }
 
 func TestPlanAction_ChasingState_Adjacent(t *testing.T) {
@@ -82,9 +82,10 @@ func TestPlanAction_ChasingState_Adjacent(t *testing.T) {
 
 	rp := newSoloPlanner(testRNG)
 
-	behavior, params := rp.Plan(world, entity)
+	behavior := rp.Plan(world, entity)
 	assert.Equal(t, gc.BehaviorAttack, behavior.Name())
-	assert.NotNil(t, params.Target)
+	attack := behavior.(*activity.AttackActivity)
+	assert.NotZero(t, attack.Target)
 }
 
 func TestPlanAction_ChasingState_NotAdjacent(t *testing.T) {
@@ -108,9 +109,10 @@ func TestPlanAction_ChasingState_NotAdjacent(t *testing.T) {
 
 	rp := newSoloPlanner(testRNG)
 
-	behavior, params := rp.Plan(world, entity)
+	behavior := rp.Plan(world, entity)
 	assert.Equal(t, gc.BehaviorMove, behavior.Name())
-	assert.NotNil(t, params.Destination)
+	move := behavior.(*activity.MoveActivity)
+	assert.NotZero(t, move.Destination)
 }
 
 func TestPlanAction_FleeingState(t *testing.T) {
@@ -134,7 +136,7 @@ func TestPlanAction_FleeingState(t *testing.T) {
 
 	rp := newSoloPlanner(testRNG)
 
-	behavior, _ := rp.Plan(world, entity)
+	behavior := rp.Plan(world, entity)
 	name := behavior.Name()
 	assert.True(t, name == gc.BehaviorMove || name == gc.BehaviorWait,
 		"逃亡時は移動か待機を返すべき: got %s", name)
@@ -161,7 +163,7 @@ func TestPlanAction_DrivingState(t *testing.T) {
 
 	rp := newSoloPlanner(testRNG)
 
-	behavior, _ := rp.Plan(world, entity)
+	behavior := rp.Plan(world, entity)
 	name := behavior.Name()
 	assert.True(t, name == gc.BehaviorMove || name == gc.BehaviorWait,
 		"Driving状態は移動か待機を返すべき: got %s", name)
@@ -188,7 +190,7 @@ func TestPlanAction_UnknownState(t *testing.T) {
 
 	rp := newSoloPlanner(testRNG)
 
-	behavior, _ := rp.Plan(world, entity)
+	behavior := rp.Plan(world, entity)
 	assert.Equal(t, gc.BehaviorWait, behavior.Name())
 }
 
@@ -211,7 +213,7 @@ func TestPlanDrivingAction_Stationary(t *testing.T) {
 	rp := newSoloPlanner(testRNG)
 	grid := world.Components.GridElement.Get(entity).(*gc.GridElement)
 
-	behavior, _ := rp.planDrivingAction(world, entity, solo, grid)
+	behavior := rp.planDrivingAction(world, entity, solo, grid)
 	assert.Equal(t, gc.BehaviorWait, behavior.Name())
 }
 
@@ -234,7 +236,7 @@ func TestPlanDrivingAction_Wander(t *testing.T) {
 	rp := newSoloPlanner(testRNG)
 	grid := world.Components.GridElement.Get(entity).(*gc.GridElement)
 
-	behavior, _ := rp.planDrivingAction(world, entity, solo, grid)
+	behavior := rp.planDrivingAction(world, entity, solo, grid)
 	name := behavior.Name()
 	assert.True(t, name == gc.BehaviorMove || name == gc.BehaviorWait)
 }
@@ -258,7 +260,7 @@ func TestPlanDrivingAction_WallHug(t *testing.T) {
 	rp := newSoloPlanner(testRNG)
 	grid := world.Components.GridElement.Get(entity).(*gc.GridElement)
 
-	behavior, _ := rp.planDrivingAction(world, entity, solo, grid)
+	behavior := rp.planDrivingAction(world, entity, solo, grid)
 	name := behavior.Name()
 	assert.True(t, name == gc.BehaviorMove || name == gc.BehaviorWait)
 }
@@ -282,7 +284,7 @@ func TestPlanDrivingAction_Swarm(t *testing.T) {
 	rp := newSoloPlanner(testRNG)
 	grid := world.Components.GridElement.Get(entity).(*gc.GridElement)
 
-	behavior, _ := rp.planDrivingAction(world, entity, solo, grid)
+	behavior := rp.planDrivingAction(world, entity, solo, grid)
 	name := behavior.Name()
 	assert.True(t, name == gc.BehaviorMove || name == gc.BehaviorWait)
 }
@@ -308,7 +310,7 @@ func TestPlanDrivingAction_Territorial(t *testing.T) {
 	rp := newSoloPlanner(testRNG)
 	grid := world.Components.GridElement.Get(entity).(*gc.GridElement)
 
-	behavior, _ := rp.planDrivingAction(world, entity, solo, grid)
+	behavior := rp.planDrivingAction(world, entity, solo, grid)
 	assert.Equal(t, gc.BehaviorMove, behavior.Name())
 }
 
@@ -331,7 +333,7 @@ func TestPlanDrivingAction_Random(t *testing.T) {
 	rp := newSoloPlanner(testRNG)
 	grid := world.Components.GridElement.Get(entity).(*gc.GridElement)
 
-	behavior, _ := rp.planDrivingAction(world, entity, solo, grid)
+	behavior := rp.planDrivingAction(world, entity, solo, grid)
 	name := behavior.Name()
 	assert.True(t, name == gc.BehaviorMove || name == gc.BehaviorWait)
 }
@@ -359,10 +361,11 @@ func TestPlanDrivingAction_Patrol(t *testing.T) {
 	rp := newSoloPlanner(testRNG)
 	grid := world.Components.GridElement.Get(entity).(*gc.GridElement)
 
-	behavior, params := rp.planDrivingAction(world, entity, solo, grid)
+	behavior := rp.planDrivingAction(world, entity, solo, grid)
 	assert.Equal(t, gc.BehaviorMove, behavior.Name())
-	assert.Equal(t, consts.Tile(21), params.Destination.X)
-	assert.Equal(t, consts.Tile(20), params.Destination.Y)
+	move := behavior.(*activity.MoveActivity)
+	assert.Equal(t, consts.Tile(21), move.Destination.X)
+	assert.Equal(t, consts.Tile(20), move.Destination.Y)
 }
 
 func TestPlanPatrolAction_ReverseOnBlock(t *testing.T) {
@@ -392,9 +395,10 @@ func TestPlanPatrolAction_ReverseOnBlock(t *testing.T) {
 	rp := newSoloPlanner(testRNG)
 	grid := world.Components.GridElement.Get(entity).(*gc.GridElement)
 
-	behavior, params := rp.planPatrolAction(world, entity, solo, grid)
+	behavior := rp.planPatrolAction(world, entity, solo, grid)
 	assert.Equal(t, gc.BehaviorMove, behavior.Name())
-	assert.Equal(t, consts.Tile(19), params.Destination.X)
+	move := behavior.(*activity.MoveActivity)
+	assert.Equal(t, consts.Tile(19), move.Destination.X)
 	assert.Equal(t, -1, solo.PatrolDirX)
 }
 
@@ -427,7 +431,7 @@ func TestPlanPatrolAction_BothBlocked(t *testing.T) {
 	rp := newSoloPlanner(testRNG)
 	grid := world.Components.GridElement.Get(entity).(*gc.GridElement)
 
-	behavior, _ := rp.planPatrolAction(world, entity, solo, grid)
+	behavior := rp.planPatrolAction(world, entity, solo, grid)
 	assert.Equal(t, gc.BehaviorWait, behavior.Name())
 }
 
@@ -454,10 +458,11 @@ func TestPlanTerritorialAction_StaysInRange(t *testing.T) {
 	for i := range 100 {
 		grid := world.Components.GridElement.Get(entity).(*gc.GridElement)
 
-		behavior, params := rp.planTerritorialAction(world, entity, solo, grid)
-		if behavior.Name() == gc.BehaviorMove && params.Destination != nil {
-			grid.X = params.Destination.X
-			grid.Y = params.Destination.Y
+		behavior := rp.planTerritorialAction(world, entity, solo, grid)
+		if behavior.Name() == gc.BehaviorMove {
+			move := behavior.(*activity.MoveActivity)
+			grid.X = move.Destination.X
+			grid.Y = move.Destination.Y
 		}
 
 		dx := int(grid.X) - solo.OriginX
@@ -495,10 +500,11 @@ func TestPlanTerritorialAction_AtBoundary(t *testing.T) {
 	grid := world.Components.GridElement.Get(entity).(*gc.GridElement)
 
 	for i := range 50 {
-		behavior, params := rp.planTerritorialAction(world, entity, solo, grid)
-		if behavior.Name() == gc.BehaviorMove && params.Destination != nil {
-			dx := int(params.Destination.X) - solo.OriginX
-			dy := int(params.Destination.Y) - solo.OriginY
+		behavior := rp.planTerritorialAction(world, entity, solo, grid)
+		if behavior.Name() == gc.BehaviorMove {
+			move := behavior.(*activity.MoveActivity)
+			dx := int(move.Destination.X) - solo.OriginX
+			dy := int(move.Destination.Y) - solo.OriginY
 			if dx < 0 {
 				dx = -dx
 			}
@@ -533,7 +539,7 @@ func TestPlanWanderAction(t *testing.T) {
 	gotMove := false
 	gotWait := false
 	for range 50 {
-		behavior, _ := rp.planWanderAction(world, entity, grid)
+		behavior := rp.planWanderAction(world, entity, grid)
 		switch behavior.Name() { //nolint:exhaustive
 		case gc.BehaviorMove:
 			gotMove = true
@@ -575,7 +581,7 @@ func TestPlanWallHugAction(t *testing.T) {
 
 	moved := false
 	for range 50 {
-		behavior, _ := rp.planWallHugAction(world, entity, grid)
+		behavior := rp.planWallHugAction(world, entity, grid)
 		if behavior.Name() == gc.BehaviorMove {
 			moved = true
 			break
@@ -603,7 +609,7 @@ func TestPlanSwarmAction_NoAllies(t *testing.T) {
 	rp := newSoloPlanner(testRNG)
 	grid := world.Components.GridElement.Get(entity).(*gc.GridElement)
 
-	behavior, _ := rp.planSwarmAction(world, entity, grid)
+	behavior := rp.planSwarmAction(world, entity, grid)
 	name := behavior.Name()
 	assert.True(t, name == gc.BehaviorMove || name == gc.BehaviorWait,
 		"仲間がいない場合は移動か待機を返すべき: got %s", name)
@@ -640,9 +646,10 @@ func TestPlanSwarmAction_WithAlly(t *testing.T) {
 
 	moved := false
 	for range 50 {
-		behavior, params := rp.planSwarmAction(world, entity, grid)
-		if behavior.Name() == gc.BehaviorMove && params.Destination != nil {
-			if params.Destination.X > grid.X || params.Destination.Y > grid.Y {
+		behavior := rp.planSwarmAction(world, entity, grid)
+		if behavior.Name() == gc.BehaviorMove {
+			move := behavior.(*activity.MoveActivity)
+			if move.Destination.X > grid.X || move.Destination.Y > grid.Y {
 				moved = true
 				break
 			}
@@ -728,7 +735,7 @@ func TestPlanRandomMoveAction(t *testing.T) {
 	gotMove := false
 	gotWait := false
 	for range 50 {
-		behavior, _ := rp.planRandomMoveAction(world, entity, grid)
+		behavior := rp.planRandomMoveAction(world, entity, grid)
 		switch behavior.Name() { //nolint:exhaustive
 		case gc.BehaviorMove:
 			gotMove = true
@@ -844,9 +851,10 @@ func TestPlanAction_ChasingState_隊員に隣接で攻撃(t *testing.T) {
 	entity := setupTestAI(t, world, 5, 5, ai)
 
 	rp := newSoloPlanner(testRNG)
-	behavior, params := rp.Plan(world, entity)
+	behavior := rp.Plan(world, entity)
 	assert.Equal(t, gc.BehaviorAttack, behavior.Name(), "隣接する隊員を攻撃すべき")
-	assert.NotNil(t, params.Target)
+	attack := behavior.(*activity.AttackActivity)
+	assert.NotZero(t, attack.Target)
 }
 
 func TestPlanAction_ChasingState_隊員に接近(t *testing.T) {
@@ -880,8 +888,8 @@ func TestPlanAction_ChasingState_隊員に接近(t *testing.T) {
 	entity := setupTestAI(t, world, 5, 5, ai)
 
 	rp := newSoloPlanner(testRNG)
-	behavior, params := rp.Plan(world, entity)
+	behavior := rp.Plan(world, entity)
 	assert.Equal(t, gc.BehaviorMove, behavior.Name(), "離れた隊員に向かって移動すべき")
-	assert.NotNil(t, params.Destination)
-	assert.True(t, int(params.Destination.X) > 5, "隊員方向に移動すべき")
+	move := behavior.(*activity.MoveActivity)
+	assert.True(t, int(move.Destination.X) > 5, "隊員方向に移動すべき")
 }

--- a/internal/aiinput/planner.go
+++ b/internal/aiinput/planner.go
@@ -16,7 +16,7 @@ import (
 // Planner はエンティティの行動計画を担うインターフェースを表す。
 // 各ターンのAPループ内で呼ばれ、次のアクションを返す
 type Planner interface {
-	Plan(world w.World, entity ecs.Entity) (activity.Behavior, activity.ActionParams)
+	Plan(world w.World, entity ecs.Entity) activity.Behavior
 }
 
 // maxActivitiesPerTurn は1ターン中に実行可能なアクティビティの上限を表す
@@ -32,7 +32,7 @@ func runAPLoop(world w.World, entity ecs.Entity, planner Planner, log *logger.Lo
 			break
 		}
 
-		behavior, params := planner.Plan(world, entity)
+		behavior := planner.Plan(world, entity)
 		if behavior == nil {
 			break
 		}
@@ -44,7 +44,7 @@ func runAPLoop(world w.World, entity ecs.Entity, planner Planner, log *logger.Lo
 			break
 		}
 
-		result, err := activity.Execute(behavior, params, world)
+		result, err := activity.Execute(behavior, entity, world)
 		if err != nil {
 			log.Warn("アクション実行失敗", "entity", entity, "activity", behavior.Name(), "error", err.Error())
 			break
@@ -116,30 +116,27 @@ func calculateMoveCandidates(delta consts.Coord[int]) []consts.Coord[int] {
 }
 
 // tryMoveCandidates は移動候補を順に試行し、最初に移動可能な方向へ移動するアクションを返す
-func tryMoveCandidates(world w.World, entity ecs.Entity, from *gc.GridElement, candidates []consts.Coord[int]) (activity.Behavior, activity.ActionParams, bool) {
+func tryMoveCandidates(world w.World, entity ecs.Entity, from *gc.GridElement, candidates []consts.Coord[int]) (activity.Behavior, bool) {
 	fromPos := consts.Coord[int]{X: int(from.X), Y: int(from.Y)}
 	for _, c := range candidates {
 		dest := consts.Coord[int]{X: fromPos.X + c.X, Y: fromPos.Y + c.Y}
 		if activity.CanMoveTo(world, dest, fromPos, entity) {
-			b, p := moveAction(entity, dest)
-			return b, p, true
+			return moveAction(dest), true
 		}
 	}
-	return nil, activity.ActionParams{}, false
+	return nil, false
 }
 
 // moveAction は指定座標への移動アクションを生成する
-func moveAction(aiEntity ecs.Entity, dest consts.Coord[int]) (activity.Behavior, activity.ActionParams) {
-	gridDest := gc.GridElement{X: consts.Tile(dest.X), Y: consts.Tile(dest.Y)}
-	return &activity.MoveActivity{}, activity.ActionParams{
-		Actor:       aiEntity,
-		Destination: &gridDest,
+func moveAction(dest consts.Coord[int]) activity.Behavior {
+	return &activity.MoveActivity{
+		Destination: gc.GridElement{X: consts.Tile(dest.X), Y: consts.Tile(dest.Y)},
 	}
 }
 
 // waitAction は待機アクションを生成する
-func waitAction(aiEntity ecs.Entity, reason string) (activity.Behavior, activity.ActionParams) {
-	return &activity.WaitActivity{}, activity.ActionParams{Actor: aiEntity, Duration: 1, Reason: reason}
+func waitAction(reason string) activity.Behavior {
+	return &activity.WaitActivity{Duration: 1, Reason: reason}
 }
 
 // shuffledEightDirections は8方向をシャッフルして返す

--- a/internal/aiinput/planner_solo.go
+++ b/internal/aiinput/planner_solo.go
@@ -35,11 +35,11 @@ func newSoloPlanner(rng *rand.Rand) *soloPlanner {
 
 // Plan は状態遷移の評価とアクション決定を一体的に行う。
 // APループ内で繰り返し呼ばれ、状態遷移は同一ターン内でべき等
-func (rp *soloPlanner) Plan(world w.World, entity ecs.Entity) (activity.Behavior, activity.ActionParams) {
+func (rp *soloPlanner) Plan(world w.World, entity ecs.Entity) activity.Behavior {
 	aiComp := world.Components.AI.Get(entity)
 	if aiComp == nil {
 		rp.logger.Warn("AIコンポーネントなし", "entity", entity)
-		return nil, activity.ActionParams{}
+		return nil
 	}
 	solo := aiComp.(*gc.AI).Planner.(*gc.SoloAI)
 	grid := world.Components.GridElement.Get(entity).(*gc.GridElement)
@@ -61,9 +61,9 @@ func (rp *soloPlanner) Plan(world w.World, entity ecs.Entity) (activity.Behavior
 	case gc.AIStateDriving:
 		return rp.planDrivingAction(world, entity, solo, grid)
 	case gc.AIStateWaiting:
-		return waitAction(entity, "AI待機")
+		return waitAction("AI待機")
 	default:
-		return waitAction(entity, "AIデフォルト待機")
+		return waitAction("AIデフォルト待機")
 	}
 }
 
@@ -175,61 +175,58 @@ func (rp *soloPlanner) initializeToWaiting(solo *gc.SoloAI, currentTurn int) {
 
 // ========== アクション計画ロジック ==========
 
-func (rp *soloPlanner) planChaseAction(world w.World, aiEntity, playerEntity ecs.Entity, aiGrid *gc.GridElement) (activity.Behavior, activity.ActionParams) {
+func (rp *soloPlanner) planChaseAction(world w.World, aiEntity, playerEntity ecs.Entity, aiGrid *gc.GridElement) activity.Behavior {
 	playerGrid := world.Components.GridElement.Get(playerEntity).(*gc.GridElement)
 
 	if isAdjacent(aiGrid, playerGrid) {
-		return &activity.AttackActivity{}, activity.ActionParams{
-			Actor:  aiEntity,
-			Target: &playerEntity,
-		}
+		return &activity.AttackActivity{Target: playerEntity}
 	}
 
 	dx := int(playerGrid.X) - int(aiGrid.X)
 	dy := int(playerGrid.Y) - int(aiGrid.Y)
 
 	candidates := calculateMoveCandidates(consts.Coord[int]{X: dx, Y: dy})
-	if b, p, ok := tryMoveCandidates(world, aiEntity, aiGrid, candidates); ok {
-		return b, p
+	if b, ok := tryMoveCandidates(world, aiEntity, aiGrid, candidates); ok {
+		return b
 	}
 
-	return waitAction(aiEntity, "AI追跡失敗")
+	return waitAction("AI追跡失敗")
 }
 
-func (rp *soloPlanner) planFleeAction(world w.World, aiEntity, playerEntity ecs.Entity, aiGrid *gc.GridElement) (activity.Behavior, activity.ActionParams) {
+func (rp *soloPlanner) planFleeAction(world w.World, aiEntity, playerEntity ecs.Entity, aiGrid *gc.GridElement) activity.Behavior {
 	playerGrid := world.Components.GridElement.Get(playerEntity).(*gc.GridElement)
 
 	dx := int(aiGrid.X) - int(playerGrid.X)
 	dy := int(aiGrid.Y) - int(playerGrid.Y)
 
 	candidates := calculateMoveCandidates(consts.Coord[int]{X: dx, Y: dy})
-	if b, p, ok := tryMoveCandidates(world, aiEntity, aiGrid, candidates); ok {
-		return b, p
+	if b, ok := tryMoveCandidates(world, aiEntity, aiGrid, candidates); ok {
+		return b
 	}
 
 	return rp.planRandomMoveAction(world, aiEntity, aiGrid)
 }
 
-func (rp *soloPlanner) planRandomMoveAction(world w.World, aiEntity ecs.Entity, aiGrid *gc.GridElement) (activity.Behavior, activity.ActionParams) {
+func (rp *soloPlanner) planRandomMoveAction(world w.World, aiEntity ecs.Entity, aiGrid *gc.GridElement) activity.Behavior {
 	if rp.rng.Float64() < 0.3 {
-		return waitAction(aiEntity, "AIランダム待機")
+		return waitAction("AIランダム待機")
 	}
 
 	from := consts.Coord[int]{X: int(aiGrid.X), Y: int(aiGrid.Y)}
 	for _, d := range shuffledEightDirections(rp.rng) {
 		dest := consts.Coord[int]{X: from.X + d.X, Y: from.Y + d.Y}
 		if activity.CanMoveTo(world, dest, from, aiEntity) {
-			return moveAction(aiEntity, dest)
+			return moveAction(dest)
 		}
 	}
 
-	return waitAction(aiEntity, "AIランダム移動失敗")
+	return waitAction("AIランダム移動失敗")
 }
 
-func (rp *soloPlanner) planDrivingAction(world w.World, aiEntity ecs.Entity, solo *gc.SoloAI, grid *gc.GridElement) (activity.Behavior, activity.ActionParams) {
+func (rp *soloPlanner) planDrivingAction(world w.World, aiEntity ecs.Entity, solo *gc.SoloAI, grid *gc.GridElement) activity.Behavior {
 	switch solo.Movement {
 	case gc.SoloStationary:
-		return waitAction(aiEntity, "AI固定待機")
+		return waitAction("AI固定待機")
 	case gc.SoloWander:
 		return rp.planWanderAction(world, aiEntity, grid)
 	case gc.SoloWallHug:
@@ -245,16 +242,16 @@ func (rp *soloPlanner) planDrivingAction(world w.World, aiEntity ecs.Entity, sol
 	}
 }
 
-func (rp *soloPlanner) planWanderAction(world w.World, aiEntity ecs.Entity, aiGrid *gc.GridElement) (activity.Behavior, activity.ActionParams) {
+func (rp *soloPlanner) planWanderAction(world w.World, aiEntity ecs.Entity, aiGrid *gc.GridElement) activity.Behavior {
 	if rp.rng.Float64() < 0.8 {
-		return waitAction(aiEntity, "AI徘徊待機")
+		return waitAction("AI徘徊待機")
 	}
 	return rp.planRandomMoveAction(world, aiEntity, aiGrid)
 }
 
-func (rp *soloPlanner) planWallHugAction(world w.World, aiEntity ecs.Entity, aiGrid *gc.GridElement) (activity.Behavior, activity.ActionParams) {
+func (rp *soloPlanner) planWallHugAction(world w.World, aiEntity ecs.Entity, aiGrid *gc.GridElement) activity.Behavior {
 	if rp.rng.Float64() < 0.3 {
-		return waitAction(aiEntity, "AI壁沿い待機")
+		return waitAction("AI壁沿い待機")
 	}
 
 	si := query.GetSpatialIndex(world)
@@ -283,7 +280,7 @@ func (rp *soloPlanner) planWallHugAction(world w.World, aiEntity ecs.Entity, aiG
 	}
 
 	if len(candidates) == 0 {
-		return waitAction(aiEntity, "AI壁沿い移動失敗")
+		return waitAction("AI壁沿い移動失敗")
 	}
 
 	best := candidates[0].score
@@ -300,10 +297,10 @@ func (rp *soloPlanner) planWallHugAction(world w.World, aiEntity ecs.Entity, aiG
 	}
 	chosen := tied[rp.rng.IntN(len(tied))]
 
-	return moveAction(aiEntity, consts.Coord[int]{X: from.X + chosen.X, Y: from.Y + chosen.Y})
+	return moveAction(consts.Coord[int]{X: from.X + chosen.X, Y: from.Y + chosen.Y})
 }
 
-func (rp *soloPlanner) planSwarmAction(world w.World, aiEntity ecs.Entity, aiGrid *gc.GridElement) (activity.Behavior, activity.ActionParams) {
+func (rp *soloPlanner) planSwarmAction(world w.World, aiEntity ecs.Entity, aiGrid *gc.GridElement) activity.Behavior {
 	_, nearestGrid, nearestDist := query.FindNearestEntity(world, aiEntity, aiGrid, func(entity ecs.Entity) bool {
 		return entity.HasComponent(world.Components.AI)
 	})
@@ -316,19 +313,19 @@ func (rp *soloPlanner) planSwarmAction(world w.World, aiEntity ecs.Entity, aiGri
 	dy := int(nearestGrid.Y) - int(aiGrid.Y)
 
 	candidates := calculateMoveCandidates(consts.Coord[int]{X: dx, Y: dy})
-	if b, p, ok := tryMoveCandidates(world, aiEntity, aiGrid, candidates); ok {
-		return b, p
+	if b, ok := tryMoveCandidates(world, aiEntity, aiGrid, candidates); ok {
+		return b
 	}
 
 	return rp.planRandomMoveAction(world, aiEntity, aiGrid)
 }
 
-func (rp *soloPlanner) planPatrolAction(world w.World, aiEntity ecs.Entity, solo *gc.SoloAI, grid *gc.GridElement) (activity.Behavior, activity.ActionParams) {
+func (rp *soloPlanner) planPatrolAction(world w.World, aiEntity ecs.Entity, solo *gc.SoloAI, grid *gc.GridElement) activity.Behavior {
 	from := consts.Coord[int]{X: int(grid.X), Y: int(grid.Y)}
 
 	dest := consts.Coord[int]{X: from.X + solo.PatrolDirX, Y: from.Y + solo.PatrolDirY}
 	if activity.CanMoveTo(world, dest, from, aiEntity) {
-		return moveAction(aiEntity, dest)
+		return moveAction(dest)
 	}
 
 	solo.PatrolDirX = -solo.PatrolDirX
@@ -336,13 +333,13 @@ func (rp *soloPlanner) planPatrolAction(world w.World, aiEntity ecs.Entity, solo
 
 	dest = consts.Coord[int]{X: from.X + solo.PatrolDirX, Y: from.Y + solo.PatrolDirY}
 	if activity.CanMoveTo(world, dest, from, aiEntity) {
-		return moveAction(aiEntity, dest)
+		return moveAction(dest)
 	}
 
-	return waitAction(aiEntity, "AI巡回移動失敗")
+	return waitAction("AI巡回移動失敗")
 }
 
-func (rp *soloPlanner) planTerritorialAction(world w.World, aiEntity ecs.Entity, solo *gc.SoloAI, grid *gc.GridElement) (activity.Behavior, activity.ActionParams) {
+func (rp *soloPlanner) planTerritorialAction(world w.World, aiEntity ecs.Entity, solo *gc.SoloAI, grid *gc.GridElement) activity.Behavior {
 	from := consts.Coord[int]{X: int(grid.X), Y: int(grid.Y)}
 
 	for _, d := range shuffledEightDirections(rp.rng) {
@@ -355,9 +352,9 @@ func (rp *soloPlanner) planTerritorialAction(world w.World, aiEntity ecs.Entity,
 		}
 
 		if activity.CanMoveTo(world, dest, from, aiEntity) {
-			return moveAction(aiEntity, dest)
+			return moveAction(dest)
 		}
 	}
 
-	return waitAction(aiEntity, "AI縄張り移動失敗")
+	return waitAction("AI縄張り移動失敗")
 }

--- a/internal/aiinput/planner_squad.go
+++ b/internal/aiinput/planner_squad.go
@@ -47,10 +47,10 @@ type squadContext struct {
 }
 
 // Plan はsquadContextを収集し、優先度チェーンで行動を決定する
-func (sp *squadPlanner) Plan(world w.World, entity ecs.Entity) (activity.Behavior, activity.ActionParams) {
+func (sp *squadPlanner) Plan(world w.World, entity ecs.Entity) activity.Behavior {
 	ctx, ok := sp.gatherSquadContext(world, entity)
 	if !ok {
-		return nil, activity.ActionParams{}
+		return nil
 	}
 	return sp.planAction(world, entity, ctx)
 }
@@ -87,29 +87,29 @@ func (sp *squadPlanner) gatherSquadContext(world w.World, entity ecs.Entity) (*s
 
 // planAction はポリシーと状況に基づいてアクションを決定する。
 // 優先順位: HP低下時後退 → エリア制限 → 戦闘 → アイテム転送 → アイテム拾得 → 位置ポリシー
-func (sp *squadPlanner) planAction(world w.World, entity ecs.Entity, ctx *squadContext) (activity.Behavior, activity.ActionParams) {
+func (sp *squadPlanner) planAction(world w.World, entity ecs.Entity, ctx *squadContext) activity.Behavior {
 	if sp.shouldRetreatLowHP(world, entity) {
-		if b, p, ok := sp.planRetreatAction(world, entity, ctx); ok {
-			return b, p
+		if b, ok := sp.planRetreatAction(world, entity, ctx); ok {
+			return b
 		}
 	}
 
 	if sp.isOutsideExploredArea(world, ctx.Grid) {
-		if b, p, ok := sp.planReturnToExploredArea(world, entity, ctx); ok {
-			return b, p
+		if b, ok := sp.planReturnToExploredArea(world, entity, ctx); ok {
+			return b
 		}
 	}
 
-	if b, p, ok := sp.planCombatAction(world, entity, ctx); ok {
-		return b, p
+	if b, ok := sp.planCombatAction(world, entity, ctx); ok {
+		return b
 	}
 
-	if b, p, ok := sp.planItemHandlingAction(world, entity, ctx); ok {
-		return b, p
+	if b, ok := sp.planItemHandlingAction(world, entity, ctx); ok {
+		return b
 	}
 
-	if b, p, ok := sp.planItemPickupAction(world, entity, ctx); ok {
-		return b, p
+	if b, ok := sp.planItemPickupAction(world, entity, ctx); ok {
+		return b
 	}
 
 	return sp.planPositionAction(world, entity, ctx)
@@ -129,7 +129,7 @@ func (sp *squadPlanner) shouldRetreatLowHP(world w.World, entity ecs.Entity) boo
 }
 
 // planRetreatAction はリーダーに向かって後退するアクションを計画する
-func (sp *squadPlanner) planRetreatAction(world w.World, entity ecs.Entity, ctx *squadContext) (activity.Behavior, activity.ActionParams, bool) {
+func (sp *squadPlanner) planRetreatAction(world w.World, entity ecs.Entity, ctx *squadContext) (activity.Behavior, bool) {
 	sp.logger.Debug("隊員HP低下、後退", "entity", entity)
 	return sp.tryMoveToward(world, entity, ctx.Grid, ctx.LeaderGrid)
 }
@@ -144,38 +144,34 @@ func (sp *squadPlanner) isOutsideExploredArea(world w.World, grid *gc.GridElemen
 }
 
 // planReturnToExploredArea は最寄りの探索済みマスへ移動するアクションを計画する
-func (sp *squadPlanner) planReturnToExploredArea(world w.World, entity ecs.Entity, ctx *squadContext) (activity.Behavior, activity.ActionParams, bool) {
+func (sp *squadPlanner) planReturnToExploredArea(world w.World, entity ecs.Entity, ctx *squadContext) (activity.Behavior, bool) {
 	sp.logger.Debug("隊員がエリア外、リーダーに向かう", "entity", entity)
 	return sp.tryMoveToward(world, entity, ctx.Grid, ctx.LeaderGrid)
 }
 
 // planCombatAction は戦闘ポリシーに基づくアクションを計画する
-func (sp *squadPlanner) planCombatAction(world w.World, entity ecs.Entity, ctx *squadContext) (activity.Behavior, activity.ActionParams, bool) {
+func (sp *squadPlanner) planCombatAction(world w.World, entity ecs.Entity, ctx *squadContext) (activity.Behavior, bool) {
 	switch ctx.Squad.CombatCurrent {
 	case gc.CombatAttack:
 		return sp.planAttackAction(world, entity, ctx)
 	case gc.CombatEvade:
 		return sp.planEvadeAction(world, entity, ctx)
 	default:
-		return nil, activity.ActionParams{}, false
+		return nil, false
 	}
 }
 
 // planAttackAction は攻撃ポリシーに基づくアクションを計画する。
 // 隣接する敵がいれば攻撃し、視界内の敵がいれば接近する。
 // 移動しても敵に近づけない場合は諦めて次の優先度に進む
-func (sp *squadPlanner) planAttackAction(world w.World, entity ecs.Entity, ctx *squadContext) (activity.Behavior, activity.ActionParams, bool) {
+func (sp *squadPlanner) planAttackAction(world w.World, entity ecs.Entity, ctx *squadContext) (activity.Behavior, bool) {
 	nearestEnemy, nearestGrid, dist := sp.findNearestEnemy(world, entity, ctx)
 	if nearestEnemy == nil {
-		return nil, activity.ActionParams{}, false
+		return nil, false
 	}
 
 	if dist == 1 {
-		target := *nearestEnemy
-		return &activity.AttackActivity{}, activity.ActionParams{
-			Actor:  entity,
-			Target: &target,
-		}, true
+		return &activity.AttackActivity{Target: *nearestEnemy}, true
 	}
 
 	return sp.tryMoveToward(world, entity, ctx.Grid, nearestGrid)
@@ -183,10 +179,10 @@ func (sp *squadPlanner) planAttackAction(world w.World, entity ecs.Entity, ctx *
 
 // planEvadeAction は回避ポリシーに基づくアクションを計画する。
 // 視界内の最寄りの敵から距離を取る
-func (sp *squadPlanner) planEvadeAction(world w.World, entity ecs.Entity, ctx *squadContext) (activity.Behavior, activity.ActionParams, bool) {
+func (sp *squadPlanner) planEvadeAction(world w.World, entity ecs.Entity, ctx *squadContext) (activity.Behavior, bool) {
 	nearestEnemy, _, _ := sp.findNearestEnemy(world, entity, ctx)
 	if nearestEnemy == nil {
-		return nil, activity.ActionParams{}, false
+		return nil, false
 	}
 
 	enemyGrid := world.Components.GridElement.Get(*nearestEnemy).(*gc.GridElement)
@@ -194,7 +190,7 @@ func (sp *squadPlanner) planEvadeAction(world w.World, entity ecs.Entity, ctx *s
 }
 
 // planPositionAction は位置ポリシーに基づくアクションを計画する
-func (sp *squadPlanner) planPositionAction(world w.World, entity ecs.Entity, ctx *squadContext) (activity.Behavior, activity.ActionParams) {
+func (sp *squadPlanner) planPositionAction(world w.World, entity ecs.Entity, ctx *squadContext) activity.Behavior {
 	switch ctx.Squad.Movement {
 	case gc.SquadEscort:
 		return sp.planEscortAction(world, entity, ctx)
@@ -203,56 +199,56 @@ func (sp *squadPlanner) planPositionAction(world w.World, entity ecs.Entity, ctx
 	case gc.SquadPatrol:
 		return sp.planSquadPatrolAction(world, entity, ctx)
 	case gc.SquadStationary:
-		return waitAction(entity, "隊員待機")
+		return waitAction("隊員待機")
 	case gc.SquadRetreat:
 		return sp.planEscortAction(world, entity, ctx)
 	default:
-		return waitAction(entity, "隊員デフォルト待機")
+		return waitAction("隊員デフォルト待機")
 	}
 }
 
 // planEscortAction はリーダーから2マス以内にとどまるアクションを計画する
-func (sp *squadPlanner) planEscortAction(world w.World, entity ecs.Entity, ctx *squadContext) (activity.Behavior, activity.ActionParams) {
+func (sp *squadPlanner) planEscortAction(world w.World, entity ecs.Entity, ctx *squadContext) activity.Behavior {
 	dist := gridDistance(ctx.Grid, ctx.LeaderGrid)
 	if dist <= escortMaxDistance {
-		return waitAction(entity, "隊員護衛位置")
+		return waitAction("隊員護衛位置")
 	}
-	if b, p, ok := sp.tryMoveToward(world, entity, ctx.Grid, ctx.LeaderGrid); ok {
-		return b, p
+	if b, ok := sp.tryMoveToward(world, entity, ctx.Grid, ctx.LeaderGrid); ok {
+		return b
 	}
-	return waitAction(entity, "隊員護衛移動失敗")
+	return waitAction("隊員護衛移動失敗")
 }
 
 // planVanguardAction はリーダーの前方に展開するアクションを計画する。
 // リーダーから離れすぎている場合はリーダーに接近する
-func (sp *squadPlanner) planVanguardAction(world w.World, entity ecs.Entity, ctx *squadContext) (activity.Behavior, activity.ActionParams) {
+func (sp *squadPlanner) planVanguardAction(world w.World, entity ecs.Entity, ctx *squadContext) activity.Behavior {
 	dist := gridDistance(ctx.Grid, ctx.LeaderGrid)
 	if dist > vanguardMaxDistance {
-		if b, p, ok := sp.tryMoveToward(world, entity, ctx.Grid, ctx.LeaderGrid); ok {
-			return b, p
+		if b, ok := sp.tryMoveToward(world, entity, ctx.Grid, ctx.LeaderGrid); ok {
+			return b
 		}
-		return waitAction(entity, "隊員前衛接近失敗")
+		return waitAction("隊員前衛接近失敗")
 	}
-	if b, p, ok := sp.tryRandomMove(world, entity, ctx); ok {
-		return b, p
+	if b, ok := sp.tryRandomMove(world, entity, ctx); ok {
+		return b
 	}
-	return waitAction(entity, "隊員前衛移動失敗")
+	return waitAction("隊員前衛移動失敗")
 }
 
 // planSquadPatrolAction は探索済みエリア内を自律的に巡回するアクションを計画する
-func (sp *squadPlanner) planSquadPatrolAction(world w.World, entity ecs.Entity, ctx *squadContext) (activity.Behavior, activity.ActionParams) {
-	if b, p, ok := sp.tryRandomMove(world, entity, ctx); ok {
-		return b, p
+func (sp *squadPlanner) planSquadPatrolAction(world w.World, entity ecs.Entity, ctx *squadContext) activity.Behavior {
+	if b, ok := sp.tryRandomMove(world, entity, ctx); ok {
+		return b
 	}
-	return waitAction(entity, "隊員巡回移動失敗")
+	return waitAction("隊員巡回移動失敗")
 }
 
 // planItemPickupAction は拾得可能アイテムを拾うアクションを計画する。
 // 足元にアイテムがあれば拾い、なければ視界内のアイテムに向かって移動する。
 // PolicyIgnoreの場合は何もしない
-func (sp *squadPlanner) planItemPickupAction(world w.World, entity ecs.Entity, ctx *squadContext) (activity.Behavior, activity.ActionParams, bool) {
+func (sp *squadPlanner) planItemPickupAction(world w.World, entity ecs.Entity, ctx *squadContext) (activity.Behavior, bool) {
 	if ctx.Squad.ItemPickup == gc.PolicyIgnore {
-		return nil, activity.ActionParams{}, false
+		return nil, false
 	}
 
 	hasPickableHere := false
@@ -286,10 +282,7 @@ func (sp *squadPlanner) planItemPickupAction(world w.World, entity ecs.Entity, c
 	if hasPickableHere {
 		sp.logger.Debug("隊員アイテム拾得", "entity", entity, "x", ctx.Grid.X, "y", ctx.Grid.Y)
 		dest := *ctx.Grid
-		return &activity.PickupActivity{}, activity.ActionParams{
-			Actor:       entity,
-			Destination: &dest,
-		}, true
+		return &activity.PickupActivity{Destination: &dest}, true
 	}
 
 	if nearestItemGrid != nil {
@@ -297,19 +290,19 @@ func (sp *squadPlanner) planItemPickupAction(world w.World, entity ecs.Entity, c
 		return sp.tryMoveToward(world, entity, ctx.Grid, nearestItemGrid)
 	}
 
-	return nil, activity.ActionParams{}, false
+	return nil, false
 }
 
 // planItemHandlingAction はバックパック内のアイテムをポリシーに基づいて処理する。
 // PolicyDistributeの場合はリーダーにアイテムを転送する
-func (sp *squadPlanner) planItemHandlingAction(world w.World, entity ecs.Entity, ctx *squadContext) (activity.Behavior, activity.ActionParams, bool) {
+func (sp *squadPlanner) planItemHandlingAction(world w.World, entity ecs.Entity, ctx *squadContext) (activity.Behavior, bool) {
 	if ctx.Squad.ItemHandling != gc.PolicyDistribute {
-		return nil, activity.ActionParams{}, false
+		return nil, false
 	}
 
 	dist := gridDistance(ctx.Grid, ctx.LeaderGrid)
 	if dist > 1 {
-		return nil, activity.ActionParams{}, false
+		return nil, false
 	}
 
 	var itemToTransfer *ecs.Entity
@@ -327,16 +320,11 @@ func (sp *squadPlanner) planItemHandlingAction(world w.World, entity ecs.Entity,
 	}))
 
 	if itemToTransfer == nil {
-		return nil, activity.ActionParams{}, false
+		return nil, false
 	}
 
 	sp.logger.Debug("隊員アイテム転送", "entity", entity, "item", *itemToTransfer)
-	leader := ctx.LeaderEntity
-	return &activity.TransferActivity{}, activity.ActionParams{
-		Actor:     entity,
-		Target:    itemToTransfer,
-		Recipient: &leader,
-	}, true
+	return &activity.TransferActivity{Target: *itemToTransfer, Recipient: ctx.LeaderEntity}, true
 }
 
 // findNearestEnemy は視界内の最も近い敵を探す
@@ -348,26 +336,25 @@ func (sp *squadPlanner) findNearestEnemy(world w.World, entity ecs.Entity, ctx *
 }
 
 // tryMoveToward はBFSで壁を迂回した最短経路でターゲットに向かう移動を試みる
-func (sp *squadPlanner) tryMoveToward(world w.World, entity ecs.Entity, from, target *gc.GridElement) (activity.Behavior, activity.ActionParams, bool) {
+func (sp *squadPlanner) tryMoveToward(world w.World, entity ecs.Entity, from, target *gc.GridElement) (activity.Behavior, bool) {
 	fromPos := consts.Coord[int]{X: int(from.X), Y: int(from.Y)}
 	goalX, goalY := int(target.X), int(target.Y)
 
 	nextX, nextY, ok := activity.FindNextStep(world, entity, fromPos.X, fromPos.Y, goalX, goalY)
 	if !ok {
-		return nil, activity.ActionParams{}, false
+		return nil, false
 	}
 
 	next := consts.Coord[int]{X: nextX, Y: nextY}
 	if !activity.CanMoveTo(world, next, fromPos, entity) {
-		return nil, activity.ActionParams{}, false
+		return nil, false
 	}
 
-	b, p := moveAction(entity, next)
-	return b, p, true
+	return moveAction(next), true
 }
 
 // tryMoveAway はターゲットから離れる移動を試みる
-func (sp *squadPlanner) tryMoveAway(world w.World, entity ecs.Entity, from, threat *gc.GridElement) (activity.Behavior, activity.ActionParams, bool) {
+func (sp *squadPlanner) tryMoveAway(world w.World, entity ecs.Entity, from, threat *gc.GridElement) (activity.Behavior, bool) {
 	dx := int(from.X) - int(threat.X)
 	dy := int(from.Y) - int(threat.Y)
 
@@ -376,7 +363,7 @@ func (sp *squadPlanner) tryMoveAway(world w.World, entity ecs.Entity, from, thre
 }
 
 // tryRandomMove は探索済みエリア内でランダム移動を試みる
-func (sp *squadPlanner) tryRandomMove(world w.World, entity ecs.Entity, ctx *squadContext) (activity.Behavior, activity.ActionParams, bool) {
+func (sp *squadPlanner) tryRandomMove(world w.World, entity ecs.Entity, ctx *squadContext) (activity.Behavior, bool) {
 	dungeon := query.GetDungeon(world)
 	from := consts.Coord[int]{X: int(ctx.Grid.X), Y: int(ctx.Grid.Y)}
 
@@ -391,9 +378,8 @@ func (sp *squadPlanner) tryRandomMove(world w.World, entity ecs.Entity, ctx *squ
 		}
 
 		if activity.CanMoveTo(world, dest, from, entity) {
-			b, p := moveAction(entity, dest)
-			return b, p, true
+			return moveAction(dest), true
 		}
 	}
-	return nil, activity.ActionParams{}, false
+	return nil, false
 }

--- a/internal/aiinput/squad_processor_test.go
+++ b/internal/aiinput/squad_processor_test.go
@@ -3,6 +3,7 @@ package aiinput
 import (
 	"testing"
 
+	"github.com/kijimaD/ruins/internal/activity"
 	gc "github.com/kijimaD/ruins/internal/components"
 	"github.com/kijimaD/ruins/internal/consts"
 	"github.com/kijimaD/ruins/internal/testutil"
@@ -144,7 +145,7 @@ func TestPlanItemPickupAction(t *testing.T) {
 			LeaderGrid:   world.Components.GridElement.Get(leader).(*gc.GridElement),
 		}
 
-		b, _, ok := sp.planItemPickupAction(world, member, ctx)
+		b, ok := sp.planItemPickupAction(world, member, ctx)
 		assert.True(t, ok, "拾得アクションが返る")
 		assert.NotNil(t, b)
 	})
@@ -172,7 +173,7 @@ func TestPlanItemPickupAction(t *testing.T) {
 			LeaderGrid:   world.Components.GridElement.Get(leader).(*gc.GridElement),
 		}
 
-		_, _, ok := sp.planItemPickupAction(world, member, ctx)
+		_, ok := sp.planItemPickupAction(world, member, ctx)
 		assert.False(t, ok, "PolicyIgnoreでは拾得しない")
 	})
 
@@ -196,7 +197,7 @@ func TestPlanItemPickupAction(t *testing.T) {
 			LeaderGrid:   world.Components.GridElement.Get(leader).(*gc.GridElement),
 		}
 
-		_, _, ok := sp.planItemPickupAction(world, member, ctx)
+		_, ok := sp.planItemPickupAction(world, member, ctx)
 		assert.False(t, ok, "アイテムがなければ何もしない")
 	})
 
@@ -223,7 +224,7 @@ func TestPlanItemPickupAction(t *testing.T) {
 			LeaderGrid:   world.Components.GridElement.Get(leader).(*gc.GridElement),
 		}
 
-		_, _, ok := sp.planItemPickupAction(world, member, ctx)
+		_, ok := sp.planItemPickupAction(world, member, ctx)
 		assert.False(t, ok, "視界外のアイテムには反応しない")
 	})
 }
@@ -257,10 +258,11 @@ func TestPlanItemHandlingAction(t *testing.T) {
 			LeaderGrid:   leaderGrid,
 		}
 
-		b, p, ok := sp.planItemHandlingAction(world, member, ctx)
+		b, ok := sp.planItemHandlingAction(world, member, ctx)
 		assert.True(t, ok, "転送アクションが返る")
 		assert.NotNil(t, b)
-		assert.NotNil(t, p.Target)
+		transfer := b.(*activity.TransferActivity)
+		assert.NotZero(t, transfer.Target)
 	})
 
 	t.Run("PolicyKeepではアイテムがあっても転送しない", func(t *testing.T) {
@@ -289,7 +291,7 @@ func TestPlanItemHandlingAction(t *testing.T) {
 			LeaderGrid:   leaderGrid,
 		}
 
-		_, _, ok := sp.planItemHandlingAction(world, member, ctx)
+		_, ok := sp.planItemHandlingAction(world, member, ctx)
 		assert.False(t, ok, "PolicyKeepでは転送しない")
 	})
 
@@ -322,7 +324,7 @@ func TestPlanItemHandlingAction(t *testing.T) {
 			LeaderGrid:   leaderGrid,
 		}
 
-		_, _, ok := sp.planItemHandlingAction(world, member, ctx)
+		_, ok := sp.planItemHandlingAction(world, member, ctx)
 		assert.False(t, ok, "離れているときは転送しない")
 	})
 
@@ -347,7 +349,7 @@ func TestPlanItemHandlingAction(t *testing.T) {
 			LeaderGrid:   leaderGrid,
 		}
 
-		_, _, ok := sp.planItemHandlingAction(world, member, ctx)
+		_, ok := sp.planItemHandlingAction(world, member, ctx)
 		assert.False(t, ok, "バックパックが空なら転送しない")
 	})
 }

--- a/internal/states/inventory_menu.go
+++ b/internal/states/inventory_menu.go
@@ -548,11 +548,7 @@ func (st *InventoryMenuState) executeActionItem(world w.World) error {
 			return err
 		}
 
-		params := activity.ActionParams{
-			Actor:  playerEntity,
-			Target: &entity,
-		}
-		_, err = activity.Execute(&activity.UseItemActivity{}, params, world)
+		_, err = activity.Execute(&activity.UseItemActivity{Target: entity}, playerEntity, world)
 		if err != nil {
 			st.subState = invSubStateMenu
 			return err
@@ -572,12 +568,7 @@ func (st *InventoryMenuState) executeActionItem(world w.World) error {
 		if remaining <= 0 {
 			remaining = 1
 		}
-		params := activity.ActionParams{
-			Actor:    playerEntity,
-			Target:   &entity,
-			Duration: remaining,
-		}
-		_, err = activity.Execute(&activity.ReadActivity{}, params, world)
+		_, err = activity.Execute(&activity.ReadActivity{Target: entity, Duration: remaining}, playerEntity, world)
 		if err != nil {
 			st.subState = invSubStateMenu
 			return err
@@ -593,12 +584,7 @@ func (st *InventoryMenuState) executeActionItem(world w.World) error {
 
 		playerGrid := world.Components.GridElement.Get(playerEntity).(*gc.GridElement)
 		destination := gc.GridElement{X: playerGrid.X, Y: playerGrid.Y}
-		params := activity.ActionParams{
-			Actor:       playerEntity,
-			Target:      &entity,
-			Destination: &destination,
-		}
-		_, err = activity.Execute(&activity.DropActivity{}, params, world)
+		_, err = activity.Execute(&activity.DropActivity{Target: entity, Destination: destination}, playerEntity, world)
 		if err != nil {
 			st.subState = invSubStateMenu
 			return err

--- a/internal/states/pickup_state.go
+++ b/internal/states/pickup_state.go
@@ -156,11 +156,7 @@ func (st *PickupState) executePickup(world w.World) error {
 	}
 
 	destination := gc.GridElement{X: st.cursor.X, Y: st.cursor.Y}
-	params := activity.ActionParams{
-		Actor:       playerEntity,
-		Destination: &destination,
-	}
-	_, err = activity.Execute(&activity.PickupActivity{}, params, world)
+	_, err = activity.Execute(&activity.PickupActivity{Destination: &destination}, playerEntity, world)
 	return err
 }
 

--- a/internal/states/place_state.go
+++ b/internal/states/place_state.go
@@ -205,12 +205,7 @@ func (st *PlaceState) executeDrop(world w.World) error {
 
 	item := st.backpackItems[st.selectedIndex]
 	destination := gc.GridElement{X: st.cursor.X, Y: st.cursor.Y}
-	params := activity.ActionParams{
-		Actor:       playerEntity,
-		Target:      &item,
-		Destination: &destination,
-	}
-	_, err = activity.Execute(&activity.DropActivity{}, params, world)
+	_, err = activity.Execute(&activity.DropActivity{Target: item, Destination: destination}, playerEntity, world)
 	return err
 }
 


### PR DESCRIPTION
共用のActionParams構造体ではどのアクションがどのフィールドを使うか不明瞭だったため、各Behavior構造体にアクション固有のフィールドを移動した。
Executeのシグネチャ変更、Plannerの返り値簡素化、BuildActivityメソッド追加。