### PR TITLE
test(resources): カバレッジ増強

### DIFF
--- a/internal/resources/font_test.go
+++ b/internal/resources/font_test.go
@@ -1,0 +1,27 @@
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewFont_存在するフォントを読み込める(t *testing.T) {
+	t.Parallel()
+
+	f, err := NewFont("file/fonts/dougenzaka/KH-Dot-Dougenzaka-16.ttf")
+
+	require.NoError(t, err)
+	assert.NotNil(t, f.FaceSource)
+	assert.NotNil(t, f.Font)
+}
+
+func TestNewFont_存在しないパスはエラー(t *testing.T) {
+	t.Parallel()
+
+	_, err := NewFont("file/fonts/not-exist.ttf")
+
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "file/fonts/not-exist.ttf")
+}

--- a/internal/resources/fonts_test.go
+++ b/internal/resources/fonts_test.go
@@ -1,0 +1,86 @@
+package resources
+
+import (
+	"testing"
+
+	"github.com/hajimehoshi/ebiten/v2/text/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newTestFaceSource(t *testing.T) *text.GoTextFaceSource {
+	t.Helper()
+
+	f, err := NewFont("file/fonts/dougenzaka/KH-Dot-Dougenzaka-16.ttf")
+	require.NoError(t, err)
+
+	return f.FaceSource
+}
+
+func TestLoadFont_ソースが空ならエラー(t *testing.T) {
+	t.Parallel()
+
+	_, err := loadFont(nil, 16)
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, errNoFontSource)
+}
+
+func TestLoadFont_要素が全てnilならエラー(t *testing.T) {
+	t.Parallel()
+
+	_, err := loadFont([]*text.GoTextFaceSource{nil, nil}, 16)
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, errNoFontSource)
+}
+
+func TestLoadFont_単一ソースはそのままFaceを返す(t *testing.T) {
+	t.Parallel()
+
+	src := newTestFaceSource(t)
+
+	face, err := loadFont([]*text.GoTextFaceSource{src}, 16)
+
+	require.NoError(t, err)
+	assert.NotNil(t, face)
+}
+
+func TestLoadFont_複数ソースはMultiFaceにフォールバックする(t *testing.T) {
+	t.Parallel()
+
+	src1 := newTestFaceSource(t)
+	src2 := newTestFaceSource(t)
+
+	face, err := loadFont([]*text.GoTextFaceSource{src1, src2}, 16)
+
+	require.NoError(t, err)
+	assert.NotNil(t, face)
+	// 複数ソース指定時は text.NewMultiFace が返す *text.MultiFace になる
+	_, ok := face.(*text.MultiFace)
+	assert.True(t, ok)
+}
+
+func TestLoadFonts_成功時は4サイズ分のFaceを持つ(t *testing.T) {
+	t.Parallel()
+
+	src := newTestFaceSource(t)
+
+	fs, err := loadFonts([]*text.GoTextFaceSource{src})
+
+	require.NoError(t, err)
+	assert.NotNil(t, fs.smallFace)
+	assert.NotNil(t, fs.bodyFace)
+	assert.NotNil(t, fs.titleFontFace)
+	assert.NotNil(t, fs.splashFontFace)
+}
+
+func TestLoadFonts_ソースが空ならエラー(t *testing.T) {
+	t.Parallel()
+
+	_, err := loadFonts(nil)
+
+	require.Error(t, err)
+	require.ErrorContains(t, err, "failed to load small font")
+	assert.ErrorIs(t, err, errNoFontSource)
+}

