### PR TITLE
ci(bench): ベンチ比較を読みやすくしノイズ誤発火を止める

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -112,19 +112,33 @@ jobs:
         run: go install golang.org/x/perf/cmd/benchstat@latest
       - name: run benchmarks (PR and base)
         run: |
-          make bench > pr.txt
-          # ベースに bench ターゲットが無い場合（初回PR等）は比較スキップ扱い
-          make -C _base bench > base.txt 2>/dev/null || true
+          # make -s で make のrecipe echo を抑止し、benchstat が読む go test 出力だけにする
+          make -s bench > pr.txt
+          # ベースにも同じ bench を走らせる。失敗（bench ターゲット無し・ビルドエラー等）は
+          # base.txt 空のまま比較スキップにする。原因を base_err.txt に残す
+          if ! make -s -C _base bench > base.txt 2> base_err.txt; then
+            echo "::warning::base のベンチ取得に失敗しました（比較をスキップします）"
+            sed 's/^/base bench err: /' base_err.txt || true
+          fi
       - name: compare
         id: cmp
         run: |
-          { echo '### ベンチ比較 (base vs PR)'; echo '```'; benchstat base.txt pr.txt || echo '比較を生成できませんでした'; echo '```'; } > cmp.md
+          bad=
+          if grep -q '^Benchmark' base.txt 2>/dev/null; then
+            # base に比較対象のベンチがある → base vs PR を並べて表示
+            { echo '### ベンチ比較 (base vs PR)'; echo '```'; benchstat base.txt pr.txt; echo '```'; } > cmp.md
+            # sec/op が2倍以上のベンチを検出（benchstatの生の平均比で判定。ノイズは2倍に届かない）
+            bad=$(benchstat -format csv base.txt pr.txt 2>/dev/null | awk -F, '
+              $1=="" && $2!="" { metric=$2; next }
+              $1!="" && $1!="geomean" && metric=="sec/op" && ($2+0==$2) && ($4+0==$4) && $2>0 && $4/$2>=2 {
+                printf "- %s: x%.2f\n", $1, $4/$2 }')
+          else
+            # base 側にベンチが無い（初回PR・リネーム・base ビルド失敗等）→ PR のみ表示し比較不可を明示
+            { echo '### ベンチ (PR のみ・base と比較不可)';
+              echo '> base 側に比較対象のベンチが取得できなかったため、今回は PR の数値のみ表示します。';
+              echo '```'; benchstat pr.txt; echo '```'; } > cmp.md
+          fi
           cat cmp.md
-          # sec/op が2倍以上のベンチを検出（benchstatの生の平均比で判定。ノイズは2倍に届かない）
-          bad=$(benchstat -format csv base.txt pr.txt 2>/dev/null | awk -F, '
-            $1=="" && $2!="" { metric=$2; next }
-            $1!="" && $1!="geomean" && metric=="sec/op" && ($2+0==$2) && ($4+0==$4) && $2>0 && $4/$2>=2 {
-              printf "- %s: x%.2f\n", $1, $4/$2 }')
           { echo "bad<<EOF"; echo "$bad"; echo "EOF"; } >> "$GITHUB_OUTPUT"
       - name: sticky comment
         if: always()

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -116,10 +116,13 @@ jobs:
           # PRブランチで bench を実行する
           make bench > pr.txt
           # ベースブランチで bench を実行する。
-          # bench ターゲット無し・ビルドエラー等の失敗はbase.txt 空のまま比較スキップにする。
-          # エラー原因を base_err.txt に残す。
-          if ! make -C _base bench > base.txt 2> base_err.txt; then
+          # -s 必須: -C は top-level でも "make: Entering/Leaving directory" を stdout に出し、
+          # benchstat がそれを "make:" 設定行と誤解釈して base 側ベンチの突き合わせが壊れる。
+          # -s はこのメッセージも recipe echo も両方抑止する（Makefile の @ では -C 由来は消せない）。
+          if ! make -s -C _base bench > base.txt 2> base_err.txt; then
             echo "::warning::base のベンチ取得に失敗しました。比較をスキップします"
+            # bench ターゲット無し・ビルドエラー等の失敗は base.txt 空のまま比較スキップにする。
+            # エラー原因を base_err.txt に残す。
             sed 's/^/base bench err: /' base_err.txt || true
           fi
       - name: compare

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -109,39 +109,40 @@ jobs:
           path: _base
       - uses: ./.github/actions/setup-go-with-x
       - name: install benchstat
-        # バージョンを固定する。@latest だと benchstat の CSV 形式が変わったとき
-        # 下の awk ゲートがサイレントに無効化される恐れがあるため
+        # benchstat の CSV 形式が変わったとき壊れるのでバージョン固定する
         run: go install golang.org/x/perf/cmd/benchstat@v0.0.0-20260709024250-82a0b07e230d
       - name: run benchmarks (PR and base)
         run: |
-          # make -s で make のrecipe echo を抑止し、benchstat が読む go test 出力だけにする
-          make -s bench > pr.txt
-          # ベースにも同じ bench を走らせる。失敗（bench ターゲット無し・ビルドエラー等）は
-          # base.txt 空のまま比較スキップにする。原因を base_err.txt に残す
-          if ! make -s -C _base bench > base.txt 2> base_err.txt; then
-            echo "::warning::base のベンチ取得に失敗しました（比較をスキップします）"
+          # PRブランチで bench を実行する
+          make -bench > pr.txt
+          # ベースブランチで bench を実行する。
+          # bench ターゲット無し・ビルドエラー等の失敗はbase.txt 空のまま比較スキップにする。
+          # エラー原因を base_err.txt に残す。
+          if ! make -C _base bench > base.txt 2> base_err.txt; then
+            echo "::warning::base のベンチ取得に失敗しました。比較をスキップします"
             sed 's/^/base bench err: /' base_err.txt || true
           fi
       - name: compare
         id: cmp
         run: |
-          touch cmp.md # 途中でクラッシュしても sticky comment ステップがファイル無しで失敗しないよう保証
+          # 途中でクラッシュしても sticky comment ステップがファイル無しで失敗しないよう保証する
+          touch cmp.md
           bad=
-          # benchstat -format csv の geomean 行は次の形（pin した版で確認済み）:
+          # benchstat -format csv の geomean 行は次の形:
           #   ,sec/op,CI,sec/op,CI,vs base,P        ← metric ヘッダ行（$1="" $2=metric）
-          #   geomean,<base値>,,<pr値>,,+200.00%,   ← $1=geomean $2=base $4=pr
+          #   geomean,<base値>,,<pr値>,,+200.00%,    ← $1=geomean $2=base $4=pr
           if grep -q '^Benchmark' base.txt 2>/dev/null; then
-            # base に比較対象のベンチがある → base vs PR を並べて表示
+            # base vs PR を並べて表示
             { echo '### ベンチ比較 (base vs PR)'; echo '```'; benchstat base.txt pr.txt; echo '```'; } > cmp.md
             # sec/op の geomean が2倍以上悪化したパッケージを検出する。
-            # 個別ベンチはサンプル数1（CI）だとノイズで簡単に2倍になり誤発火するため、
-            # 集約値の geomean で判定する（geomean が2倍動くには大半のベンチが劣化する必要がある）。
+            # 個別ベンチはサンプル数1だとノイズで簡単に2倍になり誤発火するため、
+            # 集約値の geomean で判定する。 geomean が2倍動くには大半のベンチが劣化する必要がある。
             bad=$(benchstat -format csv base.txt pr.txt 2>/dev/null | awk -F, '
               $1=="" && $2!="" { metric=$2; next }
               $1=="geomean" && metric=="sec/op" && ($2+0==$2) && ($4+0==$4) && $2>0 && $4/$2>=2 {
                 printf "- geomean: x%.2f\n", $4/$2 }')
           else
-            # base 側にベンチが無い（初回PR・リネーム・base ビルド失敗等）→ PR のみ表示し比較不可を明示
+            # base 側にベンチが無い（初回PR・リネーム・base ビルド失敗等）場合、 PR のみ表示し比較不可を明示する
             { echo '### ベンチ (PR のみ・base と比較不可)';
               echo '> base 側に比較対象のベンチが取得できなかったため、今回は PR の数値のみ表示します。';
               echo '```'; benchstat pr.txt; echo '```'; } > cmp.md
@@ -157,7 +158,7 @@ jobs:
       - name: gate on catastrophic regression
         if: steps.cmp.outputs.bad != ''
         run: |
-          echo "::error::ベンチマークが2倍以上悪化しました（詳細はPRコメント参照）"
+          echo "::error::ベンチマークが2倍以上悪化しました。詳細はPRコメント参照"
           exit 1
 
   check-ui:

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -127,11 +127,13 @@ jobs:
           if grep -q '^Benchmark' base.txt 2>/dev/null; then
             # base に比較対象のベンチがある → base vs PR を並べて表示
             { echo '### ベンチ比較 (base vs PR)'; echo '```'; benchstat base.txt pr.txt; echo '```'; } > cmp.md
-            # sec/op が2倍以上のベンチを検出（benchstatの生の平均比で判定。ノイズは2倍に届かない）
+            # sec/op の geomean が2倍以上悪化したパッケージを検出する。
+            # 個別ベンチはサンプル数1（CI）だとノイズで簡単に2倍になり誤発火するため、
+            # 集約値の geomean で判定する（geomean が2倍動くには大半のベンチが劣化する必要がある）。
             bad=$(benchstat -format csv base.txt pr.txt 2>/dev/null | awk -F, '
               $1=="" && $2!="" { metric=$2; next }
-              $1!="" && $1!="geomean" && metric=="sec/op" && ($2+0==$2) && ($4+0==$4) && $2>0 && $4/$2>=2 {
-                printf "- %s: x%.2f\n", $1, $4/$2 }')
+              $1=="geomean" && metric=="sec/op" && ($2+0==$2) && ($4+0==$4) && $2>0 && $4/$2>=2 {
+                printf "- geomean: x%.2f\n", $4/$2 }')
           else
             # base 側にベンチが無い（初回PR・リネーム・base ビルド失敗等）→ PR のみ表示し比較不可を明示
             { echo '### ベンチ (PR のみ・base と比較不可)';

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -109,7 +109,9 @@ jobs:
           path: _base
       - uses: ./.github/actions/setup-go-with-x
       - name: install benchstat
-        run: go install golang.org/x/perf/cmd/benchstat@latest
+        # バージョンを固定する。@latest だと benchstat の CSV 形式が変わったとき
+        # 下の awk ゲートがサイレントに無効化される恐れがあるため
+        run: go install golang.org/x/perf/cmd/benchstat@v0.0.0-20260709024250-82a0b07e230d
       - name: run benchmarks (PR and base)
         run: |
           # make -s で make のrecipe echo を抑止し、benchstat が読む go test 出力だけにする
@@ -123,7 +125,11 @@ jobs:
       - name: compare
         id: cmp
         run: |
+          touch cmp.md # 途中でクラッシュしても sticky comment ステップがファイル無しで失敗しないよう保証
           bad=
+          # benchstat -format csv の geomean 行は次の形（pin した版で確認済み）:
+          #   ,sec/op,CI,sec/op,CI,vs base,P        ← metric ヘッダ行（$1="" $2=metric）
+          #   geomean,<base値>,,<pr値>,,+200.00%,   ← $1=geomean $2=base $4=pr
           if grep -q '^Benchmark' base.txt 2>/dev/null; then
             # base に比較対象のベンチがある → base vs PR を並べて表示
             { echo '### ベンチ比較 (base vs PR)'; echo '```'; benchstat base.txt pr.txt; echo '```'; } > cmp.md

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -114,7 +114,7 @@ jobs:
       - name: run benchmarks (PR and base)
         run: |
           # PRブランチで bench を実行する
-          make -bench > pr.txt
+          make bench > pr.txt
           # ベースブランチで bench を実行する。
           # bench ターゲット無し・ビルドエラー等の失敗はbase.txt 空のまま比較スキップにする。
           # エラー原因を base_err.txt に残す。
@@ -128,12 +128,17 @@ jobs:
           # 途中でクラッシュしても sticky comment ステップがファイル無しで失敗しないよう保証する
           touch cmp.md
           bad=
+          # 実際にベンチを実行した commit を表示する
+          REPO_URL="${{ github.server_url }}/${{ github.repository }}"
+          PR_SHA=$(git rev-parse --short HEAD)
+          BASE_SHA=$(git -C _base rev-parse --short HEAD 2>/dev/null || echo unknown)
+          SHA_LINE="> 実行コミット: base [\`${BASE_SHA}\`](${REPO_URL}/commit/${BASE_SHA}) → PR [\`${PR_SHA}\`](${REPO_URL}/commit/${PR_SHA})"
           # benchstat -format csv の geomean 行は次の形:
           #   ,sec/op,CI,sec/op,CI,vs base,P        ← metric ヘッダ行（$1="" $2=metric）
           #   geomean,<base値>,,<pr値>,,+200.00%,    ← $1=geomean $2=base $4=pr
           if grep -q '^Benchmark' base.txt 2>/dev/null; then
             # base vs PR を並べて表示
-            { echo '### ベンチ比較 (base vs PR)'; echo '```'; benchstat base.txt pr.txt; echo '```'; } > cmp.md
+            { echo '### ベンチ比較 (base vs PR)'; echo "$SHA_LINE"; echo '```'; benchstat base.txt pr.txt; echo '```'; } > cmp.md
             # sec/op の geomean が2倍以上悪化したパッケージを検出する。
             # 個別ベンチはサンプル数1だとノイズで簡単に2倍になり誤発火するため、
             # 集約値の geomean で判定する。 geomean が2倍動くには大半のベンチが劣化する必要がある。
@@ -144,6 +149,7 @@ jobs:
           else
             # base 側にベンチが無い（初回PR・リネーム・base ビルド失敗等）場合、 PR のみ表示し比較不可を明示する
             { echo '### ベンチ (PR のみ・base と比較不可)';
+              echo "$SHA_LINE";
               echo '> base 側に比較対象のベンチが取得できなかったため、今回は PR の数値のみ表示します。';
               echo '```'; benchstat pr.txt; echo '```'; } > cmp.md
           fi

--- a/Makefile
+++ b/Makefile
@@ -30,9 +30,10 @@ updategolden: ## ゴールデンテスト用の基準画像を生成する
 	GOLDIE_UPDATE=1 RUINS_LOG_LEVEL=ignore \
 	$(BWRAP_CMD) xvfb-run -a go test ./... -run Golden -v
 
+# benchstat に読まれるため、コマンド文字列のノイズを混ぜないようにすること
 .PHONY: bench
 bench: ## ベンチマークを全て実行する
-	RUINS_LOG_LEVEL=ignore \
+	@RUINS_LOG_LEVEL=ignore \
 	$(BWRAP_CMD) xvfb-run -a go test -run '^$$' -bench=. -benchmem \
 		$(GO_TEST_PKGS)
 

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,6 @@ updategolden: ## ゴールデンテスト用の基準画像を生成する
 	GOLDIE_UPDATE=1 RUINS_LOG_LEVEL=ignore \
 	$(BWRAP_CMD) xvfb-run -a go test ./... -run Golden -v
 
-# benchstat に読まれるため、コマンド文字列のノイズを混ぜないようにすること
 .PHONY: bench
 bench: ## ベンチマークを全て実行する
 	RUINS_LOG_LEVEL=ignore \

--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ updategolden: ## ゴールデンテスト用の基準画像を生成する
 # benchstat に読まれるため、コマンド文字列のノイズを混ぜないようにすること
 .PHONY: bench
 bench: ## ベンチマークを全て実行する
-	@RUINS_LOG_LEVEL=ignore \
+	RUINS_LOG_LEVEL=ignore \
 	$(BWRAP_CMD) xvfb-run -a go test -run '^$$' -bench=. -benchmem \
 		$(GO_TEST_PKGS)
 

--- a/internal/aiinput/processor_bench_test.go
+++ b/internal/aiinput/processor_bench_test.go
@@ -90,7 +90,7 @@ func BenchmarkProcessAll(b *testing.B) {
 			}
 			b.StopTimer()
 
-			// processed はカリング後に処理される SoloAI 数（比較の文脈）。
+			// processed はカリング後に処理される SoloAI 数。
 			// ms/op は benchstat の sec/op と重複するため出さない
 			b.ReportMetric(float64(len(processed)), "processed")
 		})

--- a/internal/aiinput/processor_bench_test.go
+++ b/internal/aiinput/processor_bench_test.go
@@ -90,8 +90,9 @@ func BenchmarkProcessAll(b *testing.B) {
 			}
 			b.StopTimer()
 
+			// processed はカリング後に処理される SoloAI 数（比較の文脈）。
+			// ms/op は benchstat の sec/op と重複するため出さない
 			b.ReportMetric(float64(len(processed)), "processed")
-			b.ReportMetric(b.Elapsed().Seconds()*1000/float64(b.N), "ms/op")
 		})
 	}
 }


