### PR TITLE
fix: 分解システムのフォローアップ4件

### DIFF
--- a/internal/activity/disassemble.go
+++ b/internal/activity/disassemble.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"math"
 	"slices"
-	"strings"
 
 	gc "github.com/kijimaD/ruins/internal/components"
 	"github.com/kijimaD/ruins/internal/consts"
@@ -108,7 +107,10 @@ func (da *DisassembleActivity) Start(comp *gc.Activity, actor ecs.Entity, world 
 
 	name := query.GetEntityName(*comp.Target, world)
 	gamelog.New(query.GetGameLog(world)).
-		Append(fmt.Sprintf("%sで「%s」の分解を始めた", toolName, name)).
+		ItemName(toolName).
+		Append("で").
+		ItemName(name).
+		Append("の分解を始めた").
 		Log()
 
 	log.Debug("分解開始", "actor", actor, "target", name, "tool", toolName)
@@ -185,9 +187,11 @@ func (da *DisassembleActivity) Finish(comp *gc.Activity, actor ecs.Entity, world
 		}
 	}
 
-	gamelog.New(query.GetGameLog(world)).
-		Append(fmt.Sprintf("「%s」を分解した。%s", name, formatYields(stacks))).
-		Log()
+	logger := gamelog.New(query.GetGameLog(world)).
+		ItemName(name).
+		Append("を分解した。")
+	appendYields(logger, stacks)
+	logger.Log()
 
 	da.gainMechanicExp(actor, world)
 
