### PR TITLE
fix(states): 共有グローバル画像の data race を解消しフレーキーテストを直す

### DIFF
--- a/internal/states/dungeon.go
+++ b/internal/states/dungeon.go
@@ -26,14 +26,12 @@ import (
 	"github.com/mlange-42/ark/ecs"
 )
 
-var (
-	baseImage *ebiten.Image // 一番下にある黒背景
-)
-
 // DungeonState はダンジョン探索中のゲームステート
 type DungeonState struct {
 	es.BaseState[w.World]
-	Depth int
+	// baseImage は下に敷く背景
+	baseImage *ebiten.Image
+	Depth     int
 	// BuilderType は使用するマップビルダーのタイプ（BuilderTypeRandom の場合はランダム選択）
 	BuilderType mapplanner.PlannerType
 	// DefinitionName はダンジョン定義名。設定されていればOnStartでリソースに反映する
@@ -63,8 +61,8 @@ func (st *DungeonState) OnStart(world w.World) error {
 	screenWidth := world.Resources.ScreenDimensions.Width
 	screenHeight := world.Resources.ScreenDimensions.Height
 	if screenWidth > 0 && screenHeight > 0 {
-		baseImage = ebiten.NewImage(screenWidth, screenHeight)
-		baseImage.Fill(theme.ScreenBackground)
+		st.baseImage = ebiten.NewImage(screenWidth, screenHeight)
+		st.baseImage.Fill(theme.ScreenBackground)
 	}
 
 	query.GetDungeon(world).Depth = st.Depth
@@ -242,7 +240,9 @@ func (st *DungeonState) Update(world w.World) (es.Transition[w.World], error) {
 
 // Draw はゲームステートの描画処理を行う
 func (st *DungeonState) Draw(world w.World, screen *ebiten.Image) error {
-	screen.DrawImage(baseImage, nil)
+	if st.baseImage != nil {
+		screen.DrawImage(st.baseImage, nil)
+	}
 
 	for _, renderer := range []w.Renderer{
 		&gs.RenderSpriteSystem{},

--- a/internal/states/look_around.go
+++ b/internal/states/look_around.go
@@ -3,6 +3,7 @@ package states
 import (
 	"fmt"
 	"math"
+	"sync"
 
 	"github.com/hajimehoshi/ebiten/v2"
 	"github.com/hajimehoshi/ebiten/v2/text/v2"
@@ -142,10 +143,12 @@ func (st *LookAroundState) Draw(world w.World, screen *ebiten.Image) error {
 	return st.drawInfoPanel(world, screen)
 }
 
-// 画像キャッシュ
+// 画像キャッシュ。sync.Once で一度だけ初期化する
 var (
-	cursorImageCache *ebiten.Image
-	panelImageCache  *ebiten.Image
+	cursorImageCache     *ebiten.Image
+	cursorImageCacheOnce sync.Once
+	panelImageCache      *ebiten.Image
+	panelImageCacheOnce  sync.Once
 )
 
 // drawCursor はカーソルを描画する
@@ -155,7 +158,7 @@ func (st *LookAroundState) drawCursor(world w.World, screen *ebiten.Image) {
 	cursorPixelY := float64(int(st.cursor.Y) * tileSize)
 
 	// カーソル画像をキャッシュから取得または作成
-	if cursorImageCache == nil {
+	cursorImageCacheOnce.Do(func() {
 		cursorImageCache = ebiten.NewImage(tileSize, tileSize)
 		// 枠線を描画（太さ3px、白色で目立つように）
 		cursorColor := theme.CursorLook
@@ -177,7 +180,7 @@ func (st *LookAroundState) drawCursor(world w.World, screen *ebiten.Image) {
 				cursorImageCache.Set(tileSize-1-i, y, cursorColor)
 			}
 		}
-	}
+	})
 
 	op := &ebiten.DrawImageOptions{}
 	op.GeoM.Translate(cursorPixelX, cursorPixelY)
@@ -205,10 +208,10 @@ func (st *LookAroundState) drawInfoPanel(world w.World, screen *ebiten.Image) er
 	)
 
 	// パネル背景をキャッシュから取得または生成
-	if panelImageCache == nil {
+	panelImageCacheOnce.Do(func() {
 		panelImageCache = ebiten.NewImage(panelWidth, panelHeight)
 		panelImageCache.Fill(theme.Overlay)
-	}
+	})
 
 	panelX := screen.Bounds().Dx() - panelWidth - marginX
 	panelY := marginY

--- a/internal/states/pickup_state.go
+++ b/internal/states/pickup_state.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"image/color"
 	"math"
+	"sync"
 
 	"github.com/hajimehoshi/ebiten/v2"
 	"github.com/hajimehoshi/ebiten/v2/text/v2"
@@ -166,15 +167,18 @@ func (st *PickupState) Draw(world w.World, screen *ebiten.Image) error {
 	return st.drawPickupPanel(world, screen)
 }
 
-// pickupCursorCache はカーソル画像のキャッシュ
-var pickupCursorCache *ebiten.Image
+// pickupCursorCache はカーソル画像のキャッシュ。sync.Once で一度だけ初期化する
+var (
+	pickupCursorCache     *ebiten.Image
+	pickupCursorCacheOnce sync.Once
+)
 
 func (st *PickupState) drawTargetCursor(world w.World, screen *ebiten.Image) {
 	tileSize := int(consts.TileSize)
 	cursorPixelX := float64(int(st.cursor.X) * tileSize)
 	cursorPixelY := float64(int(st.cursor.Y) * tileSize)
 
-	if pickupCursorCache == nil {
+	pickupCursorCacheOnce.Do(func() {
 		pickupCursorCache = ebiten.NewImage(tileSize, tileSize)
 		cursorColor := theme.CursorPickup
 		for i := range 3 {
@@ -187,7 +191,7 @@ func (st *PickupState) drawTargetCursor(world w.World, screen *ebiten.Image) {
 				pickupCursorCache.Set(tileSize-1-i, y, cursorColor)
 			}
 		}
-	}
+	})
 
 	op := &ebiten.DrawImageOptions{}
 	op.GeoM.Translate(cursorPixelX, cursorPixelY)

--- a/internal/states/place_state.go
+++ b/internal/states/place_state.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"image/color"
 	"math"
+	"sync"
 
 	"github.com/hajimehoshi/ebiten/v2"
 	"github.com/hajimehoshi/ebiten/v2/text/v2"
@@ -217,15 +218,18 @@ func (st *PlaceState) Draw(world w.World, screen *ebiten.Image) error {
 	return st.drawPlacePanel(world, screen)
 }
 
-// placeCursorCache はカーソル画像のキャッシュ
-var placeCursorCache *ebiten.Image
+// placeCursorCache はカーソル画像のキャッシュ。sync.Once で一度だけ初期化する
+var (
+	placeCursorCache     *ebiten.Image
+	placeCursorCacheOnce sync.Once
+)
 
 func (st *PlaceState) drawTargetCursor(world w.World, screen *ebiten.Image) {
 	tileSize := int(consts.TileSize)
 	cursorPixelX := float64(int(st.cursor.X) * tileSize)
 	cursorPixelY := float64(int(st.cursor.Y) * tileSize)
 
-	if placeCursorCache == nil {
+	placeCursorCacheOnce.Do(func() {
 		placeCursorCache = ebiten.NewImage(tileSize, tileSize)
 		cursorColor := theme.CursorPlace
 		for i := range 3 {
@@ -238,7 +242,7 @@ func (st *PlaceState) drawTargetCursor(world w.World, screen *ebiten.Image) {
 				placeCursorCache.Set(tileSize-1-i, y, cursorColor)
 			}
 		}
-	}
+	})
 
 	op := &ebiten.DrawImageOptions{}
 	op.GeoM.Translate(cursorPixelX, cursorPixelY)

--- a/internal/states/shooting.go
+++ b/internal/states/shooting.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"math"
 	"sort"
+	"sync"
 
 	"github.com/hajimehoshi/ebiten/v2"
 	"github.com/hajimehoshi/ebiten/v2/text/v2"
@@ -223,8 +224,11 @@ func (st *ShootingState) Draw(world w.World, screen *ebiten.Image) error {
 	return st.drawShootingPanel(world, screen)
 }
 
-// shootingCursorCache はターゲットカーソル画像のキャッシュ
-var shootingCursorCache *ebiten.Image
+// shootingCursorCache はターゲットカーソル画像のキャッシュ。sync.Once で一度だけ初期化する
+var (
+	shootingCursorCache     *ebiten.Image
+	shootingCursorCacheOnce sync.Once
+)
 
 // drawTargetCursor は選択中の敵にカーソルを描画する
 func (st *ShootingState) drawTargetCursor(world w.World, screen *ebiten.Image) {
@@ -238,7 +242,7 @@ func (st *ShootingState) drawTargetCursor(world w.World, screen *ebiten.Image) {
 	cursorPixelX := float64(int(targetGrid.X) * tileSize)
 	cursorPixelY := float64(int(targetGrid.Y) * tileSize)
 
-	if shootingCursorCache == nil {
+	shootingCursorCacheOnce.Do(func() {
 		shootingCursorCache = ebiten.NewImage(tileSize, tileSize)
 		cursorColor := theme.CursorShoot
 		for i := range 3 {
@@ -251,7 +255,7 @@ func (st *ShootingState) drawTargetCursor(world w.World, screen *ebiten.Image) {
 				shootingCursorCache.Set(tileSize-1-i, y, cursorColor)
 			}
 		}
-	}
+	})
 
 	op := &ebiten.DrawImageOptions{}
 	op.GeoM.Translate(cursorPixelX, cursorPixelY)
@@ -265,8 +269,11 @@ func (st *ShootingState) drawTargetCursor(world w.World, screen *ebiten.Image) {
 	screen.DrawImage(shootingCursorCache, op)
 }
 
-// shootingPanelCache は情報パネル画像のキャッシュ
-var shootingPanelCache *ebiten.Image
+// shootingPanelCache は情報パネル画像のキャッシュ。sync.Once で一度だけ初期化する
+var (
+	shootingPanelCache     *ebiten.Image
+	shootingPanelCacheOnce sync.Once
+)
 
 // drawShootingPanel は射撃情報パネルを描画する
 func (st *ShootingState) drawShootingPanel(world w.World, screen *ebiten.Image) error {
@@ -280,10 +287,10 @@ func (st *ShootingState) drawShootingPanel(world w.World, screen *ebiten.Image) 
 		lineHeight  = 20
 	)
 
-	if shootingPanelCache == nil {
+	shootingPanelCacheOnce.Do(func() {
 		shootingPanelCache = ebiten.NewImage(panelWidth, panelHeight)
 		shootingPanelCache.Fill(theme.Overlay)
-	}
+	})
 
 	panelX := screen.Bounds().Dx() - panelWidth - marginX
 	panelY := marginY


### PR DESCRIPTION
## 概要

`make check`（`-race -shuffle`）でのみ再発し、単独実行では通る**フレーキーテスト**の原因を修正する。正体は描画差分ではなく **data race** だった。

## 原因

`baseImage`（`DungeonState` の黒背景）が**パッケージ共有のグローバル変数**で、
- `dungeon_test.go` の直接 `OnStart` 呼び出し
- golden テスト（vrt 経由）の描画（`OnStart` で write / `Draw` で read）

が並行実行され、同じグローバルを read/write して race になっていた。`-shuffle` でテスト順が変わり両者が重なると発火する。

同型のアンチパターン（package-global な `*ebiten.Image` を lazy-init）が、カーソル/パネルのキャッシュ計6箇所にも存在していた（pickup / place / shooting / look_around）。golden がこれらの state も描画するため、並行する専用テストと同じ競合を起こしうる。

## 修正

- `dungeon.go`: `baseImage` をパッケージグローバルから **`DungeonState` のフィールド**へ。各インスタンスが持つので共有されない（元々 `OnStart` ごとに作り直す値なので挙動は不変）。
- pickup / place / shooting / look_around のカーソル・パネルキャッシュ計6箇所を **`sync.Once`** で一度だけ初期化（キャッシュ挙動は維持しつつ thread-safe に）。

## 検証

`go test ./internal/states/ -race -shuffle=on -count=8` が **DATA RACE・FAIL なし**で通過（8回のシャッフル実行すべてクリーン）。build・lint も緑。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012csXVBH36pQzd4dwUqsuTB