### PR TITLE
fix(ci): pages の coverage 生成を make report に置換し DISPLAY 不在を直す

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -27,7 +27,7 @@ jobs:
           sudo apt install -y lcov
           go install github.com/jandelgado/gcov2lcov@v1.1.1
           # レポート生成
-          RUINS_LOG_LEVEL=ignore go test -covermode=count ./... -coverprofile=coverage.out
+          make report
           $(go env GOPATH)/bin/gcov2lcov -infile=coverage.out -outfile=coverage.lcov
           genhtml coverage.lcov -o ./wasm/cov
           go tool cover -html=coverage.out -o ./wasm/cov/gocoverage.html


### PR DESCRIPTION
## 問題

main への push ごとに GitHub Pages の deploy job が Generate coverage report で毎回失敗していた。

https://github.com/kijimad/ruins/actions/runs/30178802976/job/89731850467

```
glfw: X11: The DISPLAY environment variable is missing: a platform-specific error occurred
FAIL	github.com/kijimaD/ruins/internal/widgets/hud	0.078s
...
```

## 原因

#524 で setup-go-with-x から常駐 Xvfb `:99` を廃止し「各コマンドが xvfb-run で自前の X を立てる」方式に統一した。check.yml の `make test` / `make report` は Makefile 内蔵の xvfb-run で追従できたが、pages.yml だけが生の `go test` を直叩きしており、廃止された環境 DISPLAY に依存したまま取り残されていた。

## 修正

coverage 生成を `make report` に置換する。

- xvfb-run と bwrap を内包し、DISPLAY 不在が解消する
- 「生の go を叩かず make ターゲットを使う」方針に揃う
- カバレッジ母数が check.yml の octocov と同一定義になる。oapi と editor-ui の除外が pages 側にも効く

covermode は count から既定の set になるが、genhtml の表示が行ヒット回数から 0/1 になるだけで影響は軽微。

## 検証

ローカルで一連の下流処理を確認済み。

- `make report` → coverage.out 生成、total 58.6%
- `gcov2lcov -infile=coverage.out` → lcov 変換 OK
- `go tool cover -func` からのバッジ用 percent 抽出 OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EKeiMykWodu21sc2JYen9D