@@ -199,13 +203,13 @@ func (da *DisassembleActivity) Finish(comp *gc.Activity, actor ecs.Entity, world
 // 対象消滅による中断もあるため、名前は対象が生きている場合だけ出す
 func (da *DisassembleActivity) Canceled(comp *gc.Activity, actor ecs.Entity, world w.World) error {
 	if world.Components.Player.Has(actor) {
-		message := "分解を中断した"
+		logger := gamelog.New(query.GetGameLog(world))
 		if comp.Target != nil && world.ECS.Alive(*comp.Target) {
-			message = fmt.Sprintf("「%s」の分解を中断した", query.GetEntityName(*comp.Target, world))
+			logger.ItemName(query.GetEntityName(*comp.Target, world)).Append("の分解を中断した")
+		} else {
+			logger.Append("分解を中断した")
 		}
-		gamelog.New(query.GetGameLog(world)).
-			Append(message).
-			Log()
+		logger.Log()
 	}
 
 	log.Debug("分解中断", "reason", comp.CancelReason)
@@ -292,14 +296,17 @@ func mechanicSkillValue(actor ecs.Entity, world w.World) int {
 	return world.Components.Skills.Get(actor).Get(gc.SkillMechanic).Value
 }
 
-// formatYields は産出一覧をログ表示用の文字列にする
-func formatYields(stacks []lifecycle.YieldStack) string {
+// appendYields は産出一覧をアイテム名の色付きでログへ追記する
+func appendYields(logger *gamelog.Logger, stacks []lifecycle.YieldStack) {
 	if len(stacks) == 0 {
-		return "何も得られなかった"
+		logger.Append("何も得られなかった")
+		return
 	}
-	parts := make([]string, 0, len(stacks))
-	for _, s := range stacks {
-		parts = append(parts, fmt.Sprintf("%s x%d", s.Name, s.Count))
+	for i, s := range stacks {
+		if i > 0 {
+			logger.Append("、")
+		}
+		logger.ItemName(s.Name).Append(fmt.Sprintf(" x%d", s.Count))
 	}
-	return strings.Join(parts, "、") + " を得た"
+	logger.Append(" を得た")
 }

--- a/internal/activity/disassemble_test.go
+++ b/internal/activity/disassemble_test.go
@@ -6,6 +6,7 @@ import (
 
 	gc "github.com/kijimaD/ruins/internal/components"
 	"github.com/kijimaD/ruins/internal/consts"
+	"github.com/kijimaD/ruins/internal/gamelog"
 	"github.com/kijimaD/ruins/internal/oapi"
 	"github.com/kijimaD/ruins/internal/testutil"
 	"github.com/kijimaD/ruins/internal/world/lifecycle"
@@ -367,7 +368,7 @@ func TestDisassembleActivity_DoTurn_敵が接近すると中断する(t *testing
 	assert.Equal(t, "周囲に敵がいるため分解を中断", comp.CancelReason)
 }
 
-func TestFormatYields(t *testing.T) {
+func TestAppendYields(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
@@ -382,7 +383,15 @@ func TestFormatYields(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			assert.Equal(t, tt.want, formatYields(tt.stacks))
+			world := testutil.InitTestWorld(t)
+			store := query.GetGameLog(world)
+			logger := gamelog.New(store)
+			appendYields(logger, tt.stacks)
+			logger.Log()
+
+			recent := store.GetRecent(1)
+			require.Len(t, recent, 1)
+			assert.Equal(t, tt.want, recent[0])
 		})
 	}
 }

--- a/internal/activity/execute_interaction.go
+++ b/internal/activity/execute_interaction.go
@@ -143,7 +143,8 @@ func executeDisassemble(actor ecs.Entity, target ecs.Entity, world w.World) (*Ac
 	}
 	if _, _, ok := FindBestDisassemblyTool(world, actor, def.ToolCategory); !ok {
 		gamelog.New(query.GetGameLog(world)).
-			Append(fmt.Sprintf("「%s」を分解できる工具を持っていない", name)).
+			ItemName(name).
+			Append("を分解できる工具を持っていない").
 			Log()
 		return &ActionResult{Success: false, ActivityName: gc.BehaviorDisassemble, Message: "工具がない"}, nil
 	}

--- a/internal/raw/raw.go
+++ b/internal/raw/raw.go
@@ -45,6 +45,9 @@ func LoadFromFile(path string) (oapi.Raws, error) {
 	if err := ValidateRaws(raws); err != nil {
 		return oapi.Raws{}, fmt.Errorf("ローデータの検証に失敗(%s): %w", path, err)
 	}
+	if err := ValidateDisassemblyReferences(raws); err != nil {
+		return oapi.Raws{}, fmt.Errorf("ローデータの検証に失敗(%s): %w", path, err)
+	}
 	return raws, nil
 }
 

--- a/internal/raw/raw.go
+++ b/internal/raw/raw.go
@@ -425,18 +425,21 @@ func NewMemberSpec(raws oapi.Raws, name string) (gc.EntitySpec, error) {
 		entitySpec.Player = &gc.Player{}
 	}
 
+	// テーブル名はロード時に参照検証済みで、ここで失敗するのは整合性バグ
 	if member.CommandTableName != nil && *member.CommandTableName != "" {
 		ct, err := GetCommandTable(raws, *member.CommandTableName)
-		if err == nil {
-			entitySpec.CommandTable = &gc.CommandTable{Name: ct.Name}
+		if err != nil {
+			return gc.EntitySpec{}, fmt.Errorf("メンバー '%s' のコマンドテーブル取得に失敗: %w", name, err)
 		}
+		entitySpec.CommandTable = &gc.CommandTable{Name: ct.Name}
 	}
 
 	if member.DropTableName != nil && *member.DropTableName != "" {
 		dt, err := GetDropTable(raws, *member.DropTableName)
-		if err == nil {
-			entitySpec.DropTable = &gc.DropTable{Name: dt.Name}
+		if err != nil {
+			return gc.EntitySpec{}, fmt.Errorf("メンバー '%s' のドロップテーブル取得に失敗: %w", name, err)
 		}
+		entitySpec.DropTable = &gc.DropTable{Name: dt.Name}
 	}
 
 	entitySpec.LightSource = toGCLightSource(member.LightSource)

--- a/internal/raw/raw.go
+++ b/internal/raw/raw.go
@@ -45,7 +45,7 @@ func LoadFromFile(path string) (oapi.Raws, error) {
 	if err := ValidateRaws(raws); err != nil {
 		return oapi.Raws{}, fmt.Errorf("ローデータの検証に失敗(%s): %w", path, err)
 	}
-	if err := ValidateDisassemblyReferences(raws); err != nil {
+	if err := ValidateReferences(raws); err != nil {
 		return oapi.Raws{}, fmt.Errorf("ローデータの検証に失敗(%s): %w", path, err)
 	}
 	return raws, nil

--- a/internal/raw/validate.go
+++ b/internal/raw/validate.go
@@ -47,7 +47,10 @@ func ValidateReferences(raws oapi.Raws) error {
 	if err := validateDisassemblyReferences(raws); err != nil {
 		return err
 	}
-	return validateDropTableReferences(raws)
+	if err := validateDropTableReferences(raws); err != nil {
+		return err
+	}
+	return validateCommandTableReferences(raws)
 }
 
 // validateDisassemblyReferences は分解定義の産出名がアイテム定義に存在することを検証する
@@ -118,11 +121,33 @@ func validateDropTableReferences(raws oapi.Raws) error {
 
 	members := PtrSlice(raws.Members)
 	for i := range members {
-		if members[i].DropTableName == nil {
+		// 空文字は未指定と同じ扱いにする。EntitySpec 構築側の判定と揃える
+		if members[i].DropTableName == nil || *members[i].DropTableName == "" {
 			continue
 		}
 		if _, ok := tableNames[*members[i].DropTableName]; !ok {
 			return fmt.Errorf("メンバー '%s' のドロップテーブル '%s' が定義に存在しません", members[i].Name, *members[i].DropTableName)
+		}
+	}
+	return nil
+}
+
+// validateCommandTableReferences はメンバーの commandTableName がテーブル定義に存在することを検証する
+func validateCommandTableReferences(raws oapi.Raws) error {
+	commandTables := PtrSlice(raws.CommandTables)
+	tableNames := make(map[string]struct{}, len(commandTables))
+	for i := range commandTables {
+		tableNames[commandTables[i].Name] = struct{}{}
+	}
+
+	members := PtrSlice(raws.Members)
+	for i := range members {
+		// 空文字は未指定と同じ扱いにする。EntitySpec 構築側の判定と揃える
+		if members[i].CommandTableName == nil || *members[i].CommandTableName == "" {
+			continue
+		}
+		if _, ok := tableNames[*members[i].CommandTableName]; !ok {
+			return fmt.Errorf("メンバー '%s' のコマンドテーブル '%s' が定義に存在しません", members[i].Name, *members[i].CommandTableName)
 		}
 	}
 	return nil

--- a/internal/raw/validate.go
+++ b/internal/raw/validate.go
@@ -40,10 +40,18 @@ func ValidateRaws(raws oapi.Raws) error {
 	return nil
 }
 
-// ValidateDisassemblyReferences は分解定義の産出名がアイテム定義に存在することを検証する。
-// スキーマ検証は名前の参照整合を見ないため、ここで補う。実行時のスポーン失敗を
+// ValidateReferences は定義間の名前参照の整合を検証する。
+// スキーマ検証は名前の参照整合を見ないため、ここで補う。実行時の解決失敗を
 // ロード時エラーに前倒しする
-func ValidateDisassemblyReferences(raws oapi.Raws) error {
+func ValidateReferences(raws oapi.Raws) error {
+	if err := validateDisassemblyReferences(raws); err != nil {
+		return err
+	}
+	return validateDropTableReferences(raws)
+}
+
+// validateDisassemblyReferences は分解定義の産出名がアイテム定義に存在することを検証する
+func validateDisassemblyReferences(raws oapi.Raws) error {
 	items := PtrSlice(raws.Items)
 	itemNames := make(map[string]struct{}, len(items))
 	for i := range items {
@@ -79,6 +87,42 @@ func ValidateDisassemblyReferences(raws oapi.Raws) error {
 	for i := range items {
 		if err := check("item", items[i].Name, items[i].Disassembly); err != nil {
 			return err
+		}
+	}
+	return nil
+}
+
+// validateDropTableReferences はドロップテーブルの素材名がアイテム定義に存在すること、
+// メンバーの dropTableName がテーブル定義に存在することを検証する
+func validateDropTableReferences(raws oapi.Raws) error {
+	items := PtrSlice(raws.Items)
+	itemNames := make(map[string]struct{}, len(items))
+	for i := range items {
+		itemNames[items[i].Name] = struct{}{}
+	}
+
+	dropTables := PtrSlice(raws.DropTables)
+	tableNames := make(map[string]struct{}, len(dropTables))
+	for i := range dropTables {
+		tableNames[dropTables[i].Name] = struct{}{}
+		for _, entry := range dropTables[i].Entries {
+			// 空文字はドロップなしを意味する正規の値
+			if entry.Material == "" {
+				continue
+			}
+			if _, ok := itemNames[entry.Material]; !ok {
+				return fmt.Errorf("ドロップテーブル '%s' の素材 '%s' がアイテム定義に存在しません", dropTables[i].Name, entry.Material)
+			}
+		}
+	}
+
+	members := PtrSlice(raws.Members)
+	for i := range members {
+		if members[i].DropTableName == nil {
+			continue
+		}
+		if _, ok := tableNames[*members[i].DropTableName]; !ok {
+			return fmt.Errorf("メンバー '%s' のドロップテーブル '%s' が定義に存在しません", members[i].Name, *members[i].DropTableName)
 		}
 	}
 	return nil

--- a/internal/raw/validate.go
+++ b/internal/raw/validate.go
@@ -39,3 +39,47 @@ func ValidateRaws(raws oapi.Raws) error {
 
 	return nil
 }
+
+// ValidateDisassemblyReferences は分解定義の産出名がアイテム定義に存在することを検証する。
+// スキーマ検証は名前の参照整合を見ないため、ここで補う。実行時のスポーン失敗を
+// ロード時エラーに前倒しする
+func ValidateDisassemblyReferences(raws oapi.Raws) error {
+	items := PtrSlice(raws.Items)
+	itemNames := make(map[string]struct{}, len(items))
+	for i := range items {
+		itemNames[items[i].Name] = struct{}{}
+	}
+
+	check := func(ownerKind string, ownerName string, def *oapi.Disassembly) error {
+		if def == nil {
+			return nil
+		}
+		for _, y := range def.Yields {
+			if _, ok := itemNames[y.Name]; !ok {
+				return fmt.Errorf("%s '%s' の分解産出 '%s' がアイテム定義に存在しません", ownerKind, ownerName, y.Name)
+			}
+		}
+		if def.Bonus == nil {
+			return nil
+		}
+		for _, b := range *def.Bonus {
+			if _, ok := itemNames[b.Name]; !ok {
+				return fmt.Errorf("%s '%s' の分解ボーナス '%s' がアイテム定義に存在しません", ownerKind, ownerName, b.Name)
+			}
+		}
+		return nil
+	}
+
+	props := PtrSlice(raws.Props)
+	for i := range props {
+		if err := check("prop", props[i].Name, props[i].Disassembly); err != nil {
+			return err
+		}
+	}
+	for i := range items {
+		if err := check("item", items[i].Name, items[i].Disassembly); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/internal/raw/validate_test.go
+++ b/internal/raw/validate_test.go
@@ -173,12 +173,14 @@ func TestValidateDisassemblyReferences(t *testing.T) {
 	t.Run("itemのボーナス名が存在しないとエラー", func(t *testing.T) {
 		t.Parallel()
 		minSkill := oapi.SkillLevel(10)
-		items := append([]oapi.Item{}, *validItems...)
-		items[1].Disassembly = &oapi.Disassembly{
-			ToolCategory: oapi.Precision,
-			BaseAP:       100,
-			Yields:       []oapi.DisassemblyYield{{Name: "鉄くず", Amount: 1}},
-			Bonus:        &[]oapi.DisassemblyBonus{{Name: "存在しないボーナス", Amount: 1, MinSkill: &minSkill}},
+		items := []oapi.Item{
+			{Name: "鉄くず"},
+			{Name: "分解対象", Disassembly: &oapi.Disassembly{
+				ToolCategory: oapi.Precision,
+				BaseAP:       100,
+				Yields:       []oapi.DisassemblyYield{{Name: "鉄くず", Amount: 1}},
+				Bonus:        &[]oapi.DisassemblyBonus{{Name: "存在しないボーナス", Amount: 1, MinSkill: &minSkill}},
+			}},
 		}
 		raws := oapi.Raws{Items: &items}
 		err := validateDisassemblyReferences(raws)
@@ -230,6 +232,37 @@ func TestValidateDropTableReferences(t *testing.T) {
 			Members: &[]oapi.Member{{Name: "スライム", DropTableName: &tableName}},
 		}
 		err := validateDropTableReferences(raws)
+		require.Error(t, err)
+		require.ErrorContains(t, err, "未定義テーブル")
+		require.ErrorContains(t, err, "スライム")
+	})
+}
+
+func TestValidateCommandTableReferences(t *testing.T) {
+	t.Parallel()
+
+	t.Run("実在するテーブル名と未指定と空文字は通る", func(t *testing.T) {
+		t.Parallel()
+		empty := oapi.EntityName("")
+		tableName := oapi.EntityName("素手")
+		raws := oapi.Raws{
+			CommandTables: &[]oapi.CommandTable{{Name: "素手"}},
+			Members: &[]oapi.Member{
+				{Name: "戦うNPC", CommandTableName: &tableName},
+				{Name: "未指定NPC"},
+				{Name: "空文字NPC", CommandTableName: &empty},
+			},
+		}
+		require.NoError(t, validateCommandTableReferences(raws))
+	})
+
+	t.Run("テーブル名が存在しないとエラー", func(t *testing.T) {
+		t.Parallel()
+		tableName := oapi.EntityName("未定義テーブル")
+		raws := oapi.Raws{
+			Members: &[]oapi.Member{{Name: "スライム", CommandTableName: &tableName}},
+		}
+		err := validateCommandTableReferences(raws)
 		require.Error(t, err)
 		require.ErrorContains(t, err, "未定義テーブル")
 		require.ErrorContains(t, err, "スライム")

--- a/internal/raw/validate_test.go
+++ b/internal/raw/validate_test.go
@@ -148,7 +148,7 @@ func TestValidateDisassemblyReferences(t *testing.T) {
 				},
 			}},
 		}
-		require.NoError(t, ValidateDisassemblyReferences(raws))
+		require.NoError(t, validateDisassemblyReferences(raws))
 	})
 
 	t.Run("propの産出名が存在しないとエラー", func(t *testing.T) {
@@ -164,7 +164,7 @@ func TestValidateDisassemblyReferences(t *testing.T) {
 				},
 			}},
 		}
-		err := ValidateDisassemblyReferences(raws)
+		err := validateDisassemblyReferences(raws)
 		require.Error(t, err)
 		require.ErrorContains(t, err, "存在しない素材")
 		require.ErrorContains(t, err, "棚")
@@ -181,8 +181,57 @@ func TestValidateDisassemblyReferences(t *testing.T) {
 			Bonus:        &[]oapi.DisassemblyBonus{{Name: "存在しないボーナス", Amount: 1, MinSkill: &minSkill}},
 		}
 		raws := oapi.Raws{Items: &items}
-		err := ValidateDisassemblyReferences(raws)
+		err := validateDisassemblyReferences(raws)
 		require.Error(t, err)
 		require.ErrorContains(t, err, "存在しないボーナス")
+	})
+}
+
+func TestValidateDropTableReferences(t *testing.T) {
+	t.Parallel()
+
+	items := &[]oapi.Item{{Name: "鉄くず"}}
+
+	t.Run("実在する素材と空文字は通る", func(t *testing.T) {
+		t.Parallel()
+		raws := oapi.Raws{
+			Items: items,
+			DropTables: &[]oapi.DropTable{{
+				Name: "廃墟",
+				Entries: []oapi.DropTableEntry{
+					{Material: "鉄くず", Weight: 1},
+					{Material: "", Weight: 3},
+				},
+			}},
+		}
+		require.NoError(t, validateDropTableReferences(raws))
+	})
+
+	t.Run("素材名が存在しないとエラー", func(t *testing.T) {
+		t.Parallel()
+		raws := oapi.Raws{
+			Items: items,
+			DropTables: &[]oapi.DropTable{{
+				Name:    "廃墟",
+				Entries: []oapi.DropTableEntry{{Material: "存在しない素材", Weight: 1}},
+			}},
+		}
+		err := validateDropTableReferences(raws)
+		require.Error(t, err)
+		require.ErrorContains(t, err, "存在しない素材")
+		require.ErrorContains(t, err, "廃墟")
+	})
+
+	t.Run("メンバーのテーブル名が存在しないとエラー", func(t *testing.T) {
+		t.Parallel()
+		tableName := oapi.EntityName("未定義テーブル")
+		raws := oapi.Raws{
+			Items:   items,
+			Members: &[]oapi.Member{{Name: "スライム", DropTableName: &tableName}},
+		}
+		err := validateDropTableReferences(raws)
+		require.Error(t, err)
+		require.ErrorContains(t, err, "未定義テーブル")
+		require.ErrorContains(t, err, "スライム")
 	})
 }

--- a/internal/raw/validate_test.go
+++ b/internal/raw/validate_test.go
@@ -126,3 +126,63 @@ func makeItemRaws(modify func(*oapi.Item)) oapi.Raws {
 	items := []oapi.Item{item}
 	return oapi.Raws{Items: &items}
 }
+
+func TestValidateDisassemblyReferences(t *testing.T) {
+	t.Parallel()
+
+	validItems := &[]oapi.Item{
+		{Name: "鉄くず"},
+		{Name: "分解対象"},
+	}
+
+	t.Run("実在する産出名なら通る", func(t *testing.T) {
+		t.Parallel()
+		raws := oapi.Raws{
+			Items: validItems,
+			Props: &[]oapi.Prop{{
+				Name: "棚",
+				Disassembly: &oapi.Disassembly{
+					ToolCategory: oapi.Prying,
+					BaseAP:       100,
+					Yields:       []oapi.DisassemblyYield{{Name: "鉄くず", Amount: 1}},
+				},
+			}},
+		}
+		require.NoError(t, ValidateDisassemblyReferences(raws))
+	})
+
+	t.Run("propの産出名が存在しないとエラー", func(t *testing.T) {
+		t.Parallel()
+		raws := oapi.Raws{
+			Items: validItems,
+			Props: &[]oapi.Prop{{
+				Name: "棚",
+				Disassembly: &oapi.Disassembly{
+					ToolCategory: oapi.Prying,
+					BaseAP:       100,
+					Yields:       []oapi.DisassemblyYield{{Name: "存在しない素材", Amount: 1}},
+				},
+			}},
+		}
+		err := ValidateDisassemblyReferences(raws)
+		require.Error(t, err)
+		require.ErrorContains(t, err, "存在しない素材")
+		require.ErrorContains(t, err, "棚")
+	})
+
+	t.Run("itemのボーナス名が存在しないとエラー", func(t *testing.T) {
+		t.Parallel()
+		minSkill := oapi.SkillLevel(10)
+		items := append([]oapi.Item{}, *validItems...)
+		items[1].Disassembly = &oapi.Disassembly{
+			ToolCategory: oapi.Precision,
+			BaseAP:       100,
+			Yields:       []oapi.DisassemblyYield{{Name: "鉄くず", Amount: 1}},
+			Bonus:        &[]oapi.DisassemblyBonus{{Name: "存在しないボーナス", Amount: 1, MinSkill: &minSkill}},
+		}
+		raws := oapi.Raws{Items: &items}
+		err := ValidateDisassemblyReferences(raws)
+		require.Error(t, err)
+		require.ErrorContains(t, err, "存在しないボーナス")
+	})
+}

--- a/internal/systems/dead_cleanup.go
+++ b/internal/systems/dead_cleanup.go
@@ -1,6 +1,8 @@
 package systems
 
 import (
+	"fmt"
+
 	"github.com/kijimaD/ruins/internal/activity"
 	gc "github.com/kijimaD/ruins/internal/components"
 	"github.com/kijimaD/ruins/internal/consts"
@@ -96,8 +98,10 @@ func (sys *DeadCleanupSystem) Update(world w.World) error {
 		}
 		grid := world.Components.GridElement.Get(entity)
 		stacks := lifecycle.RollDisassemblyYields(world.Config.RNG, def, 0, 0, false)
+		// 産出名はロード時に参照検証済みで、ここで失敗するのは整合性バグ。
+		// 握りつぶすと産出が静かに消えるため loud に返す
 		if err := lifecycle.SpawnDisassemblyYields(world, stacks, grid.X, grid.Y); err != nil {
-			logger.Debug("破壊回収アイテム生成失敗", "error", err)
+			return fmt.Errorf("破壊回収アイテムの生成に失敗: %w", err)
 		}
 	}
 

--- a/internal/systems/dead_cleanup.go
+++ b/internal/systems/dead_cleanup.go
@@ -61,10 +61,10 @@ func (sys *DeadCleanupSystem) Update(world w.World) error {
 		dropTableComp := world.Components.DropTable.Get(entity)
 		gridElement := world.Components.GridElement.Get(entity)
 
+		// テーブル名はロード時に参照検証済みで、ここで失敗するのは整合性バグ
 		dropTable, err := raw.GetDropTable(rawMaster, dropTableComp.Name)
 		if err != nil {
-			logger.Debug("ドロップテーブル取得失敗", "error", err, "table_name", dropTableComp.Name)
-			continue
+			return fmt.Errorf("ドロップテーブルの取得に失敗: %w", err)
 		}
 
 		// アイテム選択
@@ -77,13 +77,12 @@ func (sys *DeadCleanupSystem) Update(world w.World) error {
 			continue
 		}
 
-		// フィールドにアイテムをスポーン
+		// フィールドにアイテムをスポーン。素材名はロード時に参照検証済み
 		_, err = lifecycle.SpawnFieldItem(world, materialName, gridElement.X, gridElement.Y, 1)
 		if err != nil {
-			logger.Debug("ドロップアイテム生成失敗", "error", err, "material", materialName)
-		} else {
-			logger.Debug("ドロップアイテム生成", "material", materialName, "x", gridElement.X, "y", gridElement.Y)
+			return fmt.Errorf("ドロップアイテムの生成に失敗: %w", err)
 		}
+		logger.Debug("ドロップアイテム生成", "material", materialName, "x", gridElement.X, "y", gridElement.Y)
 	}
 
 	// 分解定義を持つpropの破壊回収。工具がない序盤でも素材が少しは手に入るように、

--- a/internal/systems/disassemble_coordination_test.go
+++ b/internal/systems/disassemble_coordination_test.go
@@ -48,8 +48,9 @@ func backpackItemNames(world w.World) []string {
 	return names
 }
 
-// TestTurnSystem_分解を完走してもAPが枯渇しない は、継続アクティビティが
-// ターン交互処理で進み、旧方式のようなAP前借りの借金が発生しないことを検証する
+// TestTurnSystem_分解を完走してもAPが枯渇しない は、継続アクティビティの
+// 毎ターンのAP消費がターン終了の回復と均衡し、完了時に大きな負債が
+// 残らないことを検証する
 func TestTurnSystem_分解を完走してもAPが枯渇しない(t *testing.T) {
 	t.Parallel()
 
@@ -80,11 +81,11 @@ func TestTurnSystem_分解を完走してもAPが枯渇しない(t *testing.T) {
 	assert.False(t, world.ECS.Alive(crate), "分解したpropは消えるべき")
 	assert.Contains(t, fieldItemNames(world), "硬木", "確定枠の産出が足元に落ちるべき")
 
-	// 旧方式では完了時点でAPが約-2000の借金になっていた。
-	// ターン交互処理では毎ターン消費と回復が均衡し、大きな負債にならない
+	// 毎ターンの消費100はターン終了の回復とおおむね均衡する。
+	// 大きな負債はアクティビティの複数ステップが1ターン内で走った兆候になる
 	turnBased := world.Components.TurnBased.Get(player)
 	assert.Greater(t, turnBased.AP.Current, -200,
-		"AP前借りの借金が発生しないべき。旧方式ではここが約-2000になる")
+		"完了時のAPは毎ターンの回復と均衡し、大きな負債にならないべき")
 }
 
 // TestTurnSystem_分解中も隊員がターンごとに行動する は、プレイヤーの

--- a/internal/systems/turn_system.go
+++ b/internal/systems/turn_system.go
@@ -30,7 +30,7 @@ func (sys *TurnSystem) Update(world w.World) error {
 		// プレイヤーが継続アクション中かチェック
 		if processPlayerContinuousActivity(world) {
 			// 継続アクションの1ステップを1ゲームターンとして扱い、AIフェーズへ渡す。
-			// これでアクティビティ中も敵・NPC・時間が同じ速さで進み、
+			// アクティビティ中も敵・NPC・時間が同じ速さで進み、
 			// 敵接近による中断判定が毎ターン意味を持つ
 			turnState.Phase = gc.TurnPhaseAI
 			return nil


### PR DESCRIPTION
## 概要

#547 のマージに含まれなかった末尾4コミットを取り込む。レビュー指摘対応と堅牢化。

- **分解ログの色付き表示**: レビュー指摘対応。開始・完了・中断・工具なしの4ログをカギ括弧から `ItemName` の色付き追記に揃え、産出一覧も1品ずつ色付けする
- **破壊回収のスポーン失敗を error return**: 産出名の解決失敗は整合性バグであり握りつぶさない。あわせて分解定義の産出名・ボーナス名の参照整合をロード時検証 `ValidateReferences` に追加し、TOML のタイポを実行時から前倒しで検出する
- **ドロップテーブルも同じ原則に整合**: 素材名とメンバーの dropTableName をロード時検証し、実行時のテーブル取得・スポーン失敗は error を返す
- **コメントの定常状態化**: 「旧方式では」のような後から読めない対比表現を、現在の不変条件の説明に置き換える

## テスト

- 参照検証6ケース。分解産出・ボーナス・ドロップ素材・メンバーのテーブル名の実在と不在
- 産出ログ整形3ケース。実データの raw.toml が新検証を全通過することも loader テストで確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EKeiMykWodu21sc2JYen9D