### PR TITLE
test(gameaction): カバレッジ増強

### DIFF
--- a/internal/world/gameaction/damage_extra_test.go
+++ b/internal/world/gameaction/damage_extra_test.go
@@ -1,0 +1,46 @@
+package gameaction
+
+import (
+	"testing"
+
+	gc "github.com/kijimaD/ruins/internal/components"
+	"github.com/kijimaD/ruins/internal/testutil"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestReactToHostileAction_SquadAIも反応する はSquadAIを持つエンティティもCombatIgnoreから
+// CombatAttackへ遷移することを確認する。
+func TestReactToHostileAction_SquadAIも反応する(t *testing.T) {
+	t.Parallel()
+	world := testutil.InitTestWorld(t)
+
+	entity := world.ECS.NewEntity()
+	world.Components.SquadAI.Add(entity, &gc.SquadAI{CombatDefault: gc.CombatIgnore, CombatCurrent: gc.CombatIgnore})
+
+	reactToHostileAction(world, entity)
+
+	squad := world.Components.SquadAI.Get(entity)
+	assert.Equal(t, gc.CombatAttack, squad.CombatCurrent)
+}
+
+// TestApplyDamage_プレイヤーも隊員も関与しない場合はログを出力しない は
+// logDeathのisRelevant判定がfalseになる経路がpanicせず何もしないことを確認する。
+func TestApplyDamage_プレイヤーも隊員も関与しない場合はログを出力しない(t *testing.T) {
+	t.Parallel()
+	world := testutil.InitTestWorld(t)
+
+	source := world.ECS.NewEntity()
+	world.Components.Name.Add(source, &gc.Name{Name: "コウモリA"})
+
+	target := world.ECS.NewEntity()
+	world.Components.Name.Add(target, &gc.Name{Name: "コウモリB"})
+	world.Components.HP.Add(target, &gc.HP{Max: 10, Current: 5})
+
+	assert.NotPanics(t, func() {
+		ApplyDamage(world, target, 10, source)
+	})
+
+	hp := world.Components.HP.Get(target)
+	assert.Equal(t, 0, hp.Current)
+	assert.True(t, world.Components.Dead.Has(target), "プレイヤー・隊員が関与しなくても死亡処理自体は行われる")
+}

--- a/internal/world/gameaction/damage_extra_test.go
+++ b/internal/world/gameaction/damage_extra_test.go
@@ -23,9 +23,9 @@ func TestReactToHostileAction_SquadAIも反応する(t *testing.T) {
 	assert.Equal(t, gc.CombatAttack, squad.CombatCurrent)
 }
 
-// TestApplyDamage_プレイヤーも隊員も関与しない場合はログを出力しない は
-// logDeathのisRelevant判定がfalseになる経路がpanicせず何もしないことを確認する。
-func TestApplyDamage_プレイヤーも隊員も関与しない場合はログを出力しない(t *testing.T) {
+// TestApplyDamage_プレイヤーも隊員も関与しない場合でもpanicせず死亡処理は行われる は
+// logDeathのisRelevant判定がfalseになる経路がpanicせず死亡処理自体は完了することを確認する。
+func TestApplyDamage_プレイヤーも隊員も関与しない場合でもpanicせず死亡処理は行われる(t *testing.T) {
 	t.Parallel()
 	world := testutil.InitTestWorld(t)
 

--- a/internal/world/gameaction/shop_extra_test.go
+++ b/internal/world/gameaction/shop_extra_test.go
@@ -1,0 +1,94 @@
+package gameaction
+
+import (
+	"testing"
+
+	gc "github.com/kijimaD/ruins/internal/components"
+	"github.com/kijimaD/ruins/internal/testutil"
+	"github.com/kijimaD/ruins/internal/world/query"
+	"github.com/mlange-42/ark/ecs"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestBuyItem_スタッカブルアイテムはスタックに加算される はスタッカブルなアイテムを
+// 2回購入すると同一エンティティのCountが積み上がることを確認する。
+func TestBuyItem_スタッカブルアイテムはスタックに加算される(t *testing.T) {
+	t.Parallel()
+	world := testutil.InitTestWorld(t)
+
+	player := world.ECS.NewEntity()
+	world.Components.Wallet.Add(player, &gc.Wallet{Currency: 1000})
+
+	require.NoError(t, BuyItem(world, player, "木の棒"))
+	require.NoError(t, BuyItem(world, player, "木の棒"))
+
+	stackQuery := ecs.NewFilter2[gc.Name, gc.Stackable](world.ECS).Query()
+	found := false
+	for stackQuery.Next() {
+		name := world.Components.Name.Get(stackQuery.Entity())
+		if name.Name != "木の棒" {
+			continue
+		}
+		found = true
+		stackable := world.Components.Stackable.Get(stackQuery.Entity())
+		assert.Equal(t, 2, stackable.Count, "スタッカブルアイテムは同一エンティティのCountが増える")
+	}
+	assert.True(t, found, "スタッカブルアイテムのエンティティが存在する")
+}
+
+// TestBuyItem_交渉スキルで買値が変わる はCharModifiers.BuyPriceが購入価格に反映されることを確認する。
+func TestBuyItem_交渉スキルで買値が変わる(t *testing.T) {
+	t.Parallel()
+	world := testutil.InitTestWorld(t)
+
+	player := world.ECS.NewEntity()
+	world.Components.Wallet.Add(player, &gc.Wallet{Currency: 1000})
+	world.Components.CharModifiers.Add(player, &gc.CharModifiers{BuyPrice: 50})
+
+	require.NoError(t, BuyItem(world, player, "木刀"))
+
+	currency := query.GetCurrency(world, player)
+	normalPrice := query.CalculateBuyPrice(80)
+	discountedPrice := normalPrice / 2
+	assert.Equal(t, 1000-discountedPrice, currency, "買値倍率50%で半額になる")
+}
+
+// TestSellItem_価値0のアイテムは売却できない はValueコンポーネントを持たないアイテムの売却がエラーになることを確認する。
+func TestSellItem_価値0のアイテムは売却できない(t *testing.T) {
+	t.Parallel()
+	world := testutil.InitTestWorld(t)
+
+	player := world.ECS.NewEntity()
+	world.Components.Wallet.Add(player, &gc.Wallet{Currency: 0})
+	// Valueコンポーネントを持たないため、GetItemValueは0を返す
+	item := world.ECS.NewEntity()
+
+	err := SellItem(world, player, item)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "売却できません")
+
+	currency := query.GetCurrency(world, player)
+	assert.Equal(t, 0, currency, "売却失敗時は通貨が変動しない")
+}
+
+// TestSellItem_交渉スキルで売値が変わる はCharModifiers.SellPriceが売却価格に反映されることを確認する。
+func TestSellItem_交渉スキルで売値が変わる(t *testing.T) {
+	t.Parallel()
+	world := testutil.InitTestWorld(t)
+
+	player := world.ECS.NewEntity()
+	world.Components.Wallet.Add(player, &gc.Wallet{Currency: 0})
+	world.Components.CharModifiers.Add(player, &gc.CharModifiers{SellPrice: 200})
+
+	item := world.ECS.NewEntity()
+	world.Components.Value.Add(item, &gc.Value{Value: 100})
+	world.Components.Name.Add(item, &gc.Name{Name: "テストアイテム"})
+	world.Components.Stackable.Add(item, &gc.Stackable{Count: 1})
+
+	require.NoError(t, SellItem(world, player, item))
+
+	currency := query.GetCurrency(world, player)
+	normalPrice := query.CalculateSellPrice(100)
+	assert.Equal(t, normalPrice*2, currency, "売値倍率200%で倍額になる")
+}

--- a/internal/world/gameaction/shop_extra_test.go
+++ b/internal/world/gameaction/shop_extra_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	gc "github.com/kijimaD/ruins/internal/components"
+	"github.com/kijimaD/ruins/internal/raw"
 	"github.com/kijimaD/ruins/internal/testutil"
 	"github.com/kijimaD/ruins/internal/world/query"
 	"github.com/mlange-42/ark/ecs"
@@ -46,10 +47,13 @@ func TestBuyItem_交渉スキルで買値が変わる(t *testing.T) {
 	world.Components.Wallet.Add(player, &gc.Wallet{Currency: 1000})
 	world.Components.CharModifiers.Add(player, &gc.CharModifiers{BuyPrice: 50})
 
+	itemDef, err := raw.FindItem(world.Resources.RawMaster, "木刀")
+	require.NoError(t, err)
+
 	require.NoError(t, BuyItem(world, player, "木刀"))
 
 	currency := query.GetCurrency(world, player)
-	normalPrice := query.CalculateBuyPrice(80)
+	normalPrice := query.CalculateBuyPrice(int(itemDef.Value))
 	discountedPrice := normalPrice / 2
 	assert.Equal(t, 1000-discountedPrice, currency, "買値倍率50%で半額になる")
 }
@@ -61,12 +65,10 @@ func TestSellItem_価値0のアイテムは売却できない(t *testing.T) {
 
 	player := world.ECS.NewEntity()
 	world.Components.Wallet.Add(player, &gc.Wallet{Currency: 0})
-	// Valueコンポーネントを持たないため、GetItemValueは0を返す
 	item := world.ECS.NewEntity()
 
 	err := SellItem(world, player, item)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "売却できません")
+	require.ErrorContains(t, err, "売却できません")
 
 	currency := query.GetCurrency(world, player)
 	assert.Equal(t, 0, currency, "売却失敗時は通貨が変動しない")


### PR DESCRIPTION
## 概要

`internal/world/gameaction` パッケージにテストを追加してカバレッジを増強した。本体コードの変更はない。

## カバレッジ

`internal/world/gameaction` パッケージの文カバレッジ:

- 変更前: 80.5%
- 変更後: 86.2%

## 追加したテストと狙った振る舞い

- `shop_extra_test.go`
  - `BuyItem`: スタッカブルなアイテムを2回購入すると同一エンティティのCountが積み上がることを検証する
  - `BuyItem`: `CharModifiers.BuyPrice` の買値倍率が購入価格に反映されることを検証する
  - `SellItem`: `Value` コンポーネントを持たないアイテムは売却できずエラーになることを検証する
  - `SellItem`: `CharModifiers.SellPrice` の売値倍率が売却価格に反映されることを検証する
- `damage_extra_test.go`
  - `reactToHostileAction`: `SquadAI` を持つエンティティも `CombatIgnore` から `CombatAttack` へ遷移することを検証する
  - `ApplyDamage`: プレイヤー・隊員のどちらも関与しない死亡でもpanicせず死亡処理自体は行われることを検証する

## 検証

- `go build ./...`: 成功
- `go test ./internal/world/gameaction/...`: pass、カバレッジ86.2%
- `golangci-lint run ./...`: 0 issues

xvfbが必要なフルの `make test` はサンドボックス環境で複数パッケージを並列実行するとEbitenのX11初期化が不安定になったため、対象パッケージ単体のテストと `go build ./...` で代替した。

Co-Authored-By: Claude <noreply@anthropic.com>

---
_Generated by [Claude Code](https://claude.ai/code/session_014ksk3U3e5HgvtgixB1ZHMr)_