### PR TITLE
test(config): カバレッジ増強

### DIFF
--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,8 +1,10 @@
 package config
 
 import (
+	"os"
 	"testing"
 
+	"github.com/sebdah/goldie/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -44,7 +46,7 @@ func TestApplyProfileDefaults_UnknownProfile(t *testing.T) {
 	assert.False(t, cfg.SkipOpening)
 }
 
-func TestConfig_String(t *testing.T) {
+func TestConfig_StringGolden(t *testing.T) {
 	t.Parallel()
 
 	c := &Config{
@@ -58,11 +60,20 @@ func TestConfig_String(t *testing.T) {
 		ProfilePath: ".",
 	}
 
-	s := c.String()
-	assert.Contains(t, s, "Profile: development")
-	assert.Contains(t, s, "WindowWidth: 800, WindowHeight: 600")
-	assert.Contains(t, s, "Seed: 42")
-	assert.Contains(t, s, "TargetFPS: 30")
+	assertGoldenText(t, "config_string", c.String())
+}
+
+// assertGoldenText は文字列を testdata/<name>.golden と比較する。
+// GOLDIE_UPDATE=1 で golden を更新する。make updategolden から拾えるようテスト名には Golden を含める。
+func assertGoldenText(t *testing.T, name, actual string) {
+	t.Helper()
+
+	g := goldie.New(t, goldie.WithFixtureDir("testdata"), goldie.WithNameSuffix(".golden"))
+	if v := os.Getenv("GOLDIE_UPDATE"); v == "1" || v == "true" {
+		require.NoError(t, g.Update(t, name, []byte(actual)))
+		return
+	}
+	g.Assert(t, name, []byte(actual))
 }
 
 func TestLoad(t *testing.T) {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,7 +1,6 @@
 package config
 
 import (
-	"os"
 	"testing"
 
 	"github.com/sebdah/goldie/v2"
@@ -60,20 +59,8 @@ func TestConfig_StringGolden(t *testing.T) {
 		ProfilePath: ".",
 	}
 
-	assertGoldenText(t, "config_string", c.String())
-}
-
-// assertGoldenText は文字列を testdata/<name>.golden と比較する。
-// GOLDIE_UPDATE=1 で golden を更新する。make updategolden から拾えるようテスト名には Golden を含める。
-func assertGoldenText(t *testing.T, name, actual string) {
-	t.Helper()
-
-	g := goldie.New(t)
-	if v := os.Getenv("GOLDIE_UPDATE"); v == "1" || v == "true" {
-		require.NoError(t, g.Update(t, name, []byte(actual)))
-		return
-	}
-	g.Assert(t, name, []byte(actual))
+	// goldie は GOLDIE_UPDATE=1 のとき golden を更新する。make updategolden から拾えるようテスト名に Golden を含める。
+	goldie.New(t).Assert(t, "config_string", []byte(c.String()))
 }
 
 func TestLoad(t *testing.T) {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -44,6 +44,27 @@ func TestApplyProfileDefaults_UnknownProfile(t *testing.T) {
 	assert.False(t, cfg.SkipOpening)
 }
 
+func TestConfig_String(t *testing.T) {
+	t.Parallel()
+
+	c := &Config{
+		Profile:     ProfileDevelopment,
+		User:        UserConfig{WindowWidth: 800, WindowHeight: 600},
+		Debug:       true,
+		LogLevel:    "debug",
+		Seed:        42,
+		TargetFPS:   30,
+		PProfPort:   6060,
+		ProfilePath: ".",
+	}
+
+	s := c.String()
+	assert.Contains(t, s, "Profile: development")
+	assert.Contains(t, s, "WindowWidth: 800, WindowHeight: 600")
+	assert.Contains(t, s, "Seed: 42")
+	assert.Contains(t, s, "TargetFPS: 30")
+}
+
 func TestLoad(t *testing.T) {
 	t.Parallel()
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -68,7 +68,7 @@ func TestConfig_StringGolden(t *testing.T) {
 func assertGoldenText(t *testing.T, name, actual string) {
 	t.Helper()
 
-	g := goldie.New(t, goldie.WithFixtureDir("testdata"), goldie.WithNameSuffix(".golden"))
+	g := goldie.New(t)
 	if v := os.Getenv("GOLDIE_UPDATE"); v == "1" || v == "true" {
 		require.NoError(t, g.Update(t, name, []byte(actual)))
 		return

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -59,7 +59,6 @@ func TestConfig_StringGolden(t *testing.T) {
 		ProfilePath: ".",
 	}
 
-	// goldie は GOLDIE_UPDATE=1 のとき golden を更新する。make updategolden から拾えるようテスト名に Golden を含める。
 	goldie.New(t).Assert(t, "config_string", []byte(c.String()))
 }
 

--- a/internal/config/store_desktop_test.go
+++ b/internal/config/store_desktop_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/BurntSushi/toml"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -53,4 +54,135 @@ func TestSettingsExistAt(t *testing.T) {
 	ok, err = settingsExistAt(path)
 	require.NoError(t, err)
 	assert.True(t, ok)
+}
+
+// 以下は XDG_CONFIG_HOME を書き換えてパス解決を検証するため、
+// t.Setenv の制約上 t.Parallel は呼ばない。
+
+func TestUserConfigPath_XDG_CONFIG_HOME配下にrunisディレクトリを作る(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", dir)
+
+	path, err := userConfigPath()
+	require.NoError(t, err)
+	assert.Equal(t, filepath.Join(dir, "ruins", "settings.toml"), path)
+}
+
+func TestWriteSettings_ReadSettings_SettingsExist_ラウンドトリップ(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", dir)
+
+	ok, err := settingsExist()
+	require.NoError(t, err)
+	assert.False(t, ok)
+
+	_, ok, err = readSettings()
+	require.NoError(t, err)
+	assert.False(t, ok)
+
+	require.NoError(t, writeSettings([]byte("window_width = 1280\n")))
+
+	ok, err = settingsExist()
+	require.NoError(t, err)
+	assert.True(t, ok)
+
+	data, ok, err := readSettings()
+	require.NoError(t, err)
+	assert.True(t, ok)
+	assert.Equal(t, "window_width = 1280\n", string(data))
+}
+
+func TestSaveUserConfig(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", dir)
+
+	c := &Config{User: UserConfig{WindowWidth: 1600, WindowHeight: 900, Language: "en"}}
+	require.NoError(t, c.SaveUserConfig())
+
+	data, ok, err := readSettings()
+	require.NoError(t, err)
+	require.True(t, ok)
+
+	var got UserConfig
+	require.NoError(t, toml.Unmarshal(data, &got))
+	assert.Equal(t, c.User, got)
+}
+
+func TestEnsureUserConfigFile_ファイルが無ければデフォルト値で作成する(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", dir)
+
+	require.NoError(t, EnsureUserConfigFile())
+
+	ok, err := settingsExist()
+	require.NoError(t, err)
+	assert.True(t, ok)
+
+	data, _, err := readSettings()
+	require.NoError(t, err)
+	var got UserConfig
+	require.NoError(t, toml.Unmarshal(data, &got))
+	assert.Equal(t, DefaultUserConfig(), got)
+}
+
+func TestEnsureUserConfigFile_既にあれば上書きしない(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", dir)
+
+	require.NoError(t, writeSettings([]byte("window_width = 1280\n")))
+	require.NoError(t, EnsureUserConfigFile())
+
+	data, _, err := readSettings()
+	require.NoError(t, err)
+	assert.Equal(t, "window_width = 1280\n", string(data))
+}
+
+func TestLoadUserConfig_保存済み設定がなければ何もしない(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", dir)
+
+	c := &Config{User: DefaultUserConfig()}
+	require.NoError(t, c.loadUserConfig())
+	assert.Equal(t, DefaultUserConfig(), c.User)
+}
+
+func TestLoadUserConfig_保存済み設定を読み込んで上書きする(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", dir)
+	require.NoError(t, writeSettings([]byte("window_width = 1280\n")))
+
+	c := &Config{User: DefaultUserConfig()}
+	require.NoError(t, c.loadUserConfig())
+	assert.Equal(t, 1280, c.User.WindowWidth)
+	assert.Equal(t, 720, c.User.WindowHeight) // 保存に無いフィールドはデフォルトが残る
+}
+
+func TestLoadUserConfig_不正なTOMLはエラーを返す(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", dir)
+	require.NoError(t, writeSettings([]byte("window_width = [invalid")))
+
+	c := &Config{User: DefaultUserConfig()}
+	err := c.loadUserConfig()
+	assert.ErrorContains(t, err, "設定の解析に失敗しました")
+}
+
+func TestLoad_RUINS_SEEDを指定すると再現可能なSeedになる(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", dir)
+	t.Setenv("RUINS_SEED", "12345")
+
+	cfg, err := Load()
+	require.NoError(t, err)
+	assert.Equal(t, uint64(12345), cfg.Seed)
+}
+
+func TestLoad_ユーザー設定ファイルが不正でもデフォルト値で継続する(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", dir)
+	require.NoError(t, writeSettings([]byte("window_width = [invalid")))
+
+	cfg, err := Load()
+	require.NoError(t, err)
+	assert.Equal(t, 960, cfg.User.WindowWidth) // 不正な設定は無視されデフォルトが残る
 }

--- a/internal/config/store_desktop_test.go
+++ b/internal/config/store_desktop_test.go
@@ -59,7 +59,7 @@ func TestSettingsExistAt(t *testing.T) {
 // 以下は XDG_CONFIG_HOME を書き換えてパス解決を検証するため、
 // t.Setenv の制約上 t.Parallel は呼ばない。
 
-func TestUserConfigPath_XDG_CONFIG_HOME配下にrunisディレクトリを作る(t *testing.T) {
+func TestUserConfigPath_XDG_CONFIG_HOME配下にruinsディレクトリを作る(t *testing.T) {
 	dir := t.TempDir()
 	t.Setenv("XDG_CONFIG_HOME", dir)
 

--- a/internal/config/store_desktop_test.go
+++ b/internal/config/store_desktop_test.go
@@ -132,8 +132,9 @@ func TestEnsureUserConfigFile_既にあれば上書きしない(t *testing.T) {
 	require.NoError(t, writeSettings([]byte("window_width = 1280\n")))
 	require.NoError(t, EnsureUserConfigFile())
 
-	data, _, err := readSettings()
+	data, ok, err := readSettings()
 	require.NoError(t, err)
+	require.True(t, ok)
 	assert.Equal(t, "window_width = 1280\n", string(data))
 }
 

--- a/internal/config/testdata/config_string.golden
+++ b/internal/config/testdata/config_string.golden
@@ -1,0 +1,9 @@
+Config{
+	Profile: development,
+	WindowWidth: 800, WindowHeight: 600,
+	Debug: true, LogLevel: debug, LogCategories: , DebugPProf: false, PProfPort: 6060,
+	Seed: 42,
+	TargetFPS: 30,
+	ProfileMemory: false, ProfileCPU: false, ProfileMutex: false, ProfileTrace: false,
+	ProfilePath: .
+}


### PR DESCRIPTION
## 概要

`internal/config` パッケージのテストのみを追加してカバレッジを増強する。本体コードは変更しない。

## カバレッジ

- 変更前: 55.5%相当（`go test -cover` の statement coverage、xvfb+bwrap環境での実測）
- 変更後: 87.8%

## 追加したテストと狙った振る舞い

`store_desktop_test.go`
- `userConfigPath`: `XDG_CONFIG_HOME` 配下に `ruins/settings.toml` のパスを組み立てること
- `writeSettings` / `readSettings` / `settingsExist`: 環境変数経由のパス解決を通したラウンドトリップ
- `SaveUserConfig`: `Config.User` をTOMLへ永続化し、読み戻して一致すること
- `EnsureUserConfigFile`: ファイルが無ければデフォルト値で作成し、既にあれば上書きしないこと
- `loadUserConfig`: 保存済み設定が無ければ何もしない、保存値で上書きしつつ未保存フィールドはデフォルトが残る、不正なTOMLはエラーになること
- `Load`: `RUINS_SEED` 指定時にSeedが再現可能になること、ユーザー設定ファイルが不正でもデフォルト値で起動を継続すること

`config_test.go`
- `Config.String`: デバッグ用の文字列表現に主要フィールドが含まれること

いずれも `XDG_CONFIG_HOME` を `t.TempDir()` に差し替えることで、実際のユーザー設定を汚さずにファイルI/Oを検証している。`t.Setenv` を使うテストは仕様上 `t.Parallel` を呼んでいない。

## 検証

- `go test -v -cover ./internal/config/...` : 全テストPASS、カバレッジ 87.8%
- `golangci-lint run ./internal/config/...` : 0 issues
- `go build ./...`: 成功
- フル `make test` 相当（xvfb + bwrap経由）: 既存テストへの影響なし、FAILなし
- `go tool deadcode -test`: config パッケージ関連の unreachable func なし

---
_Generated by [Claude Code](https://claude.ai/code/session_01RLihAUv4ixwtkRGMjfigxE)_