--- a/internal/resources/fonts_test.go
+++ b/internal/resources/fonts_test.go
@@ -69,6 +69,7 @@ func TestLoadFonts_成功時は4サイズ分のFaceを持つ(t *testing.T) {
 	fs, err := loadFonts([]*text.GoTextFaceSource{src})
 
 	require.NoError(t, err)
+	// fonts は非公開型で外部から個別サイズを取り出す手段がないため、同一パッケージのテストとしてフィールドへ直接アクセスする
 	assert.NotNil(t, fs.smallFace)
 	assert.NotNil(t, fs.bodyFace)
 	assert.NotNil(t, fs.titleFontFace)

--- a/internal/resources/images_test.go
+++ b/internal/resources/images_test.go
@@ -79,8 +79,8 @@ func TestLoadImageNineSlice_中央サイズを引いた最小サイズになる(
 
 	require.NoError(t, err)
 	minW, minH := ns.MinSize()
-	// widths/heights は (w-center)/2 と w-(w-center)/2-center に分割されるため、
-	// 両端の合計は常に w-centerWidth, h-centerHeight になる
+	// widths[0] は (w-center)/2 の整数除算結果になるが、widths[2] はその同じ値を
+	// w-center から引いて求めるため、両端の合計は端数に関わらず常に w-centerWidth になる
 	assert.Equal(t, w-centerWidth, minW)
 	assert.Equal(t, h-centerHeight, minH)
 }

--- a/internal/resources/images_test.go
+++ b/internal/resources/images_test.go
@@ -1,0 +1,95 @@
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewImageFromFile_存在する画像を読み込める(t *testing.T) {
+	t.Parallel()
+
+	img, err := newImageFromFile("assets/graphics/button-idle.png")
+
+	require.NoError(t, err)
+	require.NotNil(t, img)
+	assert.Positive(t, img.Bounds().Dx())
+	assert.Positive(t, img.Bounds().Dy())
+}
+
+func TestNewImageFromFile_存在しないパスはエラー(t *testing.T) {
+	t.Parallel()
+
+	_, err := newImageFromFile("assets/graphics/not-exist.png")
+
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "assets/graphics/not-exist.png")
+}
+
+func TestLoadGraphicImages_disabled未指定ならDisabledはnil(t *testing.T) {
+	t.Parallel()
+
+	gi, err := loadGraphicImages("assets/graphics/button-idle.png", "")
+
+	require.NoError(t, err)
+	assert.NotNil(t, gi.Idle)
+	assert.Nil(t, gi.Disabled)
+}
+
+func TestLoadGraphicImages_disabled指定時は両方読み込む(t *testing.T) {
+	t.Parallel()
+
+	gi, err := loadGraphicImages("assets/graphics/button-idle.png", "assets/graphics/button-disabled.png")
+
+	require.NoError(t, err)
+	assert.NotNil(t, gi.Idle)
+	assert.NotNil(t, gi.Disabled)
+}
+
+func TestLoadGraphicImages_idleが存在しなければエラー(t *testing.T) {
+	t.Parallel()
+
+	_, err := loadGraphicImages("assets/graphics/not-exist.png", "")
+
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "assets/graphics/not-exist.png")
+}
+
+func TestLoadGraphicImages_disabledが存在しなければエラー(t *testing.T) {
+	t.Parallel()
+
+	_, err := loadGraphicImages("assets/graphics/button-idle.png", "assets/graphics/not-exist.png")
+
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "assets/graphics/not-exist.png")
+}
+
+func TestLoadImageNineSlice_中央サイズを引いた最小サイズになる(t *testing.T) {
+	t.Parallel()
+
+	path := "assets/graphics/panel-idle.png"
+	img, err := newImageFromFile(path)
+	require.NoError(t, err)
+
+	w, h := img.Bounds().Dx(), img.Bounds().Dy()
+	centerWidth, centerHeight := w/2, h/2
+
+	ns, err := loadImageNineSlice(path, centerWidth, centerHeight)
+
+	require.NoError(t, err)
+	minW, minH := ns.MinSize()
+	// widths/heights は (w-center)/2 と w-(w-center)/2-center に分割されるため、
+	// 両端の合計は常に w-centerWidth, h-centerHeight になる
+	assert.Equal(t, w-centerWidth, minW)
+	assert.Equal(t, h-centerHeight, minH)
+}
+
+func TestLoadImageNineSlice_存在しないパスはエラー(t *testing.T) {
+	t.Parallel()
+
+	_, err := loadImageNineSlice("assets/graphics/not-exist.png", 1, 1)
+
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "assets/graphics/not-exist.png")
+}

