### PR TITLE
refactor: 基準100の倍率型 consts.Percent を導入する

### DIFF
--- a/internal/activity/activity.go
+++ b/internal/activity/activity.go
@@ -188,11 +188,13 @@ func progressHunger(actor ecs.Entity, world w.World) {
 	}
 	hunger := world.Components.Hunger.Get(actor)
 
-	hungerPct := 100
+	// 空腹進行倍率。基準は等倍
+	hungerPct := consts.PercentBase
 	if world.Components.CharModifiers.Has(actor) {
 		hungerPct = world.Components.CharModifiers.Get(actor).HungerProgress
 	}
-	if world.Config.RNG.IntN(100) < hungerPct {
+	// 確率比較なので int で比べる
+	if world.Config.RNG.IntN(int(consts.PercentBase)) < int(hungerPct) {
 		hunger.Decrease(1)
 	}
 }

--- a/internal/activity/activity.go
+++ b/internal/activity/activity.go
@@ -193,7 +193,10 @@ func progressHunger(actor ecs.Entity, world w.World) {
 	if world.Components.CharModifiers.Has(actor) {
 		hungerPct = world.Components.CharModifiers.Get(actor).HungerProgress
 	}
-	// 確率比較なので int で比べる
+	// 確率比較なので int で比べる。
+	// HungerProgress は耐性スキルが高いと 0 以下に達し、空腹が進まなくなる
+	// （IntN(100) < 0 は常に偽）。下限を設けるかは進行系倍率（Hunger/Cold/Heat）
+	// 共通の課題として将来のバランス設計でまとめて検討する。ここでは意図的に下限を置かない。
 	if world.Config.RNG.IntN(int(consts.PercentBase)) < int(hungerPct) {
 		hunger.Decrease(1)
 	}

--- a/internal/activity/attack.go
+++ b/internal/activity/attack.go
@@ -238,19 +238,19 @@ func getAttackParams(attacker ecs.Entity, world w.World) (gc.Attacker, string, e
 // getSkillMult は事前計算済みのスキル倍率(%)を返す。
 // isDamageがtrueならWeaponDamage、falseならWeaponAccuracyを参照する。
 // Effectsコンポーネントを持たないエンティティでは100(等倍)を返す。
-func getSkillMult(entity ecs.Entity, attack gc.Attacker, world w.World, isDamage bool) int {
+func getSkillMult(entity ecs.Entity, attack gc.Attacker, world w.World, isDamage bool) consts.Percent {
 	if attack == nil {
-		return 100
+		return consts.PercentBase
 	}
 	if !world.Components.CharModifiers.Has(entity) {
-		return 100
+		return consts.PercentBase
 	}
 	effects := world.Components.CharModifiers.Get(entity)
 	skillID, ok := gc.WeaponSkillID(attack.GetAttackCategory())
 	if !ok {
-		return 100
+		return consts.PercentBase
 	}
-	var mults map[gc.SkillID]int
+	var mults map[gc.SkillID]consts.Percent
 	if isDamage {
 		mults = effects.WeaponDamage
 	} else {
@@ -259,7 +259,7 @@ func getSkillMult(entity ecs.Entity, attack gc.Attacker, world w.World, isDamage
 	if mult, ok := mults[skillID]; ok {
 		return mult
 	}
-	return 100
+	return consts.PercentBase
 }
 
 // applyElementResist は事前計算済みの元素耐性倍率でダメージを軽減する
@@ -272,7 +272,7 @@ func applyElementResist(damage int, target ecs.Entity, element gc.ElementType, w
 	if !ok {
 		return damage
 	}
-	reduced := max(damage*mult/100, formula.MinDamage)
+	reduced := max(mult.ApplyInt(damage), formula.MinDamage)
 	return reduced
 }
 
@@ -321,7 +321,7 @@ func calculateHitRate(attacker, target ecs.Entity, world w.World, attack gc.Atta
 
 	hitRate := formula.BaseHitRate + (attackerAbils.Dexterity.Total-targetAgility)*formula.HitRatePerStatPoint
 	hitRate += getWeaponAccuracyFromAttack(attack)
-	hitRate = hitRate * getSkillMult(attacker, attack, world, false) / 100
+	hitRate = getSkillMult(attacker, attack, world, false).ApplyInt(hitRate)
 	hitRate += modifier
 
 	if hitRate > formula.MaxHitRate {
@@ -372,7 +372,7 @@ func calculateDamage(attacker, target ecs.Entity, world w.World, attack gc.Attac
 	baseDamage += attack.GetDamage()
 	baseDamage += damageModifier
 
-	baseDamage = baseDamage * getSkillMult(attacker, attack, world, true) / 100
+	baseDamage = getSkillMult(attacker, attack, world, true).ApplyInt(baseDamage)
 
 	if critical {
 		baseDamage = formula.ApplyCritical(baseDamage)

--- a/internal/activity/attack_test.go
+++ b/internal/activity/attack_test.go
@@ -17,8 +17,8 @@ func TestGetSkillMult_NoCharModifiers(t *testing.T) {
 	entity := world.ECS.NewEntity()
 	// CharModifiersコンポーネントなし → 100を返す
 	melee := &gc.Melee{AttackCategory: gc.AttackSword}
-	assert.Equal(t, 100, getSkillMult(entity, melee, world, true))
-	assert.Equal(t, 100, getSkillMult(entity, melee, world, false))
+	assert.Equal(t, 100, int(getSkillMult(entity, melee, world, true)))
+	assert.Equal(t, 100, int(getSkillMult(entity, melee, world, false)))
 }
 
 func TestGetSkillMult_NilAttack(t *testing.T) {
@@ -26,7 +26,7 @@ func TestGetSkillMult_NilAttack(t *testing.T) {
 
 	world := testutil.InitTestWorld(t)
 	entity := world.ECS.NewEntity()
-	assert.Equal(t, 100, getSkillMult(entity, nil, world, true))
+	assert.Equal(t, 100, int(getSkillMult(entity, nil, world, true)))
 }
 
 func TestGetSkillMult_WithCharModifiers(t *testing.T) {
@@ -42,9 +42,9 @@ func TestGetSkillMult_WithCharModifiers(t *testing.T) {
 
 	melee := &gc.Melee{AttackCategory: gc.AttackSword}
 	// 刀剣Lv3: ダメージ倍率 = 100 + 3*5 = 115
-	assert.Equal(t, 115, getSkillMult(entity, melee, world, true))
+	assert.Equal(t, 115, int(getSkillMult(entity, melee, world, true)))
 	// 刀剣Lv3: 命中倍率 = 100 + 3*3 = 109
-	assert.Equal(t, 109, getSkillMult(entity, melee, world, false))
+	assert.Equal(t, 109, int(getSkillMult(entity, melee, world, false)))
 }
 
 func TestGetSkillMult_UnmappedWeapon(t *testing.T) {
@@ -59,7 +59,7 @@ func TestGetSkillMult_UnmappedWeapon(t *testing.T) {
 
 	// 未登録の武器種 → 100
 	melee := &gc.Melee{AttackCategory: gc.AttackType{Type: "unknown"}}
-	assert.Equal(t, 100, getSkillMult(entity, melee, world, true))
+	assert.Equal(t, 100, int(getSkillMult(entity, melee, world, true)))
 }
 
 func TestApplyElementResist_NoCharModifiers(t *testing.T) {
@@ -300,7 +300,7 @@ func TestGrowWeaponSkill_LevelUpWithHealthStatus(t *testing.T) {
 	mods := world.Components.CharModifiers.Get(actor)
 	require.NotNil(t, mods)
 	// MoveCost = 100 + 走破Lv0*(-2) + AGI0*(-1) + 軽度低体温10 = 110
-	assert.Equal(t, 110, mods.MoveCost, "HealthStatusのペナルティがCharModifiers再計算に反映されている")
+	assert.Equal(t, 110, int(mods.MoveCost), "HealthStatusのペナルティがCharModifiers再計算に反映されている")
 }
 
 func TestApplyAttackDamage_InterruptsActivity(t *testing.T) {

--- a/internal/activity/use_item.go
+++ b/internal/activity/use_item.go
@@ -143,7 +143,7 @@ func (u *UseItemActivity) applyHealing(_ *gc.Activity, actor ecs.Entity, world w
 	// 回復効果倍率を適用する
 	if world.Components.CharModifiers.Has(actor) {
 		mods := world.Components.CharModifiers.Get(actor)
-		amount = amount * mods.HealingEffect / 100
+		amount = mods.HealingEffect.ApplyInt(amount)
 	}
 	if amount < 1 {
 		amount = 1

--- a/internal/aiinput/vision_system.go
+++ b/internal/aiinput/vision_system.go
@@ -32,7 +32,7 @@ func (vs *DefaultVisionSystem) CanSeeTarget(world w.World, aiEntity, targetEntit
 
 	if world.Components.CharModifiers.Has(targetEntity) {
 		mods := world.Components.CharModifiers.Get(targetEntity)
-		viewDist = viewDist * float64(mods.EnemyVision) / 100
+		viewDist = mods.EnemyVision.ApplyFloat(viewDist)
 	}
 
 	return float64(distSq) <= viewDist*viewDist

--- a/internal/components/book.go
+++ b/internal/components/book.go
@@ -45,6 +45,8 @@ type SkillBookEffect struct {
 
 // ReadingEfficiency は本とプレイヤーのスキルレベル差に基づく経験値効率を倍率で返す（0-100%）
 // diff = bookLevel - playerLevel（正=本が難しい）
+// 理解不能（diff > maxDifficulty）のときは 0 を返す。呼び出し元は 0 のとき経験値が
+// 入らないことを前提に扱うこと（例: GainExpScaled は max(..., 1) で下限1を保証する）。
 func ReadingEfficiency(playerLevel, bookLevel int) consts.Percent {
 	diff := bookLevel - playerLevel
 

--- a/internal/components/book.go
+++ b/internal/components/book.go
@@ -1,6 +1,10 @@
 package components
 
-import "fmt"
+import (
+	"fmt"
+
+	"github.com/kijimaD/ruins/internal/consts"
+)
 
 // Book は読書可能な本のコンポーネント
 type Book struct {
@@ -39,9 +43,9 @@ type SkillBookEffect struct {
 	RequiredLevel int     // 読むのに必要なスキルレベル。0なら誰でも読める
 }
 
-// ReadingEfficiency は本とプレイヤーのスキルレベル差に基づく経験値効率を返す（0-100）
+// ReadingEfficiency は本とプレイヤーのスキルレベル差に基づく経験値効率を倍率で返す（0-100%）
 // diff = bookLevel - playerLevel（正=本が難しい）
-func ReadingEfficiency(playerLevel, bookLevel int) int {
+func ReadingEfficiency(playerLevel, bookLevel int) consts.Percent {
 	diff := bookLevel - playerLevel
 
 	const (
@@ -57,10 +61,10 @@ func ReadingEfficiency(playerLevel, bookLevel int) int {
 		return 0
 	case diff >= 0:
 		// 難しい側: 100→50（線形）
-		return 100 - diff*hardPenaltyRate
+		return consts.Percent(100 - diff*hardPenaltyRate)
 	case diff >= -maxEase:
 		// 易しい側: 100→10（線形）
-		return 100 + diff*easePenaltyRate
+		return consts.Percent(100 + diff*easePenaltyRate)
 	default:
 		return minEfficiency
 	}

--- a/internal/components/book_test.go
+++ b/internal/components/book_test.go
@@ -108,7 +108,7 @@ func TestReadingEfficiency(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			result := ReadingEfficiency(tt.playerLevel, tt.bookLevel)
-			assert.Equal(t, tt.expected, result)
+			assert.Equal(t, tt.expected, int(result))
 		})
 	}
 }

--- a/internal/components/modifiers.go
+++ b/internal/components/modifiers.go
@@ -1,6 +1,10 @@
 package components
 
-import "fmt"
+import (
+	"fmt"
+
+	"github.com/kijimaD/ruins/internal/consts"
+)
 
 // ModifierKey は効果倍率の識別キー
 type ModifierKey string
@@ -132,23 +136,23 @@ type ModifierSource struct {
 // CharModifiers はエンティティの効果倍率を集約するコンポーネント。
 // スキル、健康状態など複数の要因から算出される。100が基準値で変化なし。
 type CharModifiers struct {
-	WeaponDamage   map[SkillID]int     // 武器ダメージ倍率%
-	WeaponAccuracy map[SkillID]int     // 武器命中倍率%
-	ElementResist  map[ElementType]int // 元素耐性倍率%
-	ColdProgress   int                 // 低体温進行倍率%
-	HeatProgress   int                 // 高体温進行倍率%
-	HungerProgress int                 // 空腹進行倍率%
-	HealingEffect  int                 // 回復効果倍率%
-	MaxWeight      int                 // 最大所持重量倍率%
-	Exploration    int                 // TODO: アイテム発見システム実装時に適用する。アイテム発見率倍率%
-	EnemyVision    int                 // 敵視界距離倍率%
-	NightVision    int                 // TODO: 暗所視界システム実装時に適用する。暗所視界倍率%
-	MoveCost       int                 // 移動APコスト倍率%
-	CraftCost      int                 // 素材消費量倍率%
-	SmithQuality   int                 // 合成品質倍率%
-	BuyPrice       int                 // 買値倍率%
-	SellPrice      int                 // 売値倍率%
-	HeavyArmor     int                 // 重装備AGIペナルティ倍率%
+	WeaponDamage   map[SkillID]consts.Percent     // 武器ダメージ倍率
+	WeaponAccuracy map[SkillID]consts.Percent     // 武器命中倍率
+	ElementResist  map[ElementType]consts.Percent // 元素耐性倍率
+	ColdProgress   consts.Percent                 // 低体温進行倍率
+	HeatProgress   consts.Percent                 // 高体温進行倍率
+	HungerProgress consts.Percent                 // 空腹進行倍率
+	HealingEffect  consts.Percent                 // 回復効果倍率
+	MaxWeight      consts.Percent                 // 最大所持重量倍率
+	Exploration    consts.Percent                 // TODO: アイテム発見システム実装時に適用する。アイテム発見率倍率
+	EnemyVision    consts.Percent                 // 敵視界距離倍率
+	NightVision    consts.Percent                 // TODO: 暗所視界システム実装時に適用する。暗所視界倍率
+	MoveCost       consts.Percent                 // 移動APコスト倍率
+	CraftCost      consts.Percent                 // 素材消費量倍率
+	SmithQuality   consts.Percent                 // 合成品質倍率
+	BuyPrice       consts.Percent                 // 買値倍率
+	SellPrice      consts.Percent                 // 売値倍率
+	HeavyArmor     consts.Percent                 // 重装備AGIペナルティ倍率
 
 	// Sources は各効果の算出元を保持する。
 	// 1つの効果に複数の要因が影響しうるためスライスにしている。
@@ -162,7 +166,7 @@ func RecalculateCharModifiers(skills *Skills, abils *Abilities, hs *HealthStatus
 	e := &CharModifiers{}
 	src := make(map[ModifierKey][]ModifierSource)
 
-	calcEffect := func(key ModifierKey, skillID SkillID, coeff int) int {
+	calcEffect := func(key ModifierKey, skillID SkillID, coeff int) consts.Percent {
 		v := skills.Get(skillID).Value
 		bonus := v * coeff
 		src[key] = append(src[key], ModifierSource{
@@ -186,17 +190,17 @@ func RecalculateCharModifiers(skills *Skills, abils *Abilities, hs *HealthStatus
 			bonus += ablBonus
 		}
 
-		return 100 + bonus
+		return consts.PercentBase + consts.Percent(bonus)
 	}
 
-	e.WeaponDamage = make(map[SkillID]int, len(weaponSkillIDs))
-	e.WeaponAccuracy = make(map[SkillID]int, len(weaponSkillIDs))
+	e.WeaponDamage = make(map[SkillID]consts.Percent, len(weaponSkillIDs))
+	e.WeaponAccuracy = make(map[SkillID]consts.Percent, len(weaponSkillIDs))
 	for _, id := range weaponSkillIDs {
 		e.WeaponDamage[id] = calcEffect(WeaponDamageKey(id), id, coeffWeaponDamage)
 		e.WeaponAccuracy[id] = calcEffect(WeaponAccuracyKey(id), id, coeffWeaponAccuracy)
 	}
 
-	e.ElementResist = map[ElementType]int{
+	e.ElementResist = map[ElementType]consts.Percent{
 		ElementTypeFire:    calcEffect(ModFireResist, SkillFireResist, coeffElementResist),
 		ElementTypeThunder: calcEffect(ModThunderResist, SkillThunderResist, coeffElementResist),
 		ElementTypeChill:   calcEffect(ModChillResist, SkillChillResist, coeffElementResist),
@@ -223,7 +227,7 @@ func RecalculateCharModifiers(skills *Skills, abils *Abilities, hs *HealthStatus
 		wb := &hs.Parts[BodyPartWholeBody]
 		for _, cond := range wb.Conditions {
 			if penalty := temperatureMovePenalty(cond.Severity); penalty != 0 {
-				e.MoveCost += penalty
+				e.MoveCost += consts.Percent(penalty)
 				src[ModMoveCost] = append(src[ModMoveCost], ModifierSource{
 					Label: ConditionTypeDisplayName(cond.Type),
 					Value: penalty,

--- a/internal/components/modifiers_test.go
+++ b/internal/components/modifiers_test.go
@@ -14,21 +14,21 @@ func TestRecalculateCharModifiers_AllSkillsZero(t *testing.T) {
 
 	// スキル値0のとき全倍率は100（等倍）
 	for _, id := range weaponSkillIDs {
-		assert.Equal(t, 100, mods.WeaponDamage[id], "武器ダメージ %s は100", id)
-		assert.Equal(t, 100, mods.WeaponAccuracy[id], "武器命中 %s は100", id)
+		assert.Equal(t, 100, int(mods.WeaponDamage[id]), "武器ダメージ %s は100", id)
+		assert.Equal(t, 100, int(mods.WeaponAccuracy[id]), "武器命中 %s は100", id)
 	}
-	assert.Equal(t, 100, mods.ColdProgress)
-	assert.Equal(t, 100, mods.HeatProgress)
-	assert.Equal(t, 100, mods.HungerProgress)
-	assert.Equal(t, 100, mods.HealingEffect)
-	assert.Equal(t, 100, mods.MaxWeight)
-	assert.Equal(t, 100, mods.EnemyVision)
-	assert.Equal(t, 100, mods.MoveCost)
-	assert.Equal(t, 100, mods.CraftCost)
-	assert.Equal(t, 100, mods.SmithQuality)
-	assert.Equal(t, 100, mods.BuyPrice)
-	assert.Equal(t, 100, mods.SellPrice)
-	assert.Equal(t, 100, mods.HeavyArmor)
+	assert.Equal(t, 100, int(mods.ColdProgress))
+	assert.Equal(t, 100, int(mods.HeatProgress))
+	assert.Equal(t, 100, int(mods.HungerProgress))
+	assert.Equal(t, 100, int(mods.HealingEffect))
+	assert.Equal(t, 100, int(mods.MaxWeight))
+	assert.Equal(t, 100, int(mods.EnemyVision))
+	assert.Equal(t, 100, int(mods.MoveCost))
+	assert.Equal(t, 100, int(mods.CraftCost))
+	assert.Equal(t, 100, int(mods.SmithQuality))
+	assert.Equal(t, 100, int(mods.BuyPrice))
+	assert.Equal(t, 100, int(mods.SellPrice))
+	assert.Equal(t, 100, int(mods.HeavyArmor))
 }
 
 func TestRecalculateCharModifiers_SkillEffects(t *testing.T) {
@@ -40,11 +40,11 @@ func TestRecalculateCharModifiers_SkillEffects(t *testing.T) {
 	mods := RecalculateCharModifiers(skills, nil, nil)
 
 	// 刀剣Lv2: ダメージ倍率 = 100 + 2*5 = 110
-	assert.Equal(t, 110, mods.WeaponDamage[SkillSword])
+	assert.Equal(t, 110, int(mods.WeaponDamage[SkillSword]))
 	// 刀剣Lv2: 命中倍率 = 100 + 2*3 = 106
-	assert.Equal(t, 106, mods.WeaponAccuracy[SkillSword])
+	assert.Equal(t, 106, int(mods.WeaponAccuracy[SkillSword]))
 	// 他の武器は影響なし
-	assert.Equal(t, 100, mods.WeaponDamage[SkillSpear])
+	assert.Equal(t, 100, int(mods.WeaponDamage[SkillSpear]))
 }
 
 func TestRecalculateCharModifiers_NegativeCoefficient(t *testing.T) {
@@ -56,9 +56,9 @@ func TestRecalculateCharModifiers_NegativeCoefficient(t *testing.T) {
 	mods := RecalculateCharModifiers(skills, nil, nil)
 
 	// 耐寒Lv3: 低体温進行 = 100 + 3*(-3) = 91
-	assert.Equal(t, 91, mods.ColdProgress)
+	assert.Equal(t, 91, int(mods.ColdProgress))
 	// 耐寒Lv3: 火耐性 = 100 + 0*(-3) = 100（SkillFireResistはLv0のまま）
-	assert.Equal(t, 100, mods.ElementResist[ElementTypeFire])
+	assert.Equal(t, 100, int(mods.ElementResist[ElementTypeFire]))
 }
 
 func TestRecalculateCharModifiers_WithAbilities(t *testing.T) {
@@ -74,9 +74,9 @@ func TestRecalculateCharModifiers_WithAbilities(t *testing.T) {
 	mods := RecalculateCharModifiers(skills, abils, nil)
 
 	// 刀剣Lv2 + STR10: ダメージ = 100 + 2*5 + 10*1 = 120
-	assert.Equal(t, 120, mods.WeaponDamage[SkillSword])
+	assert.Equal(t, 120, int(mods.WeaponDamage[SkillSword]))
 	// 刀剣Lv2 + STR10: 命中 = 100 + 2*3 + 10*1 = 116
-	assert.Equal(t, 116, mods.WeaponAccuracy[SkillSword])
+	assert.Equal(t, 116, int(mods.WeaponAccuracy[SkillSword]))
 }
 
 func TestRecalculateCharModifiers_AbilityNegativeDirection(t *testing.T) {
@@ -92,7 +92,7 @@ func TestRecalculateCharModifiers_AbilityNegativeDirection(t *testing.T) {
 	mods := RecalculateCharModifiers(skills, abils, nil)
 
 	// 耐寒Lv1 + VIT5: 低体温進行 = 100 + 1*(-3) + 5*(-1) = 92
-	assert.Equal(t, 92, mods.ColdProgress)
+	assert.Equal(t, 92, int(mods.ColdProgress))
 }
 
 func TestRecalculateCharModifiers_Sources(t *testing.T) {
@@ -130,7 +130,7 @@ func TestRecalculateCharModifiers_HealthPenalty(t *testing.T) {
 	mods := RecalculateCharModifiers(skills, nil, hs)
 
 	// 中度低体温: MoveCost = 100 + 20
-	assert.Equal(t, 120, mods.MoveCost)
+	assert.Equal(t, 120, int(mods.MoveCost))
 
 	// Sourcesに低体温のペナルティが記録される
 	sources := mods.Sources[ModMoveCost]
@@ -180,9 +180,9 @@ func TestRecalculateCharModifiers_Negotiation(t *testing.T) {
 	mods := RecalculateCharModifiers(skills, nil, nil)
 
 	// 交渉Lv4: 買値 = 100 + 4*(-2) = 92 (安く買える)
-	assert.Equal(t, 92, mods.BuyPrice)
+	assert.Equal(t, 92, int(mods.BuyPrice))
 	// 交渉Lv4: 売値 = 100 + 4*2 = 108 (高く売れる)
-	assert.Equal(t, 108, mods.SellPrice)
+	assert.Equal(t, 108, int(mods.SellPrice))
 }
 
 func TestRecalculateCharModifiers_MultipleSkills(t *testing.T) {
@@ -202,13 +202,13 @@ func TestRecalculateCharModifiers_MultipleSkills(t *testing.T) {
 	mods := RecalculateCharModifiers(skills, abils, nil)
 
 	// 刀剣Lv3 + STR8: ダメージ = 100 + 3*5 + 8*1 = 123
-	assert.Equal(t, 123, mods.WeaponDamage[SkillSword])
+	assert.Equal(t, 123, int(mods.WeaponDamage[SkillSword]))
 	// 拳銃Lv5 + SEN6: ダメージ = 100 + 5*5 + 6*1 = 131
-	assert.Equal(t, 131, mods.WeaponDamage[SkillHandgun])
+	assert.Equal(t, 131, int(mods.WeaponDamage[SkillHandgun]))
 	// 合成Lv2 + DEX4: 素材消費 = 100 + 2*(-3) + 4*(-1) = 90
-	assert.Equal(t, 90, mods.CraftCost)
+	assert.Equal(t, 90, int(mods.CraftCost))
 	// 長物は未使用: ダメージ = 100 + 0*5 + 8*1 = 108（STR能力値のみ）
-	assert.Equal(t, 108, mods.WeaponDamage[SkillSpear])
+	assert.Equal(t, 108, int(mods.WeaponDamage[SkillSpear]))
 }
 
 func TestRecalculateCharModifiers_AllFactors(t *testing.T) {
@@ -234,7 +234,7 @@ func TestRecalculateCharModifiers_AllFactors(t *testing.T) {
 	// 走破Lv4 + AGI10: MoveCost = 100 + 4*(-2) + 10*(-1) = 82
 	// 重度低体温ペナルティ: +30
 	// 合計: 82 + 30 = 112
-	assert.Equal(t, 112, mods.MoveCost)
+	assert.Equal(t, 112, int(mods.MoveCost))
 
 	// Sourcesに3要因が記録される
 	sources := mods.Sources[ModMoveCost]
@@ -254,9 +254,9 @@ func TestRecalculateCharModifiers_FireAbility(t *testing.T) {
 	mods := RecalculateCharModifiers(skills, abils, nil)
 
 	// 小銃Lv4 + SEN12: ダメージ = 100 + 4*5 + 12*1 = 132
-	assert.Equal(t, 132, mods.WeaponDamage[SkillRifle])
+	assert.Equal(t, 132, int(mods.WeaponDamage[SkillRifle]))
 	// 小銃Lv4 + SEN12: 命中 = 100 + 4*3 + 12*1 = 124
-	assert.Equal(t, 124, mods.WeaponAccuracy[SkillRifle])
+	assert.Equal(t, 124, int(mods.WeaponAccuracy[SkillRifle]))
 }
 
 func TestRecalculateCharModifiers_ElementResistAllTypes(t *testing.T) {
@@ -271,8 +271,8 @@ func TestRecalculateCharModifiers_ElementResistAllTypes(t *testing.T) {
 	mods := RecalculateCharModifiers(skills, nil, nil)
 
 	// 各元素耐性: 100 + Lv*(-3)
-	assert.Equal(t, 94, mods.ElementResist[ElementTypeFire])    // 100 + 2*(-3)
-	assert.Equal(t, 88, mods.ElementResist[ElementTypeThunder]) // 100 + 4*(-3)
-	assert.Equal(t, 82, mods.ElementResist[ElementTypeChill])   // 100 + 6*(-3)
-	assert.Equal(t, 76, mods.ElementResist[ElementTypePhoton])  // 100 + 8*(-3)
+	assert.Equal(t, 94, int(mods.ElementResist[ElementTypeFire]))    // 100 + 2*(-3)
+	assert.Equal(t, 88, int(mods.ElementResist[ElementTypeThunder])) // 100 + 4*(-3)
+	assert.Equal(t, 82, int(mods.ElementResist[ElementTypeChill]))   // 100 + 6*(-3)
+	assert.Equal(t, 76, int(mods.ElementResist[ElementTypePhoton]))  // 100 + 8*(-3)
 }

--- a/internal/consts/percent.go
+++ b/internal/consts/percent.go
@@ -1,0 +1,26 @@
+package consts
+
+// Percent は 100 を基準(等倍)とする倍率。120 なら 1.2 倍、50 なら 0.5 倍、0 なら 0 倍。
+// CharModifiers の各倍率や進行速度など「基準 100 の%」に使い、base*pct/100 の適用を
+// 一元化して意味を型に載せる。
+type Percent int
+
+// PercentBase は等倍の基準値。
+const PercentBase Percent = 100
+
+// applyPercent は倍率適用の中核。式を1箇所に集約する。
+// Go の / は型で意味が変わるため、int で呼べば整数除算で切り捨て、float で呼べば
+// 非切り捨てになり、外皮の ApplyInt/ApplyFloat が期待する丸めが型ごとに自動で決まる。
+func applyPercent[T ~int | ~float64](base T, p Percent) T {
+	return base * T(p) / T(PercentBase)
+}
+
+// ApplyInt は base に倍率を適用する。整数計算のため端数は切り捨てる。
+func (p Percent) ApplyInt(base int) int {
+	return applyPercent(base, p)
+}
+
+// ApplyFloat は base に倍率を適用する(float64)。切り捨ては行わない。
+func (p Percent) ApplyFloat(base float64) float64 {
+	return applyPercent(base, p)
+}

--- a/internal/consts/percent_test.go
+++ b/internal/consts/percent_test.go
@@ -1,0 +1,40 @@
+package consts_test
+
+import (
+	"testing"
+
+	"github.com/kijimaD/ruins/internal/consts"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPercent_ApplyInt(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		pct  consts.Percent
+		base int
+		want int
+	}{
+		{"等倍は変えない", consts.PercentBase, 200, 200},
+		{"1.2倍", 120, 100, 120},
+		{"半分", 50, 100, 50},
+		{"0倍", 0, 100, 0},
+		{"端数は切り捨て", 33, 10, 3}, // 10*33/100 = 3.3 -> 3
+		{"増幅は100超", 250, 4, 10},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, tt.pct.ApplyInt(tt.base))
+		})
+	}
+}
+
+func TestPercent_ApplyFloat(t *testing.T) {
+	t.Parallel()
+
+	assert.InDelta(t, 120.0, consts.Percent(120).ApplyFloat(100), 1e-9)
+	assert.InDelta(t, 3.3, consts.Percent(33).ApplyFloat(10), 1e-9, "float は切り捨てない")
+	assert.InDelta(t, 100.0, consts.PercentBase.ApplyFloat(100), 1e-9)
+}

--- a/internal/skill/growth.go
+++ b/internal/skill/growth.go
@@ -1,6 +1,9 @@
 package skill
 
-import gc "github.com/kijimaD/ruins/internal/components"
+import (
+	gc "github.com/kijimaD/ruins/internal/components"
+	"github.com/kijimaD/ruins/internal/consts"
+)
 
 // growthConfig はスキル成長のバランスパラメータ
 var growthConfig = struct {
@@ -21,10 +24,10 @@ func GainExp(s *gc.Skill, abilityValue int) bool {
 	return gainExp(s, abilityValue, growthConfig.BaseExp)
 }
 
-// GainExpScaled はBaseExpにefficiencyPct（0-100%）を適用してから経験値を加算する。
+// GainExpScaled はBaseExpにefficiencyPct（0-100%の倍率）を適用してから経験値を加算する。
 // 読書など、状況に応じて獲得量を調整する場合に使う。
-func GainExpScaled(s *gc.Skill, abilityValue int, efficiencyPct int) bool {
-	baseExp := max(growthConfig.BaseExp*efficiencyPct/100, 1)
+func GainExpScaled(s *gc.Skill, abilityValue int, efficiencyPct consts.Percent) bool {
+	baseExp := max(efficiencyPct.ApplyInt(growthConfig.BaseExp), 1)
 	return gainExp(s, abilityValue, baseExp)
 }
 

--- a/internal/skill/growth.go
+++ b/internal/skill/growth.go
@@ -37,10 +37,11 @@ func gainExp(s *gc.Skill, abilityValue int, baseExp int) bool {
 		return false
 	}
 
-	growthSpeed := 100 + abilityValue*growthConfig.AbilBonus
+	// 経験値への乗数倍率。decay は割り算で効く逆適用の倍率なのでApplyInt は使わず int のまま扱う。
+	growthSpeed := consts.PercentBase + consts.Percent(abilityValue*growthConfig.AbilBonus)
 	decay := 100 + s.Value*growthConfig.DecayPerLevel
 
-	exp := max(baseExp*growthSpeed/100*100/decay, 1)
+	exp := max(growthSpeed.ApplyInt(baseExp)*100/decay, 1)
 	s.Exp.Current += exp
 
 	if s.Exp.Current >= s.Exp.Max {

--- a/internal/states/shop_menu.go
+++ b/internal/states/shop_menu.go
@@ -8,6 +8,7 @@ import (
 	"github.com/hajimehoshi/ebiten/v2"
 	gc "github.com/kijimaD/ruins/internal/components"
 	"github.com/kijimaD/ruins/internal/config"
+	"github.com/kijimaD/ruins/internal/consts"
 	es "github.com/kijimaD/ruins/internal/engine/states"
 	"github.com/kijimaD/ruins/internal/hooks"
 	"github.com/kijimaD/ruins/internal/inputmapper"
@@ -194,7 +195,7 @@ type shopWindowProps struct {
 
 func (st *ShopMenuState) fetchProps(world w.World) shopProps {
 	var currency int
-	buyPriceMod, sellPriceMod := 100, 100
+	buyPriceMod, sellPriceMod := consts.PercentBase, consts.PercentBase
 	query.Player(world, func(playerEntity ecs.Entity) {
 		currency = query.GetCurrency(world, playerEntity)
 		if world.Components.CharModifiers.Has(playerEntity) {
@@ -210,19 +211,19 @@ func (st *ShopMenuState) fetchProps(world w.World) shopProps {
 	}
 }
 
-func (st *ShopMenuState) createTabs(world w.World, currency, buyPriceMod, sellPriceMod int) []shopTabData {
+func (st *ShopMenuState) createTabs(world w.World, currency int, buyPriceMod, sellPriceMod consts.Percent) []shopTabData {
 	return []shopTabData{
 		{ID: "buy", Label: "購入", Items: st.createBuyItems(world, currency, buyPriceMod)},
 		{ID: "sell", Label: "売却", Items: st.createSellItems(world, sellPriceMod)},
 	}
 }
 
-func (st *ShopMenuState) createBuyItems(world w.World, currency, buyPriceMod int) []shopItemData {
+func (st *ShopMenuState) createBuyItems(world w.World, currency int, buyPriceMod consts.Percent) []shopItemData {
 	shopInventory := gameaction.GetShopInventory()
 	items := make([]shopItemData, 0, len(shopInventory))
 
 	for _, itemName := range shopInventory {
-		price := st.getItemPrice(world, itemName, true) * buyPriceMod / 100
+		price := buyPriceMod.ApplyInt(st.getItemPrice(world, itemName, true))
 		canAfford := currency >= price
 
 		items = append(items, shopItemData{
@@ -236,7 +237,7 @@ func (st *ShopMenuState) createBuyItems(world w.World, currency, buyPriceMod int
 	return items
 }
 
-func (st *ShopMenuState) createSellItems(world w.World, sellPriceMod int) []shopItemData {
+func (st *ShopMenuState) createSellItems(world w.World, sellPriceMod consts.Percent) []shopItemData {
 	var items []shopItemData
 
 	query.Player(world, func(_ ecs.Entity) {
@@ -247,7 +248,7 @@ func (st *ShopMenuState) createSellItems(world w.World, sellPriceMod int) []shop
 			itemName := nameComp.Name
 
 			baseValue := query.GetItemValue(world, entity)
-			price := query.CalculateSellPrice(baseValue) * sellPriceMod / 100
+			price := sellPriceMod.ApplyInt(query.CalculateSellPrice(baseValue))
 
 			count := query.GetEntityCount(world, entity)
 

--- a/internal/systems/temperature.go
+++ b/internal/systems/temperature.go
@@ -89,7 +89,7 @@ func (sys *TemperatureSystem) Update(world w.World) error {
 		isPlayer := world.Components.Player.Has(entity)
 
 		// 体温進行倍率を取得する
-		coldProgressPct, heatProgressPct := 100, 100
+		coldProgressPct, heatProgressPct := consts.PercentBase, consts.PercentBase
 		if world.Components.CharModifiers.Has(entity) {
 			mods := world.Components.CharModifiers.Get(entity)
 			coldProgressPct = mods.ColdProgress
@@ -155,7 +155,7 @@ func getTileTemperatureAt(world w.World, x, y consts.Tile) int {
 // - isPlayerがtrueの場合、状態変化時にログを出力する。
 // - coldProgressPct/heatProgressPctは体温進行倍率%。100が基準で、低いほど進行が遅くなる。
 // - 戻り値: 状態のSeverityが変化した場合trueを返す
-func updateTemperatureConditions(world w.World, hs *gc.HealthStatus, envTemp int, insulation Insulation, isPlayer bool, coldProgressPct, heatProgressPct int) bool {
+func updateTemperatureConditions(world w.World, hs *gc.HealthStatus, envTemp int, insulation Insulation, isPlayer bool, coldProgressPct, heatProgressPct consts.Percent) bool {
 	hasChange := false
 	partHealth := &hs.Parts[gc.BodyPartWholeBody]
 
@@ -164,8 +164,8 @@ func updateTemperatureConditions(world w.World, hs *gc.HealthStatus, envTemp int
 	// 耐暑を適用した有効温度（暑さ判定用）: 耐暑が高いほど涼しく感じる
 	effectiveTempHeat := envTemp - insulation.Heat
 
-	coldDelta := calcTimerDelta(effectiveTempCold) * float64(coldProgressPct) / 100
-	heatDelta := calcTimerDelta(effectiveTempHeat) * float64(heatProgressPct) / 100
+	coldDelta := coldProgressPct.ApplyFloat(calcTimerDelta(effectiveTempCold))
+	heatDelta := heatProgressPct.ApplyFloat(calcTimerDelta(effectiveTempHeat))
 
 	var changes []gc.SeverityChange
 

--- a/internal/world/gameaction/craft.go
+++ b/internal/world/gameaction/craft.go
@@ -23,7 +23,7 @@ func Craft(world w.World, name string) (ecs.Entity, error) {
 		return consts.InvalidEntity, fmt.Errorf("必要素材が足りません")
 	}
 
-	craftCostPct, smithQualityPct := 100, 100
+	craftCostPct, smithQualityPct := consts.PercentBase, consts.PercentBase
 	player, playerErr := query.GetPlayerEntity(world)
 	if playerErr == nil && world.Components.CharModifiers.Has(player) {
 		mods := world.Components.CharModifiers.Get(player)
@@ -74,9 +74,9 @@ func CanCraft(world w.World, name string) (bool, error) {
 
 // consumeMaterials はアイテム合成に必要な素材を消費する。
 // craftCostPctは素材消費量の倍率%で、100が基準。低いほど素材が節約できる。
-func consumeMaterials(world w.World, goal string, craftCostPct int) error {
+func consumeMaterials(world w.World, goal string, craftCostPct consts.Percent) error {
 	for _, recipeInput := range requiredMaterials(world, goal) {
-		consumed := max(recipeInput.Amount*craftCostPct/100, 1)
+		consumed := max(craftCostPct.ApplyInt(recipeInput.Amount), 1)
 		err := lifecycle.ChangeStackableCount(world, recipeInput.Name, -consumed)
 		if err != nil {
 			return err
@@ -103,7 +103,7 @@ func requiredMaterials(world w.World, need string) []gc.RecipeInput {
 
 // randomize はアイテムにランダム値を設定する。
 // smithQualityPctは品質倍率%で、100が基準。高いほどボーナスが大きくなる。
-func randomize(world w.World, entity ecs.Entity, smithQualityPct int) {
+func randomize(world w.World, entity ecs.Entity, smithQualityPct consts.Percent) {
 	// Stackableなアイテムを合成した場合、SpawnBackpackItem内の統合処理で
 	// このエンティティが既存スタックに統合されて削除されていることがある。
 	// 統合済みStackableに武器/防具の乱数化は不要なので、死亡していれば何もしない
@@ -111,7 +111,8 @@ func randomize(world w.World, entity ecs.Entity, smithQualityPct int) {
 		return
 	}
 
-	qualityBonus := (smithQualityPct - 100) / 10
+	// 基準からの乖離を10%刻みでボーナス段階に換算する。倍率そのものでなく段数なので int で扱う
+	qualityBonus := (int(smithQualityPct) - int(consts.PercentBase)) / 10
 
 	if world.Components.Melee.Has(entity) {
 		melee := world.Components.Melee.Get(entity)

--- a/internal/world/gameaction/run.go
+++ b/internal/world/gameaction/run.go
@@ -5,6 +5,7 @@ import (
 	"sort"
 
 	gc "github.com/kijimaD/ruins/internal/components"
+	"github.com/kijimaD/ruins/internal/consts"
 	"github.com/kijimaD/ruins/internal/raw"
 	w "github.com/kijimaD/ruins/internal/world"
 	"github.com/kijimaD/ruins/internal/world/lifecycle"
@@ -63,7 +64,7 @@ func ExecuteEndRun(world w.World, playerEntity ecs.Entity, total int) error {
 // collectBackpackItems はバックパック内の全アイテムを収集して返す。
 // エンティティは削除しない。
 func collectBackpackItems(world w.World, playerEntity ecs.Entity) AutoSellResult {
-	sellPriceMod := 100
+	sellPriceMod := consts.PercentBase
 	if world.Components.CharModifiers.Has(playerEntity) {
 		mods := world.Components.CharModifiers.Get(playerEntity)
 		sellPriceMod = mods.SellPrice
@@ -83,7 +84,7 @@ func collectBackpackItems(world w.World, playerEntity ecs.Entity) AutoSellResult
 		if world.Components.Value.Has(entity) {
 			count := query.GetEntityCount(world, entity)
 			baseValue := world.Components.Value.Get(entity).Value
-			price = query.CalculateSellPrice(baseValue) * count * sellPriceMod / 100
+			price = sellPriceMod.ApplyInt(query.CalculateSellPrice(baseValue) * count)
 		}
 
 		items = append(items, SoldItem{Entity: entity, Name: name, Price: price})

--- a/internal/world/gameaction/shop.go
+++ b/internal/world/gameaction/shop.go
@@ -24,7 +24,7 @@ func BuyItem(world w.World, playerEntity ecs.Entity, itemName string) error {
 	// 交渉スキルによる買値倍率を適用する
 	if world.Components.CharModifiers.Has(playerEntity) {
 		mods := world.Components.CharModifiers.Get(playerEntity)
-		price = price * mods.BuyPrice / 100
+		price = mods.BuyPrice.ApplyInt(price)
 	}
 
 	if !query.HasCurrency(world, playerEntity, price) {
@@ -69,7 +69,7 @@ func SellItem(world w.World, playerEntity ecs.Entity, itemEntity ecs.Entity) err
 	// 交渉スキルによる売値倍率を適用する
 	if world.Components.CharModifiers.Has(playerEntity) {
 		mods := world.Components.CharModifiers.Get(playerEntity)
-		price = price * mods.SellPrice / 100
+		price = mods.SellPrice.ApplyInt(price)
 	}
 
 	if err := lifecycle.ChangeItemCount(world, itemEntity, -1); err != nil {

--- a/internal/world/query/turn.go
+++ b/internal/world/query/turn.go
@@ -128,7 +128,8 @@ func CalculateSpeed(world w.World, entity ecs.Entity) int {
 	// 100% = 変化なし、90% = 速い（走破スキル）、130% = 遅い（低体温）
 	if world.Components.CharModifiers.Has(entity) {
 		effects := world.Components.CharModifiers.Get(entity)
-		moveCost := max(effects.MoveCost, 10)
+		// MoveCost はコスト倍率なので速度へは逆適用する（高いほど遅い）。ApplyInt は使わない
+		moveCost := max(int(effects.MoveCost), 10)
 		speed = speed * 100 / moveCost
 	}
 

--- a/internal/world/query/weight.go
+++ b/internal/world/query/weight.go
@@ -30,7 +30,7 @@ func UpdateWeightCapacity(world w.World, entity ecs.Entity) {
 
 		if world.Components.CharModifiers.Has(entity) {
 			mods := world.Components.CharModifiers.Get(entity)
-			maxWeight = maxWeight * float64(mods.MaxWeight) / 100
+			maxWeight = mods.MaxWeight.ApplyFloat(maxWeight)
 		}
 
 		wc.Max = maxWeight


### PR DESCRIPTION
## 背景

`CharModifiers` の各倍率フィールドや進行速度など「基準100の%」を表す `int` がコード全体に散在し、`base*pct/100` の適用も各所で重複していた。素の `int` では「これは基準100の倍率だ」という意味が型に乗らず、丸め方の揺れも起きやすい。

## 変更

倍率型 `consts.Percent`（基準 `PercentBase = 100`、適用メソッド `ApplyInt`/`ApplyFloat`）を新設し、倍率まわりを移行する。

- **型定義** (`internal/consts/percent.go`): `type Percent int` ＋ `ApplyInt`（整数・切り捨て）/`ApplyFloat`（float64）。裏付けは int なので serde では数値のまま保存される
- **`CharModifiers`** の全倍率スカラーフィールド・武器倍率/元素耐性のマップ値・`calcEffect` の戻り値を `consts.Percent` へ
- **適用サイト**（weight / temperature / healing / craft / shop / vision / attack など）の手計算 `base*pct/100` を `ApplyInt`/`ApplyFloat` に置換して丸めを一元化
- `ReadingEfficiency`/`GainExpScaled` の効率%も同じ基準100の倍率なので揃える

### 掛け算でない箇所は int キャストで従来どおり

型を機械的に `Apply` へ寄せず、意味に合わせて扱いを分けている。

- **MoveCost**: コスト倍率なので速度へは逆適用（割り算）。`ApplyInt` は使わず int キャスト
- **SmithQuality**: 基準からの乖離を10%刻みの段数に換算するため int キャスト
- **HungerProgress**: 確率比較 `RNG.IntN(100) < pct`、表示は `%d` のため int キャスト

## テスト

- `consts.Percent` の `ApplyInt`/`ApplyFloat` に単体テスト追加（切り捨て・0倍・100超）
- 型変更で `assert.Equal(t, 100, mods.X)` が型不一致になる箇所は実値を `int(...)` でラップして従来の数値検証を維持
- `make check` パス（0 issues）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Session: https://claude.ai/code/session_011WK4MFoYM4ZAzgiEhv7YWg