### PR DESCRIPTION
## 概要

PR のベンチ比較コメントが「見にくい・意図どおり比較できない」問題を、CI ログ調査で原因特定して修正する。

## 調査で判明した原因と対応

1. **base 列が出ず比較できていなかった** → 真因は `make bench` が recipe を stdout に echo し、`make: ` の1行が `pr.txt`/`base.txt` の先頭に混入して benchstat の base 解析を壊していた。**`make -s` で recipe echo を抑止**して解決（base vs PR が正しく並ぶ）。

2. **重複テーブルで見にくい** → `ms/op` の ReportMetric が benchstat の `sec/op` と重複（×1000の同じ数字）していた。**`ms/op` を削除**。

3. **ゲートが count=1 のノイズで誤発火** → base 比較が復活したことで顕在化。全ベンチ `~ (p=1.000 n=1)`（1サンプルで有意差なし）なのに、生の2倍比ゲートが単一サンプルのブレで発火していた。**ゲートを個別ベンチ→ sec/op の geomean 判定に変更**（geomean が2倍動くには大半のベンチが劣化する必要があり、単一ベンチのノイズに強い）。実ベンチ出力で benchstat CSV の geomean 行を awk 判定できることを確認済み。

4. base 取得失敗を握り潰さず warning + `base_err.txt` で可視化、base が無いときは「base vs PR」と誤表示せず「PR のみ・比較不可」を明示。

## 補足

シームレスワールド実装 PR (#489) の CI で発覚したが、CI/ベンチツール改善は独立した変更のため別 PR に分離した。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011WK4MFoYM4ZAzgiEhv7YWg