### PR TITLE
test(dungeon): カバレッジ増強

### DIFF
--- a/internal/dungeon/definition_test.go
+++ b/internal/dungeon/definition_test.go
@@ -4,6 +4,7 @@ import (
 	"math/rand/v2"
 	"testing"
 
+	"github.com/kijimaD/ruins/internal/consts"
 	"github.com/kijimaD/ruins/internal/mapplanner"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -126,4 +127,58 @@ func TestSelectPlanner(t *testing.T) {
 		// 異なる結果が一定数あるはず
 		assert.Greater(t, differentCount, 10)
 	})
+}
+
+func TestDungeonDefinition_BossPlanner(t *testing.T) {
+	t.Parallel()
+
+	boss := mapplanner.PlannerTypeBossFloor
+
+	t.Run("ボスプランナーがあり最終階なら取得できる", func(t *testing.T) {
+		t.Parallel()
+		def := DungeonDefinition{
+			name:        "テスト",
+			totalFloors: 20,
+			bossPlanner: &boss,
+		}
+		result, ok := def.BossPlanner(20)
+		assert.True(t, ok)
+		assert.Equal(t, boss.Name, result.Name)
+	})
+
+	t.Run("ボスプランナーがあっても最終階でなければ取得できない", func(t *testing.T) {
+		t.Parallel()
+		def := DungeonDefinition{
+			name:        "テスト",
+			totalFloors: 20,
+			bossPlanner: &boss,
+		}
+		result, ok := def.BossPlanner(19)
+		assert.False(t, ok)
+		assert.Equal(t, mapplanner.PlannerType{}, result)
+	})
+
+	t.Run("ボスプランナーが設定されていなければ最終階でも取得できない", func(t *testing.T) {
+		t.Parallel()
+		def := DungeonDefinition{
+			name:        "テスト",
+			totalFloors: 20,
+		}
+		result, ok := def.BossPlanner(20)
+		assert.False(t, ok)
+		assert.Equal(t, mapplanner.PlannerType{}, result)
+	})
+}
+
+func TestNewOverworldDefinition_フィールドを保持する(t *testing.T) {
+	t.Parallel()
+
+	def := NewOverworldDefinition("テスト帯", 7, consts.Tile(30), consts.Tile(40), consts.Chunk(2))
+
+	assert.Equal(t, "テスト帯", def.Name())
+	assert.Equal(t, 7, def.BaseTemperature())
+	chunkW, chunkH, k := def.BandShape()
+	assert.Equal(t, consts.Tile(30), chunkW)
+	assert.Equal(t, consts.Tile(40), chunkH)
+	assert.Equal(t, consts.Chunk(2), k)
 }

--- a/internal/dungeon/registry_test.go
+++ b/internal/dungeon/registry_test.go
@@ -3,6 +3,7 @@ package dungeon
 import (
 	"testing"
 
+	"github.com/kijimaD/ruins/internal/consts"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -72,6 +73,9 @@ func TestDefinitions(t *testing.T) {
 		assert.Equal(t, 20, DungeonForest.TotalFloors())
 		assert.Equal(t, "森", DungeonForest.EnemyTableName())
 		assert.Equal(t, "森", DungeonForest.ItemTableName())
+		assert.Equal(t, "凍りついた森に、かつて猟師たちが分け入った。\n戻った者は少ない。冷気が骨まで届く。", DungeonForest.Description())
+		assert.Equal(t, "forest1", DungeonForest.ImageKey())
+		assert.Equal(t, 0, DungeonForest.BaseTemperature())
 		assert.NotEmpty(t, DungeonForest.PlannerPool())
 	})
 
@@ -81,6 +85,9 @@ func TestDefinitions(t *testing.T) {
 		assert.Equal(t, 20, DungeonCave.TotalFloors())
 		assert.Equal(t, "洞窟", DungeonCave.EnemyTableName())
 		assert.Equal(t, "洞窟", DungeonCave.ItemTableName())
+		assert.Equal(t, "灰色の岩壁に凍晶が脈のように走っている。\n奥に進むほど、静かになる。", DungeonCave.Description())
+		assert.Equal(t, "cave1", DungeonCave.ImageKey())
+		assert.Equal(t, 5, DungeonCave.BaseTemperature())
 		assert.NotEmpty(t, DungeonCave.PlannerPool())
 	})
 
@@ -90,6 +97,19 @@ func TestDefinitions(t *testing.T) {
 		assert.Equal(t, 20, DungeonRuins.TotalFloors())
 		assert.Equal(t, "廃墟", DungeonRuins.EnemyTableName())
 		assert.Equal(t, "廃墟", DungeonRuins.ItemTableName())
+		assert.Equal(t, "古代の都市が、そのまま凍りついている。\n誰が何を忘れたのか、もう誰も知らない。", DungeonRuins.Description())
+		assert.Equal(t, "city1", DungeonRuins.ImageKey())
+		assert.Equal(t, 15, DungeonRuins.BaseTemperature())
 		assert.NotEmpty(t, DungeonRuins.PlannerPool())
+	})
+
+	t.Run("DungeonOverworldの設定が正しい", func(t *testing.T) {
+		t.Parallel()
+		assert.Equal(t, "オーバーワールド", DungeonOverworld.Name())
+		assert.Equal(t, 0, DungeonOverworld.BaseTemperature())
+		chunkW, chunkH, k := DungeonOverworld.BandShape()
+		assert.Equal(t, consts.Tile(50), chunkW)
+		assert.Equal(t, consts.Tile(50), chunkH)
+		assert.Equal(t, consts.Chunk(3), k)
 	})
 }


### PR DESCRIPTION
## 概要

`internal/dungeon` パッケージのテストカバレッジを増強する。本体コードは変更しない。

- カバレッジ: 64.1% → 97.3%

## 追加したテスト

- `DungeonDefinition.BossPlanner`: ボスプランナーがあり最終階のとき取得できる分岐、あっても最終階でないとき取得できない分岐、設定されていないとき取得できない分岐の3パターン
- `NewOverworldDefinition`: コンストラクタで渡した Name・BaseTemperature・BandShape がそのまま保持されることの検証
- `DungeonForest` / `DungeonCave` / `DungeonRuins`: 既存の `TestDefinitions` に Description・ImageKey・BaseTemperature の検証を追加
- `DungeonOverworld`: Name・BaseTemperature・BandShape の検証を追加

## 検証

- `go test ./internal/dungeon/... -v -cover`: PASS、カバレッジ97.3%
- `make test`: PASS
- `golangci-lint run ./internal/dungeon/...`: 0 issues
- `go build ./...`: 成功

---
_Generated by [Claude Code](https://claude.ai/code/session_01UozU55aze5GeN4ZTj9YRKh)_