### PR TITLE
ci: カバレッジ計測をテスト実行に統合し xvfb セッションを1本にする

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -83,9 +83,9 @@ jobs:
       - uses: actions/checkout@v7
       - uses: ./.github/actions/setup-go-with-x
       - name: test
+        # カバレッジは make test が coverage.out に出力し octocov が読む。
+        # テストの別実行を挟まないことで xvfb セッションを1本に保つ
         run: make test
-      - name: coverage for octocov
-        run: make report
       - uses: k1LoW/octocov-action@v1
 
   flaky-check:

--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,8 @@ cdda/
 oas/redoc/
 # make mutation(go-mutesting)が出力する
 /report.json
+# make test が出力するカバレッジプロファイル
+/coverage.out
 # ゲームバランスコマンドが出力する
 balance.json
 # graphify(コード知識グラフ)が出力する

--- a/Makefile
+++ b/Makefile
@@ -21,8 +21,10 @@ editor: ## ゲームデータエディタを起動する
 test: ## テストを実行する。RACE=-race で競合検出、COUNT=N で繰り返し実行できる（デフォルト1）
 	# bwrap: /dev/input を隠してebitenのgamepad初期化エラー(EINTR)を防ぐ
 	# xvfb-run: ebitenのゴールデンテストがウィンドウを開くのを防ぐ
+	# coverprofile: カバレッジをテスト実行と同時に採る。別実行にすると
+	# xvfbセッションが2本立ち、2本目のディスプレイ初期化が稀に失敗する
 	RUINS_LOG_LEVEL=ignore \
-	$(BWRAP_CMD) xvfb-run -a go test $(RACE) -v -cover -shuffle=on -timeout=60m -count=$(or $(COUNT),1) \
+	$(BWRAP_CMD) xvfb-run -a go test $(RACE) -v -cover -coverprofile=coverage.out -shuffle=on -timeout=60m -count=$(or $(COUNT),1) \
 		$(GO_TEST_PKGS)
 
 .PHONY: updategolden
@@ -37,9 +39,7 @@ bench: ## ベンチマークを全て実行する
 		$(GO_TEST_PKGS)
 
 .PHONY: report
-report: ## AIが読みやすい形でカバレッジレポートを表示する
-	RUINS_LOG_LEVEL=ignore \
-	$(BWRAP_CMD) xvfb-run -a go test -coverprofile=coverage.out $(GO_TEST_PKGS)
+report: test ## AIが読みやすい形でカバレッジレポートを表示する
 	go tool cover -func=coverage.out
 
 .PHONY: build


### PR DESCRIPTION
## 概要

test ジョブがテスト本体と `make report` で全スイートを2回実行し、それぞれ別の xvfb セッションを張っていた。2本目のディスプレイ初期化が稀に失敗し、coverage for octocov ステップだけが落ちる flaky の原因になっていた。実例: https://github.com/kijimad/ruins/actions/runs/30269061208/job/89986790506

```
glfw: X11: Failed to open display :99
panic: glfw: The GLFW library is not initialized
```

## 変更

- `make test` が `-coverprofile=coverage.out` を直接出力し、octocov がそれを読む
- `make report` は test に依存して `go tool cover -func` の集計表示だけを行う
- check.yml の「coverage for octocov」ステップを削除
- `/coverage.out` を gitignore に追加

## 効果

- xvfb セッションが1本になり、2本目の初期化競合が原理的に消える
- テスト実行が1回になり CI が約3分短縮される

## オーバーヘッド計測

ローカルのウォームキャッシュで3変種を計測した。`-coverprofile` の追加コストは誤差内で、計装コスト約+14秒は変更前の `-cover` が既に払っていたもの。通常テストは遅くならない。

| 変種 | 実測 |
|---|---|
| 素 | 約25s |
| `-cover`(変更前) | 約39s |
| `-cover -coverprofile`(変更後) | 約35s ±ノイズ |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EKeiMykWodu21sc2JYen9D