### PR TITLE
test(widgets/messagewindow): カバレッジ増強

### DIFF
--- a/internal/widgets/messagewindow/queue_test.go
+++ b/internal/widgets/messagewindow/queue_test.go
@@ -1,0 +1,143 @@
+package messagewindow
+
+import (
+	"testing"
+
+	"github.com/kijimaD/ruins/internal/messagedata"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewQueueManager_初期状態は空(t *testing.T) {
+	t.Parallel()
+
+	q := NewQueueManager()
+
+	assert.Equal(t, 0, q.Size())
+	assert.False(t, q.HasNext())
+	assert.Nil(t, q.Current())
+}
+
+func TestQueueManager_Enqueue(t *testing.T) {
+	t.Parallel()
+
+	t.Run("メッセージを末尾に追加する", func(t *testing.T) {
+		t.Parallel()
+
+		q := NewQueueManager()
+		msg1 := messagedata.NewSystemMessage("1件目")
+		msg2 := messagedata.NewSystemMessage("2件目")
+
+		q.Enqueue(msg1)
+		q.Enqueue(msg2)
+
+		assert.Equal(t, 2, q.Size())
+		assert.True(t, q.HasNext())
+		assert.Equal(t, msg1, q.Dequeue())
+		assert.Equal(t, msg2, q.Dequeue())
+	})
+
+	t.Run("複数メッセージをまとめて追加する", func(t *testing.T) {
+		t.Parallel()
+
+		q := NewQueueManager()
+		msg1 := messagedata.NewSystemMessage("1件目")
+		msg2 := messagedata.NewSystemMessage("2件目")
+
+		q.Enqueue(msg1, msg2)
+
+		assert.Equal(t, 2, q.Size())
+	})
+}
+
+func TestQueueManager_EnqueueFront(t *testing.T) {
+	t.Parallel()
+
+	q := NewQueueManager()
+	msg1 := messagedata.NewSystemMessage("後発")
+	msg2 := messagedata.NewSystemMessage("先発")
+
+	q.Enqueue(msg1)
+	q.EnqueueFront(msg2)
+
+	assert.Equal(t, 2, q.Size())
+	assert.Equal(t, msg2, q.Dequeue())
+	assert.Equal(t, msg1, q.Dequeue())
+}
+
+func TestQueueManager_Dequeue(t *testing.T) {
+	t.Parallel()
+
+	t.Run("空のキューはnilを返しCurrentも変化しない", func(t *testing.T) {
+		t.Parallel()
+
+		q := NewQueueManager()
+
+		assert.Nil(t, q.Dequeue())
+		assert.Nil(t, q.Current())
+	})
+
+	t.Run("取り出したメッセージがCurrentになりキューから除かれる", func(t *testing.T) {
+		t.Parallel()
+
+		q := NewQueueManager()
+		msg := messagedata.NewSystemMessage("対象")
+		q.Enqueue(msg)
+
+		got := q.Dequeue()
+
+		assert.Equal(t, msg, got)
+		assert.Equal(t, msg, q.Current())
+		assert.Equal(t, 0, q.Size())
+	})
+
+	t.Run("連鎖メッセージを持つ場合は次のメッセージがキュー先頭に展開される", func(t *testing.T) {
+		t.Parallel()
+
+		q := NewQueueManager()
+		chained := messagedata.NewSystemMessage("開始").
+			SystemMessage("連鎖1").
+			SystemMessage("連鎖2")
+		after := messagedata.NewSystemMessage("後続")
+		q.Enqueue(chained, after)
+
+		require.Equal(t, chained, q.Dequeue())
+		require.Equal(t, 3, q.Size())
+
+		next1 := q.Dequeue()
+		next2 := q.Dequeue()
+		last := q.Dequeue()
+
+		assert.Equal(t, chained.GetNextMessages()[0], next1)
+		assert.Equal(t, chained.GetNextMessages()[1], next2)
+		assert.Equal(t, after, last)
+	})
+}
+
+func TestQueueManager_HasNext(t *testing.T) {
+	t.Parallel()
+
+	q := NewQueueManager()
+	assert.False(t, q.HasNext())
+
+	q.Enqueue(messagedata.NewSystemMessage("メッセージ"))
+	assert.True(t, q.HasNext())
+
+	q.Dequeue()
+	assert.False(t, q.HasNext())
+}
+
+func TestQueueManager_Clear(t *testing.T) {
+	t.Parallel()
+
+	q := NewQueueManager()
+	q.Enqueue(messagedata.NewSystemMessage("1件目"), messagedata.NewSystemMessage("2件目"))
+	q.Dequeue()
+	require.NotNil(t, q.Current())
+
+	q.Clear()
+
+	assert.Equal(t, 0, q.Size())
+	assert.False(t, q.HasNext())
+	assert.Nil(t, q.Current())
+}

--- a/internal/widgets/messagewindow/queue_test.go
+++ b/internal/widgets/messagewindow/queue_test.go
@@ -111,6 +111,7 @@ func TestQueueManager_Dequeue(t *testing.T) {
 		assert.Equal(t, chained.GetNextMessages()[0], next1)
 		assert.Equal(t, chained.GetNextMessages()[1], next2)
 		assert.Equal(t, after, last)
+		assert.Equal(t, 0, q.Size())
 	})
 }
 


### PR DESCRIPTION
## 概要

`internal/widgets/messagewindow` の `QueueManager` にテストを追加してカバレッジを増強する。本体コードは変更しない。

このパッケージはメッセージウィンドウの描画中心で全体のテストは書きにくいが、`queue.go` はEbitenに依存しないメッセージキューの純粋なロジックで、既存テストが一件もなかった。

## カバレッジ

- 変更前: `internal/widgets/messagewindow` 全体 0.0%
- 変更後: `internal/widgets/messagewindow` 全体 5.3%、`queue.go` 内の全関数は100.0%

## 追加したテストと狙った振る舞い

`queue_test.go`

- `NewQueueManager`: 初期状態でキューが空、`HasNext` が `false`、`Current` が `nil` であること
- `Enqueue`: メッセージを末尾に追加すること、複数メッセージをまとめて追加できること
- `EnqueueFront`: メッセージをキューの先頭に追加すること
- `Dequeue`: 空のキューでは `nil` を返し `Current` が変化しないこと、取り出したメッセージが `Current` になりキューから除かれること、連鎖メッセージを持つメッセージを取り出した場合は連鎖先が即座にキュー先頭へ展開されること
- `HasNext`: キューの有無に応じて切り替わること
- `Clear`: キューと `Current` が両方ともリセットされること

## 検証

- `go test -v -cover ./internal/widgets/messagewindow/...`: 全テストPASS、カバレッジ0.0% → 5.3%
- `golangci-lint run ./internal/widgets/messagewindow/...`: 0 issues
- `go build ./...`: 成功
- フル `make test`: 全パッケージPASS、回帰なし
- フル `make lint`: `golangci-lint run` は0 issues。`govulncheck` はサンドボックス環境のネットワークポリシーで `vuln.go.dev` への接続がブロックされ実行不可だった


---
_Generated by [Claude Code](https://claude.ai/code/session_01NnEBbHBE9Cn5AKfubVteHR)_