### PR TITLE
test(consts): カバレッジ増強

### DIFF
--- a/internal/consts/chunk_test.go
+++ b/internal/consts/chunk_test.go
@@ -19,6 +19,7 @@ func TestChunk_Tiles(t *testing.T) {
 		{"1チャンク", 1, 16, 16},
 		{"複数チャンク", 3, 16, 48},
 		{"ゼロチャンク", 0, 16, 0},
+		{"チャンクサイズが異なる場合", 3, 2, 6},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/consts/chunk_test.go
+++ b/internal/consts/chunk_test.go
@@ -1,0 +1,29 @@
+package consts_test
+
+import (
+	"testing"
+
+	"github.com/kijimaD/ruins/internal/consts"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestChunk_Tiles(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		c         consts.Chunk
+		chunkSize consts.Tile
+		want      consts.Tile
+	}{
+		{"1チャンク", 1, 16, 16},
+		{"複数チャンク", 3, 16, 48},
+		{"ゼロチャンク", 0, 16, 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, tt.c.Tiles(tt.chunkSize))
+		})
+	}
+}

--- a/internal/consts/coord_test.go
+++ b/internal/consts/coord_test.go
@@ -1,0 +1,140 @@
+package consts_test
+
+import (
+	"testing"
+
+	"github.com/kijimaD/ruins/internal/consts"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCoord_String(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		c    consts.Coord[int]
+		want string
+	}{
+		{"正の座標", consts.Coord[int]{X: 1, Y: 2}, "(1,2)"},
+		{"ゼロ", consts.Coord[int]{X: 0, Y: 0}, "(0,0)"},
+		{"負の座標", consts.Coord[int]{X: -3, Y: -4}, "(-3,-4)"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, tt.c.String())
+		})
+	}
+}
+
+func TestCoord_Add(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		a    consts.Coord[int]
+		b    consts.Coord[int]
+		want consts.Coord[int]
+	}{
+		{"正同士", consts.Coord[int]{X: 1, Y: 2}, consts.Coord[int]{X: 3, Y: 4}, consts.Coord[int]{X: 4, Y: 6}},
+		{"ゼロを足す", consts.Coord[int]{X: 5, Y: 5}, consts.Coord[int]{X: 0, Y: 0}, consts.Coord[int]{X: 5, Y: 5}},
+		{"負を足すと減る", consts.Coord[int]{X: 5, Y: 5}, consts.Coord[int]{X: -2, Y: -3}, consts.Coord[int]{X: 3, Y: 2}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, tt.a.Add(tt.b))
+		})
+	}
+}
+
+func TestCoord_Sub(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		a    consts.Coord[int]
+		b    consts.Coord[int]
+		want consts.Coord[int]
+	}{
+		{"正同士", consts.Coord[int]{X: 5, Y: 6}, consts.Coord[int]{X: 3, Y: 4}, consts.Coord[int]{X: 2, Y: 2}},
+		{"ゼロを引く", consts.Coord[int]{X: 5, Y: 5}, consts.Coord[int]{X: 0, Y: 0}, consts.Coord[int]{X: 5, Y: 5}},
+		{"引いた結果が負になる", consts.Coord[int]{X: 1, Y: 1}, consts.Coord[int]{X: 3, Y: 4}, consts.Coord[int]{X: -2, Y: -3}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, tt.a.Sub(tt.b))
+		})
+	}
+}
+
+func TestTileCenterToWorld(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		grid consts.Coord[consts.Tile]
+		want consts.Coord[consts.WorldPixel]
+	}{
+		// タイル中心へ半タイル分ずらした位置になる
+		{"原点タイル", consts.Coord[consts.Tile]{X: 0, Y: 0}, consts.Coord[consts.WorldPixel]{X: 16, Y: 16}},
+		{"1マス目", consts.Coord[consts.Tile]{X: 1, Y: 1}, consts.Coord[consts.WorldPixel]{X: 48, Y: 48}},
+		{"XとYが異なる", consts.Coord[consts.Tile]{X: 2, Y: 0}, consts.Coord[consts.WorldPixel]{X: 80, Y: 16}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, consts.TileCenterToWorld(tt.grid))
+		})
+	}
+}
+
+func TestWorldToScreen(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		world     consts.Coord[consts.WorldPixel]
+		cameraPos consts.Coord[consts.WorldPixel]
+		scale     float64
+		screenW   int
+		screenH   int
+		want      consts.Coord[consts.ScreenPixel]
+	}{
+		{
+			name:      "カメラ原点で等倍なら画面中央基準",
+			world:     consts.Coord[consts.WorldPixel]{X: 0, Y: 0},
+			cameraPos: consts.Coord[consts.WorldPixel]{X: 0, Y: 0},
+			scale:     1,
+			screenW:   960,
+			screenH:   720,
+			want:      consts.Coord[consts.ScreenPixel]{X: 480, Y: 360},
+		},
+		{
+			name:      "カメラがずれると相対位置がずれる",
+			world:     consts.Coord[consts.WorldPixel]{X: 100, Y: 0},
+			cameraPos: consts.Coord[consts.WorldPixel]{X: 50, Y: 0},
+			scale:     1,
+			screenW:   960,
+			screenH:   720,
+			want:      consts.Coord[consts.ScreenPixel]{X: 530, Y: 360},
+		},
+		{
+			name:      "スケール2倍で差分が拡大する",
+			world:     consts.Coord[consts.WorldPixel]{X: 100, Y: 0},
+			cameraPos: consts.Coord[consts.WorldPixel]{X: 0, Y: 0},
+			scale:     2,
+			screenW:   960,
+			screenH:   720,
+			want:      consts.Coord[consts.ScreenPixel]{X: 680, Y: 360},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := consts.WorldToScreen(tt.world, tt.cameraPos, tt.scale, tt.screenW, tt.screenH)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/internal/consts/coord_test.go
+++ b/internal/consts/coord_test.go
@@ -72,15 +72,16 @@ func TestCoord_Sub(t *testing.T) {
 func TestTileCenterToWorld(t *testing.T) {
 	t.Parallel()
 
+	// タイル中心へ半タイル分ずらした位置になる
+	half := consts.TileSize / 2
 	tests := []struct {
 		name string
 		grid consts.Coord[consts.Tile]
 		want consts.Coord[consts.WorldPixel]
 	}{
-		// タイル中心へ半タイル分ずらした位置になる
-		{"原点タイル", consts.Coord[consts.Tile]{X: 0, Y: 0}, consts.Coord[consts.WorldPixel]{X: 16, Y: 16}},
-		{"1マス目", consts.Coord[consts.Tile]{X: 1, Y: 1}, consts.Coord[consts.WorldPixel]{X: 48, Y: 48}},
-		{"XとYが異なる", consts.Coord[consts.Tile]{X: 2, Y: 0}, consts.Coord[consts.WorldPixel]{X: 80, Y: 16}},
+		{"原点タイル", consts.Coord[consts.Tile]{X: 0, Y: 0}, consts.Coord[consts.WorldPixel]{X: half, Y: half}},
+		{"1マス目", consts.Coord[consts.Tile]{X: 1, Y: 1}, consts.Coord[consts.WorldPixel]{X: consts.TileSize + half, Y: consts.TileSize + half}},
+		{"XとYが異なる", consts.Coord[consts.Tile]{X: 2, Y: 0}, consts.Coord[consts.WorldPixel]{X: 2*consts.TileSize + half, Y: half}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -93,6 +94,8 @@ func TestTileCenterToWorld(t *testing.T) {
 func TestWorldToScreen(t *testing.T) {
 	t.Parallel()
 
+	const screenW, screenH = consts.GameWidth, consts.GameHeight
+	centerX, centerY := consts.ScreenPixel(screenW)/2, consts.ScreenPixel(screenH)/2
 	tests := []struct {
 		name      string
 		world     consts.Coord[consts.WorldPixel]
@@ -107,27 +110,27 @@ func TestWorldToScreen(t *testing.T) {
 			world:     consts.Coord[consts.WorldPixel]{X: 0, Y: 0},
 			cameraPos: consts.Coord[consts.WorldPixel]{X: 0, Y: 0},
 			scale:     1,
-			screenW:   960,
-			screenH:   720,
-			want:      consts.Coord[consts.ScreenPixel]{X: 480, Y: 360},
+			screenW:   screenW,
+			screenH:   screenH,
+			want:      consts.Coord[consts.ScreenPixel]{X: centerX, Y: centerY},
 		},
 		{
 			name:      "カメラがずれると相対位置がずれる",
 			world:     consts.Coord[consts.WorldPixel]{X: 100, Y: 0},
 			cameraPos: consts.Coord[consts.WorldPixel]{X: 50, Y: 0},
 			scale:     1,
-			screenW:   960,
-			screenH:   720,
-			want:      consts.Coord[consts.ScreenPixel]{X: 530, Y: 360},
+			screenW:   screenW,
+			screenH:   screenH,
+			want:      consts.Coord[consts.ScreenPixel]{X: centerX + 50, Y: centerY},
 		},
 		{
 			name:      "スケール2倍で差分が拡大する",
 			world:     consts.Coord[consts.WorldPixel]{X: 100, Y: 0},
 			cameraPos: consts.Coord[consts.WorldPixel]{X: 0, Y: 0},
 			scale:     2,
-			screenW:   960,
-			screenH:   720,
-			want:      consts.Coord[consts.ScreenPixel]{X: 680, Y: 360},
+			screenW:   screenW,
+			screenH:   screenH,
+			want:      consts.Coord[consts.ScreenPixel]{X: centerX + 200, Y: centerY},
 		},
 	}
 	for _, tt := range tests {

--- a/internal/consts/coord_test.go
+++ b/internal/consts/coord_test.go
@@ -69,6 +69,23 @@ func TestCoord_Sub(t *testing.T) {
 	}
 }
 
+func TestCoord_Add_float64座標を加算する(t *testing.T) {
+	t.Parallel()
+
+	// WorldPixel/ScreenPixel は float64 基底なので、ジェネリックが float でも動くことを確認する。
+	a := consts.Coord[float64]{X: 1.5, Y: 2.5}
+	b := consts.Coord[float64]{X: 0.5, Y: 1.0}
+	assert.Equal(t, consts.Coord[float64]{X: 2.0, Y: 3.5}, a.Add(b))
+}
+
+func TestCoord_Sub_float64座標を減算する(t *testing.T) {
+	t.Parallel()
+
+	a := consts.Coord[float64]{X: 3.5, Y: 2.0}
+	b := consts.Coord[float64]{X: 1.0, Y: 2.5}
+	assert.Equal(t, consts.Coord[float64]{X: 2.5, Y: -0.5}, a.Sub(b))
+}
+
 func TestTileCenterToWorld(t *testing.T) {
 	t.Parallel()
 

--- a/internal/consts/weight_test.go
+++ b/internal/consts/weight_test.go
@@ -115,3 +115,19 @@ func TestParseWeight_Stringラウンドトリップ(t *testing.T) {
 	assert.Equal(t, "3.5"+consts.IconKg, mg.String())    // 最適単位
 	assert.Equal(t, "3.50"+consts.IconKg, mg.KgString()) // kg固定
 }
+
+func TestMustParseWeight(t *testing.T) {
+	t.Parallel()
+
+	// 成功時は ParseWeight と同じ値を返す
+	assert.Equal(t, consts.Milligram(2_000_000), consts.MustParseWeight("2 kg"))
+}
+
+func TestMustParseWeight_パニック(t *testing.T) {
+	t.Parallel()
+
+	// パース失敗時はパニックする
+	assert.Panics(t, func() {
+		consts.MustParseWeight("不正な値")
+	})
+}


### PR DESCRIPTION
## 概要

`internal/consts` パッケージのテストカバレッジを増強する。本体コードの変更はなく、`*_test.go` の追加・変更のみ。

## カバレッジ

- 変更前: 64.5%
- 変更後: 100.0%

## 追加したテスト

- `coord_test.go`: `Coord[T]` の `String`・`Add`・`Sub`、および `TileCenterToWorld`・`WorldToScreen` の座標変換。タイル中心への半タイルずらしやカメラ変換のスケール・オフセットを table-driven で確認する
- `chunk_test.go`: `Chunk.Tiles` のチャンク数からタイル数への変換。1チャンク・複数チャンク・ゼロチャンクを確認する
- `weight_test.go`: 既存の `ParseWeight` のパニック版である `MustParseWeight` を追加。成功時に同じ値を返すことと、不正な入力でパニックすることを確認する

## 検証

- `go test ./internal/consts/...`: pass、カバレッジ100%
- `make test`: 全パッケージ pass
- `golangci-lint run ./...`: 0 issues
- `go build ./...`: pass

フルの `make check` は CI に委ねる。

---

Generated by an autonomous routine.

Co-Authored-By: Claude <noreply@anthropic.com>


---
_Generated by [Claude Code](https://claude.ai/code/session_016pwgixZiqvUbHBMxVNmnNN)_