### PR TITLE
refactor(test): designdoc の golden 更新を goldie 標準に任せる

### DIFF
--- a/internal/designdoc/readme_golden_test.go
+++ b/internal/designdoc/readme_golden_test.go
@@ -1,24 +1,18 @@
 package designdoc
 
 import (
-	"os"
 	"testing"
 
 	"github.com/sebdah/goldie/v2"
-	"github.com/stretchr/testify/require"
 )
 
-// assertGoldenMarkdown は markdown 文字列をゴールデンファイルと比較する。
-// GOLDIE_UPDATE=1 で実行すると testdata/<name>.golden.md を更新する。make updategolden から拾えるよう
-// テスト名には Golden を含める。
+// assertGoldenMarkdown は markdown 文字列を testdata/<name>.golden.md と比較する。
+// goldie が GOLDIE_UPDATE=1 のとき golden を更新する。make updategolden から拾えるようテスト名には Golden を含める。
 func assertGoldenMarkdown(t *testing.T, name, actual string) {
 	t.Helper()
 
-	g := goldie.New(t, goldie.WithFixtureDir("testdata"), goldie.WithNameSuffix(".golden.md"))
-	if v := os.Getenv("GOLDIE_UPDATE"); v == "1" || v == "true" {
-		require.NoError(t, g.Update(t, name, []byte(actual)))
-		return
-	}
+	// 拡張子はエディタで開きやすいよう .golden.md にする。goldie 既定の .golden から変える
+	g := goldie.New(t, goldie.WithNameSuffix(".golden.md"))
 	g.Assert(t, name, []byte(actual))
 }
 

--- a/internal/designdoc/readme_golden_test.go
+++ b/internal/designdoc/readme_golden_test.go
@@ -6,12 +6,11 @@ import (
 	"github.com/sebdah/goldie/v2"
 )
 
-// assertGoldenMarkdown は markdown 文字列を testdata/<name>.golden.md と比較する。
-// goldie が GOLDIE_UPDATE=1 のとき golden を更新する。make updategolden から拾えるようテスト名には Golden を含める。
+// assertGoldenMarkdown は markdown をゴールデンファイルと比較する。
 func assertGoldenMarkdown(t *testing.T, name, actual string) {
 	t.Helper()
 
-	// 拡張子はエディタで開きやすいよう .golden.md にする。goldie 既定の .golden から変える
+	// エディタで markdown として開けるよう拡張子を .golden.md にする
 	g := goldie.New(t, goldie.WithNameSuffix(".golden.md"))
 	g.Assert(t, name, []byte(actual))
 }


### PR DESCRIPTION
## 背景

golden ヘルパにある `if os.Getenv("GOLDIE_UPDATE") == "1" { g.Update(...) }` の手動分岐は、goldie の再実装で冗長だった。goldie は `-update` フラグの既定値を `os.Getenv("GOLDIE_UPDATE")` から取る仕様のため、`g.Assert` を呼ぶだけで `GOLDIE_UPDATE=1` のとき golden を更新する。

```go
// goldie.go
update = flag.Bool("update", truthy(os.Getenv("GOLDIE_UPDATE")), "Update golden test file fixture")
```

## 変更

`internal/designdoc/readme_golden_test.go` の `assertGoldenMarkdown` を標準の `g.Assert` 一本に簡略化。

- 手動 env 分岐を除去。`os` と `require` の import も除去。
- デフォルトと同じ `WithFixtureDir("testdata")` も除去。
- 非デフォルトの `WithNameSuffix(".golden.md")` は残す。

## vrt は据え置く

`internal/vrt/golden.go` の `isGoldieUpdate` も一見同型だが、こちらは**更新モードでもトレランス内なら golden を上書きしない**独自ロジックのトリガ。標準 `Assert` には無い挙動なので冗長ではなく、そのまま残す。

## 検証

`GOLDIE_UPDATE=1 go test -run Golden` で golden を壊しても標準 Assert だけで復元されること、env なしでは差分検出で FAIL することを実測で確認。`make updategolden` は `GOLDIE_UPDATE=1` を渡すので従来どおり更新できる。

🤖 Generated with [Claude Code](https://claude.com/claude-code)