### PR TITLE
test(resources): カバレッジ増強

### DIFF
--- a/internal/resources/ui_test.go
+++ b/internal/resources/ui_test.go
@@ -4,8 +4,74 @@ import (
 	"image/color"
 	"testing"
 
+	"github.com/hajimehoshi/ebiten/v2/text/v2"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+func TestNewUIResources_正常系で全リソースが構築される(t *testing.T) {
+	t.Parallel()
+
+	src := newTestFaceSource(t)
+
+	ui, err := NewUIResources([]*text.GoTextFaceSource{src})
+
+	require.NoError(t, err)
+	assert.NotNil(t, ui.Fonts)
+	assert.NotNil(t, ui.Background)
+	assert.NotNil(t, ui.SeparatorColor)
+	assert.NotNil(t, ui.GradientLine)
+	assert.NotNil(t, ui.GaugeFill)
+	assert.NotNil(t, ui.Text)
+	assert.NotNil(t, ui.Text.SmallFace)
+	assert.NotNil(t, ui.Text.BodyFace)
+	assert.NotNil(t, ui.Text.TitleFontFace)
+	assert.NotNil(t, ui.Text.SplashFontFace)
+	assert.NotNil(t, ui.Button)
+	assert.NotNil(t, ui.Button.Image)
+	assert.NotNil(t, ui.Label)
+	assert.NotNil(t, ui.Checkbox)
+	assert.NotNil(t, ui.Checkbox.Image)
+	assert.NotNil(t, ui.Checkbox.Graphic)
+	assert.NotNil(t, ui.ComboButton)
+	assert.NotNil(t, ui.ComboButton.Graphic)
+	assert.NotNil(t, ui.List)
+	assert.NotNil(t, ui.List.Image)
+	assert.NotNil(t, ui.List.ImageTrans)
+	assert.NotNil(t, ui.List.Track)
+	assert.NotNil(t, ui.List.Handle)
+	assert.NotNil(t, ui.Slider)
+	assert.NotNil(t, ui.Slider.TrackImage)
+	assert.NotNil(t, ui.Slider.Handle)
+	assert.NotNil(t, ui.ProgressBar)
+	assert.NotNil(t, ui.ProgressBar.TrackImage)
+	assert.NotNil(t, ui.ProgressBar.FillImage)
+	assert.NotNil(t, ui.Panel)
+	assert.NotNil(t, ui.Panel.Image)
+	assert.NotNil(t, ui.Panel.TitleBar)
+	assert.NotNil(t, ui.Panel.SelectionBar)
+	assert.NotNil(t, ui.TabBook)
+	assert.NotNil(t, ui.TabBook.ButtonFace)
+	assert.NotNil(t, ui.Header)
+	assert.NotNil(t, ui.Header.Background)
+	assert.NotNil(t, ui.TextInput)
+	assert.NotNil(t, ui.TextInput.Image)
+	assert.NotNil(t, ui.TextArea)
+	assert.NotNil(t, ui.TextArea.Image)
+	assert.NotNil(t, ui.ToolTip)
+	assert.NotNil(t, ui.ToolTip.Background)
+}
+
+func TestNewUIResources_フォントソースが空だとエラー(t *testing.T) {
+	t.Parallel()
+
+	ui, err := NewUIResources(nil)
+
+	require.Error(t, err)
+	require.ErrorIs(t, err, errNoFontSource)
+	require.ErrorContains(t, err, "failed to load small font")
+	assert.Equal(t, UIResources{}, ui)
+}
 
 func TestHexToColor(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
## 概要

`internal/resources` パッケージのテストのみを追加してカバレッジを増強する。本体コードは変更しない。

先行の #520 で `resources.go`・`font.go`・`fonts.go`・`images.go`・`hexToColor` はカバー済みだったが、`ui.go` の `NewUIResources` とその内部で呼ばれる `New*Resources` 系の構築関数群は「スコープが大きい」として対象外にされ、カバレッジ0%のまま残っていた。これらはすべて `NewUIResources` からのみ呼ばれるため、`NewUIResources` を1回実行するテストでまとめて経路をカバーできることを確認して追加した。

## カバレッジ

- 変更前: 22.0%
- 変更後: 75.1%

## 追加したテストと狙った振る舞い

`ui_test.go`

- `NewUIResources`: フォントソースが揃っている正常系で、`Background`・`Text`・`Button`・`Label`・`Checkbox`・`ComboButton`・`List`・`Slider`・`ProgressBar`・`Panel`・`TabBook`・`Header`・`TextInput`・`TextArea`・`ToolTip` の各リソースおよびその主要フィールドが構築されることを検証する。これにより内部の `newButtonResources` 等の非公開ビルダー関数群も実行経路として通る
- `NewUIResources`: フォントソースが空のときに `loadFonts` 由来のエラーが伝播すること、`errNoFontSource` を含むこと、返り値がゼロ値になることを検証する

## 検証

- `go test -v -cover ./internal/resources/...`: 全テストPASS、カバレッジ75.1%
- `golangci-lint run ./internal/resources/...`: 0 issues
- `go build ./...`: 成功
- フル `make test` 相当: `bwrap ... xvfb-run -a go test -cover -shuffle=on ./...` で全パッケージPASS、回帰なし
- フル `make lint` 相当: `golangci-lint run -v ./...` 0 issues、`go tool deadcode -test ./...` で unreachable func なし

---
_Generated by [Claude Code](https://claude.ai/code/session_01B54r7fH1mBwSstjf9c1q1W)_