--- a/internal/resources/resources_test.go
+++ b/internal/resources/resources_test.go
@@ -1,0 +1,47 @@
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetScreenDimensions_SetScreenDimensionsで設定した値を取得できる(t *testing.T) {
+	t.Parallel()
+
+	r := &Resources{}
+	r.SetScreenDimensions(1920, 1080)
+
+	w, h := r.GetScreenDimensions()
+	assert.Equal(t, 1920, w)
+	assert.Equal(t, 1080, h)
+}
+
+func TestInitGameResources_マップフィールドが空で初期化される(t *testing.T) {
+	t.Parallel()
+
+	r := InitGameResources()
+
+	require.NotNil(t, r.SpriteSheets)
+	require.NotNil(t, r.Fonts)
+	require.NotNil(t, r.Faces)
+	assert.Empty(t, r.SpriteSheets)
+	assert.Empty(t, r.Fonts)
+	assert.Empty(t, r.Faces)
+	assert.Equal(t, ScreenDimensions{}, r.ScreenDimensions)
+}
+
+func TestInitializeResources_エラーなくフィールドを置き換える(t *testing.T) {
+	t.Parallel()
+
+	r := &Resources{}
+	// 事前に値を入れておき、InitializeResources で上書きされることを確認する
+	r.SetScreenDimensions(100, 100)
+
+	err := r.InitializeResources()
+
+	require.NoError(t, err)
+	assert.NotNil(t, r.SpriteSheets)
+	assert.Equal(t, ScreenDimensions{}, r.ScreenDimensions)
+}

--- a/internal/resources/resources_test.go
+++ b/internal/resources/resources_test.go
@@ -43,5 +43,10 @@ func TestInitializeResources_エラーなくフィールドを置き換える(t 
 
 	require.NoError(t, err)
 	assert.NotNil(t, r.SpriteSheets)
-	assert.Equal(t, ScreenDimensions{}, r.ScreenDimensions)
+	assert.NotNil(t, r.Fonts)
+	assert.NotNil(t, r.Faces)
+	// SetScreenDimensions で設定した値は *r 全体の置き換えにより消える
+	w, h := r.GetScreenDimensions()
+	assert.Zero(t, w)
+	assert.Zero(t, h)
 }

--- a/internal/resources/ui_test.go
+++ b/internal/resources/ui_test.go
@@ -1,0 +1,40 @@
+package resources
+
+import (
+	"image/color"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHexToColor(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		hex  string
+		want color.NRGBA
+	}{
+		{"白", "ffffff", color.NRGBA{R: 255, G: 255, B: 255, A: 255}},
+		{"黒", "000000", color.NRGBA{R: 0, G: 0, B: 0, A: 255}},
+		{"赤", "ff0000", color.NRGBA{R: 255, G: 0, B: 0, A: 255}},
+		{"緑", "00ff00", color.NRGBA{R: 0, G: 255, B: 0, A: 255}},
+		{"青", "0000ff", color.NRGBA{R: 0, G: 0, B: 255, A: 255}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := hexToColor(tc.hex)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestHexToColor_不正な16進数文字列はpanicする(t *testing.T) {
+	t.Parallel()
+
+	assert.Panics(t, func() {
+		hexToColor("zzzzzz")
+	})
+}


### PR DESCRIPTION
## 概要

`internal/resources` パッケージのテストカバレッジを増強する。

このパッケージはカバレッジ0%だった。ゲーム固有のリソース管理を担う中心的なパッケージで、画面寸法の保持、リソース初期化、フォント読み込み、UIリソース構築に使う画像読み込みユーティリティなどを持つが、テストが一切なかった。

## 変更内容

- `resources.go`: `SetScreenDimensions`/`GetScreenDimensions` の値受け渡し、`InitGameResources` がマップフィールドを空で初期化すること、`InitializeResources` が既存フィールドを上書き初期化することを検証
- `font.go`: `NewFont` の正常系（実フォントファイルの読み込み）と異常系（存在しないパスでエラー）を検証。エラー内容まで確認
- `fonts.go`: `loadFont`/`loadFonts` のソース0件・全nil時のエラー、単一ソース時・複数ソース時のフォールバック挙動を検証
- `images.go`: `newImageFromFile`/`loadGraphicImages`/`loadImageNineSlice` の正常系・異常系を実アセットで検証。ナインスライスは中央サイズを引いた最小サイズになる不変条件を検証
- `ui.go`: `hexToColor` の色変換と、不正な16進数文字列でのpanicを検証

本体コードの変更はなく、`*_test.go` の追加のみ。

## カバレッジ

`internal/resources`: 0.0% → 22.0%

`ui.go` の `New*Resources` 系の大きな構築関数群は、多数の画像アセットを組み合わせるものでスコープが大きいため今回は対象外にした。

## 検証

- `go test ./internal/resources/...`
- `golangci-lint run ./internal/resources/...`
- `go build ./...`
- `make test`・`golangci-lint run ./...` のフルスイートで回帰なしを確認


---
_Generated by [Claude Code](https://claude.ai/code/session_017MgbWsmXohaGu6fg5nBEJ8)_