### PR TITLE
refactor: Go context でない context 命名を snap/margin にリネームする

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,8 +61,8 @@ $ make help
 |---|---|
 | in-progress | 2 |
 | accepted | 2 |
-| draft | 4 |
-| done | 64 |
+| draft | 3 |
+| done | 65 |
 
 ### 進行中
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ $ make help
 |---|---|
 | in-progress | 2 |
 | accepted | 2 |
-| draft | 3 |
+| draft | 4 |
 | done | 64 |
 
 ### 進行中

--- a/docs/design/20260730_76.md
+++ b/docs/design/20260730_76.md
@@ -1,0 +1,68 @@
+---
+status: draft
+tags: [refactor]
+auto: needs-decision
+---
+
+# Go context でない「context」命名を一掃する
+
+## 背景
+
+Go では `context` は標準ライブラリ `context.Context` を強く連想させる予約的な語彙で、キャンセルや期限、リクエストスコープの値伝播を意味する。ドメインの都合で `context` や `ctx` を別の意味に使うと、読み手が Go の context と取り違える。コードベースを洗うと、Go context でない `context` 命名が次の箇所に残っている。
+
+| 箇所 | 識別子 | 実際の意味 |
+|---|---|---|
+| `internal/aiinput/planner_squad.go` ほか4ファイル | `squadContext` 型・`gatherSquadContext`・変数 `ctx`・`TestGatherSquadContext` | 隊員AIの1ターンの判断に使う情報の束 |
+| `internal/states/overworld_map.go` | `mapContextCh` | 俯瞰図で帯の東西に足す余白チャンク数 |
+| `internal/logger/logger_test.go` | `TestContextLevelFiltering` | カテゴリ別のログレベル絞り込み |
+
+`internal/oapi/server.gen.go` の `r.Context()` は `http.Request` が返す本物の `context.Context` で、生成コードでもあるため対象外にする。
+
+## 要件
+
+- Go context でない `context`/`ctx` 命名をすべて別語に置き換える
+- 置換後の名前は、その値が実際に何であるかを表す
+- 挙動は変えない。純粋なリネームにする
+
+## 設計
+
+意味に即した名前へ機械的にリネームする。
+
+| 現在 | 変更後 | 理由 |
+|---|---|---|
+| `squadContext` 型 | `squadSnapshot` | 1ターン分の状態のスナップショットである |
+| `gatherSquadContext` | `gatherSquadSnapshot` | 上に揃える |
+| 変数 `ctx`, レシーバ内の `ctx` | `snap` | スナップショットの略 |
+| `TestGatherSquadContext` | `TestGatherSquadSnapshot` | 対象関数に揃える |
+| `mapContextCh` | `marginCh` | 東西対称に足す余白であり、context ではなく margin |
+| `TestContextLevelFiltering` | `TestCategoryLevelFiltering` | 実際に検証するのは `CategoryLevels` によるカテゴリ別絞り込み |
+
+aiinput の命名は、未マージの #554 が既に採用している `squadSnapshot`/`snap` と一致させる。どちらが先にマージされても名前が収束する。
+
+## 変更箇所
+
+| ファイル | 変更 |
+|---|---|
+| `internal/aiinput/planner_squad.go` | `squadContext`→`squadSnapshot`、`gatherSquadContext`→`gatherSquadSnapshot`、`ctx`→`snap` |
+| `internal/aiinput/planner_squad_test.go` | 同上と `TestGatherSquadContext`→`TestGatherSquadSnapshot` |
+| `internal/aiinput/planner_squad_advanced_test.go` | 同上 |
+| `internal/aiinput/squad_processor_test.go` | 同上 |
+| `internal/states/overworld_map.go` | `mapContextCh`→`marginCh` |
+| `internal/logger/logger_test.go` | `TestContextLevelFiltering`→`TestCategoryLevelFiltering` |
+
+## 採用しなかった方法
+
+- **aiinput を #554 に任せてこの PR から外す** — #554 は aiinput の同リネームを既に含むが、`planner_squad_advanced_test.go` だけは未リネームで、しかも #554 は現在 main と CONFLICTING で rebase 待ちである。main には今この命名が残っているので、本 PR で main を直接直す。名前を #554 と揃えるので、rebase 時の衝突は同一リネームどうしで解消できる
+- **`ctx`→`context` と完全語にする** — 語を変えても Go context の連想は消えない。`snap` のように別語にする
+- **`mapContextCh`→`lookaheadCh`** — 先読みの語感は合うが、実際は東西両方へ対称に足す余白なので margin が正確
+
+## コメント
+
+- 非 context の `context` 命名は aiinput にほぼ集中していた。#554 が同じ問題意識で先にリネームしており、本 PR はそれを main へ取り込みつつ #554 の取りこぼしと aiinput 外を仕上げる位置づけになる
+
+## 進捗
+
+- [ ] aiinput 4ファイルの `squadContext`/`ctx` 系を `squadSnapshot`/`snap` にリネームする
+- [ ] `mapContextCh`→`marginCh` にリネームする
+- [ ] `TestContextLevelFiltering`→`TestCategoryLevelFiltering` にリネームする
+- [ ] `make check` で緑を確認する

--- a/docs/design/20260730_76.md
+++ b/docs/design/20260730_76.md
@@ -1,5 +1,5 @@
 ---
-status: draft
+status: done
 tags: [refactor]
 auto: needs-decision
 ---

--- a/docs/design/20260730_76.md
+++ b/docs/design/20260730_76.md
@@ -8,11 +8,14 @@ auto: needs-decision
 
 ## 背景
 
-Go では `context` は標準ライブラリ `context.Context` を強く連想させる予約的な語彙で、キャンセルや期限、リクエストスコープの値伝播を意味する。ドメインの都合で `context` や `ctx` を別の意味に使うと、読み手が Go の context と取り違える。コードベースを洗うと、Go context でない `context` 命名が次の箇所に残っている。
+Go では `context` は標準ライブラリ `context.Context` を強く連想させる予約的な語彙で、キャンセルや期限、リクエストスコープの値伝播を意味する。ドメインの都合で `context` や `ctx` を別の意味に使うと、読み手が Go の context と取り違える。
+
+aiinput の `squadContext` 型と `ctx` 変数はこの問題の中心だったが、#554 で `squadSnapshot`/`snap` へリネーム済みである。ただし取りこぼしがあり、`planner_squad_advanced_test.go` の変数 `ctx` と `planner_squad_test.go` のテスト名 `TestGatherSquadContext` が旧名のまま残った。これらと、aiinput 外の残りを本 PR で仕上げる。
 
 | 箇所 | 識別子 | 実際の意味 |
 |---|---|---|
-| `internal/aiinput/planner_squad.go` ほか4ファイル | `squadContext` 型・`gatherSquadContext`・変数 `ctx`・`TestGatherSquadContext` | 隊員AIの1ターンの判断に使う情報の束 |
+| `internal/aiinput/planner_squad_advanced_test.go` | 変数 `ctx` | 隊員AIの1ターンの判断に使う情報の束。型は `squadSnapshot` 済み |
+| `internal/aiinput/planner_squad_test.go` | `TestGatherSquadContext` | `gatherSquadSnapshot` の検証 |
 | `internal/states/overworld_map.go` | `mapContextCh` | 俯瞰図で帯の東西に足す余白チャンク数 |
 | `internal/logger/logger_test.go` | `TestContextLevelFiltering` | カテゴリ別のログレベル絞り込み |
 
@@ -30,39 +33,32 @@ Go では `context` は標準ライブラリ `context.Context` を強く連想�
 
 | 現在 | 変更後 | 理由 |
 |---|---|---|
-| `squadContext` 型 | `squadSnapshot` | 1ターン分の状態のスナップショットである |
-| `gatherSquadContext` | `gatherSquadSnapshot` | 上に揃える |
-| 変数 `ctx`, レシーバ内の `ctx` | `snap` | スナップショットの略 |
-| `TestGatherSquadContext` | `TestGatherSquadSnapshot` | 対象関数に揃える |
+| `ctx` 変数 in advanced_test | `snap` | スナップショットの略。#554 が他ファイルで採用した名に揃える |
+| `TestGatherSquadContext` | `TestGatherSquadSnapshot` | 対象関数 `gatherSquadSnapshot` に揃える |
 | `mapContextCh` | `marginCh` | 東西対称に足す余白であり、context ではなく margin |
 | `TestContextLevelFiltering` | `TestCategoryLevelFiltering` | 実際に検証するのは `CategoryLevels` によるカテゴリ別絞り込み |
-
-aiinput の命名は、未マージの #554 が既に採用している `squadSnapshot`/`snap` と一致させる。どちらが先にマージされても名前が収束する。
 
 ## 変更箇所
 
 | ファイル | 変更 |
 |---|---|
-| `internal/aiinput/planner_squad.go` | `squadContext`→`squadSnapshot`、`gatherSquadContext`→`gatherSquadSnapshot`、`ctx`→`snap` |
-| `internal/aiinput/planner_squad_test.go` | 同上と `TestGatherSquadContext`→`TestGatherSquadSnapshot` |
-| `internal/aiinput/planner_squad_advanced_test.go` | 同上 |
-| `internal/aiinput/squad_processor_test.go` | 同上 |
+| `internal/aiinput/planner_squad_advanced_test.go` | 変数 `ctx`→`snap` |
+| `internal/aiinput/planner_squad_test.go` | `TestGatherSquadContext`→`TestGatherSquadSnapshot` |
 | `internal/states/overworld_map.go` | `mapContextCh`→`marginCh` |
 | `internal/logger/logger_test.go` | `TestContextLevelFiltering`→`TestCategoryLevelFiltering` |
 
 ## 採用しなかった方法
 
-- **aiinput を #554 に任せてこの PR から外す** — #554 は aiinput の同リネームを既に含むが、`planner_squad_advanced_test.go` だけは未リネームで、しかも #554 は現在 main と CONFLICTING で rebase 待ちである。main には今この命名が残っているので、本 PR で main を直接直す。名前を #554 と揃えるので、rebase 時の衝突は同一リネームどうしで解消できる
 - **`ctx`→`context` と完全語にする** — 語を変えても Go context の連想は消えない。`snap` のように別語にする
 - **`mapContextCh`→`lookaheadCh`** — 先読みの語感は合うが、実際は東西両方へ対称に足す余白なので margin が正確
 
 ## コメント
 
-- 非 context の `context` 命名は aiinput にほぼ集中していた。#554 が同じ問題意識で先にリネームしており、本 PR はそれを main へ取り込みつつ #554 の取りこぼしと aiinput 外を仕上げる位置づけになる
+- 非 context の `context` 命名は aiinput にほぼ集中しており、#554 が同じ問題意識で先にリネームした。本 PR はその取りこぼしの `advanced_test` の `ctx` とテスト名、および aiinput 外の `mapContextCh`・`TestContextLevelFiltering` を仕上げる位置づけになる
 
 ## 進捗
 
-- [ ] aiinput 4ファイルの `squadContext`/`ctx` 系を `squadSnapshot`/`snap` にリネームする
-- [ ] `mapContextCh`→`marginCh` にリネームする
-- [ ] `TestContextLevelFiltering`→`TestCategoryLevelFiltering` にリネームする
-- [ ] `make check` で緑を確認する
+- [x] `advanced_test.go` の `ctx`→`snap`、`TestGatherSquadContext`→`TestGatherSquadSnapshot` にリネームする
+- [x] `mapContextCh`→`marginCh` にリネームする
+- [x] `TestContextLevelFiltering`→`TestCategoryLevelFiltering` にリネームする
+- [x] `make check` で緑を確認する

--- a/internal/aiinput/planner_squad_advanced_test.go
+++ b/internal/aiinput/planner_squad_advanced_test.go
@@ -66,7 +66,7 @@ func TestSquadPlanner_GatherSquadContext(t *testing.T) {
 		assert.Nil(t, snap)
 	})
 
-	t.Run("正常系ではコンテキストを構築する", func(t *testing.T) {
+	t.Run("正常系ではスナップショットを構築する", func(t *testing.T) {
 		t.Parallel()
 		world := testutil.InitTestWorld(t)
 		leader, err := lifecycle.SpawnPlayer(world, consts.Coord[consts.Tile]{X: 10, Y: 10}, "Ash")

--- a/internal/aiinput/planner_squad_advanced_test.go
+++ b/internal/aiinput/planner_squad_advanced_test.go
@@ -47,9 +47,9 @@ func TestSquadPlanner_GatherSquadContext(t *testing.T) {
 		world.Components.GridElement.Add(entity, &gc.GridElement{Coord: consts.Coord[consts.Tile]{X: 1, Y: 1}})
 
 		sp := newSquadPlanner(newTestRNG())
-		ctx, ok := sp.gatherSquadSnapshot(world, entity)
+		snap, ok := sp.gatherSquadSnapshot(world, entity)
 		assert.False(t, ok)
-		assert.Nil(t, ctx)
+		assert.Nil(t, snap)
 	})
 
 	t.Run("プレイヤーがいなければfalse", func(t *testing.T) {
@@ -61,9 +61,9 @@ func TestSquadPlanner_GatherSquadContext(t *testing.T) {
 		world.Components.SquadAI.Add(entity, &gc.SquadAI{})
 
 		sp := newSquadPlanner(newTestRNG())
-		ctx, ok := sp.gatherSquadSnapshot(world, entity)
+		snap, ok := sp.gatherSquadSnapshot(world, entity)
 		assert.False(t, ok)
-		assert.Nil(t, ctx)
+		assert.Nil(t, snap)
 	})
 
 	t.Run("正常系ではコンテキストを構築する", func(t *testing.T) {
@@ -75,12 +75,12 @@ func TestSquadPlanner_GatherSquadContext(t *testing.T) {
 		require.NoError(t, err)
 
 		sp := newSquadPlanner(newTestRNG())
-		ctx, ok := sp.gatherSquadSnapshot(world, member)
+		snap, ok := sp.gatherSquadSnapshot(world, member)
 		require.True(t, ok)
-		require.NotNil(t, ctx)
-		assert.Equal(t, leader, ctx.LeaderEntity)
-		assert.Equal(t, world.Components.GridElement.Get(member), ctx.Grid)
-		assert.Equal(t, world.Components.GridElement.Get(leader), ctx.LeaderGrid)
+		require.NotNil(t, snap)
+		assert.Equal(t, leader, snap.LeaderEntity)
+		assert.Equal(t, world.Components.GridElement.Get(member), snap.Grid)
+		assert.Equal(t, world.Components.GridElement.Get(leader), snap.LeaderGrid)
 	})
 }
 
@@ -98,14 +98,14 @@ func TestSquadPlanner_PlanRetreatAction(t *testing.T) {
 	query.InvalidateSpatialIndex(world)
 
 	sp := newSquadPlanner(newTestRNG())
-	ctx := &squadSnapshot{
+	snap := &squadSnapshot{
 		Grid:         memberGrid,
 		Squad:        &gc.SquadAI{},
 		LeaderEntity: leader,
 		LeaderGrid:   world.Components.GridElement.Get(leader),
 	}
 
-	b, ok := sp.planRetreatAction(world, member, ctx)
+	b, ok := sp.planRetreatAction(world, member, snap)
 	require.True(t, ok, "リーダーに向かって後退できるべき")
 	require.NotNil(t, b)
 	assert.Equal(t, gc.BehaviorMove, b.Name())
@@ -138,14 +138,14 @@ func TestSquadPlanner_PlanReturnToExploredArea(t *testing.T) {
 	query.InvalidateSpatialIndex(world)
 
 	sp := newSquadPlanner(newTestRNG())
-	ctx := &squadSnapshot{
+	snap := &squadSnapshot{
 		Grid:         memberGrid,
 		Squad:        &gc.SquadAI{},
 		LeaderEntity: leader,
 		LeaderGrid:   world.Components.GridElement.Get(leader),
 	}
 
-	b, ok := sp.planReturnToExploredArea(world, member, ctx)
+	b, ok := sp.planReturnToExploredArea(world, member, snap)
 	require.True(t, ok, "リーダーに向かって移動できるべき")
 	assert.Equal(t, gc.BehaviorMove, b.Name())
 }
@@ -172,14 +172,14 @@ func TestSquadPlanner_PlanAction(t *testing.T) {
 		hp.Current = hp.Max * 10 / 100
 
 		sp := newSquadPlanner(newTestRNG())
-		ctx := &squadSnapshot{
+		snap := &squadSnapshot{
 			Grid:         memberGrid,
 			Squad:        &gc.SquadAI{CombatCurrent: gc.CombatAttack, ViewDistance: 10},
 			LeaderEntity: leader,
 			LeaderGrid:   world.Components.GridElement.Get(leader),
 		}
 
-		b := sp.planAction(world, member, ctx)
+		b := sp.planAction(world, member, snap)
 		require.NotNil(t, b)
 		_, isAttack := b.(*activity.AttackActivity)
 		assert.False(t, isAttack, "HP低下時は攻撃せず後退するべき")
@@ -203,14 +203,14 @@ func TestSquadPlanner_PlanAction(t *testing.T) {
 		hp.Current = hp.Max * 10 / 100
 
 		sp := newSquadPlanner(newTestRNG())
-		ctx := &squadSnapshot{
+		snap := &squadSnapshot{
 			Grid:         memberGrid,
 			Squad:        &gc.SquadAI{CombatCurrent: gc.CombatIgnore, Movement: gc.SquadStationary, ViewDistance: 10},
 			LeaderEntity: leader,
 			LeaderGrid:   world.Components.GridElement.Get(leader),
 		}
 
-		b := sp.planAction(world, member, ctx)
+		b := sp.planAction(world, member, snap)
 		require.NotNil(t, b)
 		assert.Equal(t, gc.BehaviorWait, b.Name(), "後退できなければ位置ポリシーの待機に落ちる")
 	})
@@ -232,14 +232,14 @@ func TestSquadPlanner_PlanAction(t *testing.T) {
 		query.InvalidateSpatialIndex(world)
 
 		sp := newSquadPlanner(newTestRNG())
-		ctx := &squadSnapshot{
+		snap := &squadSnapshot{
 			Grid:         memberGrid,
 			Squad:        &gc.SquadAI{CombatCurrent: gc.CombatAttack, ViewDistance: 10},
 			LeaderEntity: leader,
 			LeaderGrid:   world.Components.GridElement.Get(leader),
 		}
 
-		b := sp.planAction(world, member, ctx)
+		b := sp.planAction(world, member, snap)
 		require.NotNil(t, b)
 		_, isAttack := b.(*activity.AttackActivity)
 		assert.False(t, isAttack, "未探索エリアでは攻撃せずリーダーへ復帰するべき")
@@ -262,14 +262,14 @@ func TestSquadPlanner_PlanAction(t *testing.T) {
 		memberGrid.Y = leaderGrid.Y
 
 		sp := newSquadPlanner(newTestRNG())
-		ctx := &squadSnapshot{
+		snap := &squadSnapshot{
 			Grid:         memberGrid,
 			Squad:        &gc.SquadAI{CombatCurrent: gc.CombatIgnore, Movement: gc.SquadEscort, ItemPickup: gc.PolicyIgnore, ItemHandling: gc.PolicyKeep, ViewDistance: 10},
 			LeaderEntity: leader,
 			LeaderGrid:   leaderGrid,
 		}
 
-		b := sp.planAction(world, member, ctx)
+		b := sp.planAction(world, member, snap)
 		require.NotNil(t, b)
 		assert.Equal(t, gc.BehaviorWait, b.Name(), "護衛距離内では待機するべき")
 	})
@@ -294,14 +294,14 @@ func TestSquadPlanner_PlanCombatAction(t *testing.T) {
 		query.InvalidateSpatialIndex(world)
 
 		sp := newSquadPlanner(newTestRNG())
-		ctx := &squadSnapshot{
+		snap := &squadSnapshot{
 			Grid:         memberGrid,
 			Squad:        &gc.SquadAI{CombatCurrent: gc.CombatAttack, ViewDistance: 10},
 			LeaderEntity: leader,
 			LeaderGrid:   world.Components.GridElement.Get(leader),
 		}
 
-		b, ok := sp.planCombatAction(world, member, ctx)
+		b, ok := sp.planCombatAction(world, member, snap)
 		require.True(t, ok)
 		attack, ok := b.(*activity.AttackActivity)
 		require.True(t, ok, "型が *activity.AttackActivity であるべき")
@@ -324,14 +324,14 @@ func TestSquadPlanner_PlanCombatAction(t *testing.T) {
 		query.InvalidateSpatialIndex(world)
 
 		sp := newSquadPlanner(newTestRNG())
-		ctx := &squadSnapshot{
+		snap := &squadSnapshot{
 			Grid:         memberGrid,
 			Squad:        &gc.SquadAI{CombatCurrent: gc.CombatEvade, ViewDistance: 10},
 			LeaderEntity: leader,
 			LeaderGrid:   world.Components.GridElement.Get(leader),
 		}
 
-		b, ok := sp.planCombatAction(world, member, ctx)
+		b, ok := sp.planCombatAction(world, member, snap)
 		require.True(t, ok)
 		assert.Equal(t, gc.BehaviorMove, b.Name())
 	})
@@ -345,14 +345,14 @@ func TestSquadPlanner_PlanCombatAction(t *testing.T) {
 		require.NoError(t, err)
 
 		sp := newSquadPlanner(newTestRNG())
-		ctx := &squadSnapshot{
+		snap := &squadSnapshot{
 			Grid:         world.Components.GridElement.Get(member),
 			Squad:        &gc.SquadAI{CombatCurrent: gc.CombatIgnore, ViewDistance: 10},
 			LeaderEntity: leader,
 			LeaderGrid:   world.Components.GridElement.Get(leader),
 		}
 
-		_, ok := sp.planCombatAction(world, member, ctx)
+		_, ok := sp.planCombatAction(world, member, snap)
 		assert.False(t, ok, "CombatIgnoreは戦闘計画を持たない")
 	})
 }
@@ -369,14 +369,14 @@ func TestSquadPlanner_PlanAttackAction(t *testing.T) {
 		require.NoError(t, err)
 
 		sp := newSquadPlanner(newTestRNG())
-		ctx := &squadSnapshot{
+		snap := &squadSnapshot{
 			Grid:         world.Components.GridElement.Get(member),
 			Squad:        &gc.SquadAI{ViewDistance: 5},
 			LeaderEntity: leader,
 			LeaderGrid:   world.Components.GridElement.Get(leader),
 		}
 
-		_, ok := sp.planAttackAction(world, member, ctx)
+		_, ok := sp.planAttackAction(world, member, snap)
 		assert.False(t, ok)
 	})
 
@@ -396,14 +396,14 @@ func TestSquadPlanner_PlanAttackAction(t *testing.T) {
 		query.InvalidateSpatialIndex(world)
 
 		sp := newSquadPlanner(newTestRNG())
-		ctx := &squadSnapshot{
+		snap := &squadSnapshot{
 			Grid:         memberGrid,
 			Squad:        &gc.SquadAI{ViewDistance: 10},
 			LeaderEntity: leader,
 			LeaderGrid:   world.Components.GridElement.Get(leader),
 		}
 
-		b, ok := sp.planAttackAction(world, member, ctx)
+		b, ok := sp.planAttackAction(world, member, snap)
 		require.True(t, ok)
 		assert.Equal(t, gc.BehaviorMove, b.Name())
 	})
@@ -421,14 +421,14 @@ func TestSquadPlanner_PlanEvadeAction(t *testing.T) {
 		require.NoError(t, err)
 
 		sp := newSquadPlanner(newTestRNG())
-		ctx := &squadSnapshot{
+		snap := &squadSnapshot{
 			Grid:         world.Components.GridElement.Get(member),
 			Squad:        &gc.SquadAI{ViewDistance: 5},
 			LeaderEntity: leader,
 			LeaderGrid:   world.Components.GridElement.Get(leader),
 		}
 
-		_, ok := sp.planEvadeAction(world, member, ctx)
+		_, ok := sp.planEvadeAction(world, member, snap)
 		assert.False(t, ok)
 	})
 
@@ -450,14 +450,14 @@ func TestSquadPlanner_PlanEvadeAction(t *testing.T) {
 		initialX := int(memberGrid.X)
 
 		sp := newSquadPlanner(newTestRNG())
-		ctx := &squadSnapshot{
+		snap := &squadSnapshot{
 			Grid:         memberGrid,
 			Squad:        &gc.SquadAI{ViewDistance: 10},
 			LeaderEntity: leader,
 			LeaderGrid:   world.Components.GridElement.Get(leader),
 		}
 
-		b, ok := sp.planEvadeAction(world, member, ctx)
+		b, ok := sp.planEvadeAction(world, member, snap)
 		require.True(t, ok)
 		move, ok := b.(*activity.MoveActivity)
 		require.True(t, ok)
@@ -495,14 +495,14 @@ func TestSquadPlanner_PlanPositionAction(t *testing.T) {
 			memberGrid.Y = leaderGrid.Y
 
 			sp := newSquadPlanner(newTestRNG())
-			ctx := &squadSnapshot{
+			snap := &squadSnapshot{
 				Grid:         memberGrid,
 				Squad:        &gc.SquadAI{Movement: tt.movement},
 				LeaderEntity: leader,
 				LeaderGrid:   leaderGrid,
 			}
 
-			b := sp.planPositionAction(world, member, ctx)
+			b := sp.planPositionAction(world, member, snap)
 			require.NotNil(t, b, "常に何らかの行動を返す")
 		})
 	}
@@ -525,9 +525,9 @@ func TestSquadPlanner_PlanEscortAction(t *testing.T) {
 		memberGrid.Y = leaderGrid.Y
 
 		sp := newSquadPlanner(newTestRNG())
-		ctx := &squadSnapshot{Grid: memberGrid, LeaderGrid: leaderGrid}
+		snap := &squadSnapshot{Grid: memberGrid, LeaderGrid: leaderGrid}
 
-		b := sp.planEscortAction(world, member, ctx)
+		b := sp.planEscortAction(world, member, snap)
 		assert.Equal(t, gc.BehaviorWait, b.Name())
 	})
 
@@ -545,9 +545,9 @@ func TestSquadPlanner_PlanEscortAction(t *testing.T) {
 		query.InvalidateSpatialIndex(world)
 
 		sp := newSquadPlanner(newTestRNG())
-		ctx := &squadSnapshot{Grid: memberGrid, LeaderGrid: world.Components.GridElement.Get(leader)}
+		snap := &squadSnapshot{Grid: memberGrid, LeaderGrid: world.Components.GridElement.Get(leader)}
 
-		b := sp.planEscortAction(world, member, ctx)
+		b := sp.planEscortAction(world, member, snap)
 		assert.Equal(t, gc.BehaviorMove, b.Name())
 	})
 
@@ -565,9 +565,9 @@ func TestSquadPlanner_PlanEscortAction(t *testing.T) {
 		surroundWithWalls(world, memberGrid.Coord)
 
 		sp := newSquadPlanner(newTestRNG())
-		ctx := &squadSnapshot{Grid: memberGrid, LeaderGrid: world.Components.GridElement.Get(leader)}
+		snap := &squadSnapshot{Grid: memberGrid, LeaderGrid: world.Components.GridElement.Get(leader)}
 
-		b := sp.planEscortAction(world, member, ctx)
+		b := sp.planEscortAction(world, member, snap)
 		assert.Equal(t, gc.BehaviorWait, b.Name(), "壁に囲まれて移動できないときは待機する")
 	})
 }
@@ -589,9 +589,9 @@ func TestSquadPlanner_PlanVanguardAction(t *testing.T) {
 		query.InvalidateSpatialIndex(world)
 
 		sp := newSquadPlanner(newTestRNG())
-		ctx := &squadSnapshot{Grid: memberGrid, LeaderGrid: world.Components.GridElement.Get(leader)}
+		snap := &squadSnapshot{Grid: memberGrid, LeaderGrid: world.Components.GridElement.Get(leader)}
 
-		b := sp.planVanguardAction(world, member, ctx)
+		b := sp.planVanguardAction(world, member, snap)
 		assert.Equal(t, gc.BehaviorMove, b.Name())
 	})
 
@@ -607,9 +607,9 @@ func TestSquadPlanner_PlanVanguardAction(t *testing.T) {
 
 		memberGrid := world.Components.GridElement.Get(member)
 		sp := newSquadPlanner(newTestRNG())
-		ctx := &squadSnapshot{Grid: memberGrid, Squad: &gc.SquadAI{}, LeaderGrid: world.Components.GridElement.Get(leader)}
+		snap := &squadSnapshot{Grid: memberGrid, Squad: &gc.SquadAI{}, LeaderGrid: world.Components.GridElement.Get(leader)}
 
-		b := sp.planVanguardAction(world, member, ctx)
+		b := sp.planVanguardAction(world, member, snap)
 		assert.Equal(t, gc.BehaviorMove, b.Name())
 	})
 
@@ -624,9 +624,9 @@ func TestSquadPlanner_PlanVanguardAction(t *testing.T) {
 		// 探索済みタイルを一切設定しないので tryRandomMove は必ず失敗する
 		memberGrid := world.Components.GridElement.Get(member)
 		sp := newSquadPlanner(newTestRNG())
-		ctx := &squadSnapshot{Grid: memberGrid, Squad: &gc.SquadAI{}, LeaderGrid: world.Components.GridElement.Get(leader)}
+		snap := &squadSnapshot{Grid: memberGrid, Squad: &gc.SquadAI{}, LeaderGrid: world.Components.GridElement.Get(leader)}
 
-		b := sp.planVanguardAction(world, member, ctx)
+		b := sp.planVanguardAction(world, member, snap)
 		assert.Equal(t, gc.BehaviorWait, b.Name())
 	})
 }
@@ -645,9 +645,9 @@ func TestSquadPlanner_PlanSquadPatrolAction(t *testing.T) {
 		exploreAllTiles(world)
 
 		sp := newSquadPlanner(newTestRNG())
-		ctx := &squadSnapshot{Grid: world.Components.GridElement.Get(member), Squad: &gc.SquadAI{}}
+		snap := &squadSnapshot{Grid: world.Components.GridElement.Get(member), Squad: &gc.SquadAI{}}
 
-		b := sp.planSquadPatrolAction(world, member, ctx)
+		b := sp.planSquadPatrolAction(world, member, snap)
 		assert.Equal(t, gc.BehaviorMove, b.Name())
 	})
 
@@ -660,9 +660,9 @@ func TestSquadPlanner_PlanSquadPatrolAction(t *testing.T) {
 		require.NoError(t, err)
 
 		sp := newSquadPlanner(newTestRNG())
-		ctx := &squadSnapshot{Grid: world.Components.GridElement.Get(member), Squad: &gc.SquadAI{}}
+		snap := &squadSnapshot{Grid: world.Components.GridElement.Get(member), Squad: &gc.SquadAI{}}
 
-		b := sp.planSquadPatrolAction(world, member, ctx)
+		b := sp.planSquadPatrolAction(world, member, snap)
 		assert.Equal(t, gc.BehaviorWait, b.Name())
 	})
 }
@@ -689,9 +689,9 @@ func TestSquadPlanner_FindNearestEnemy(t *testing.T) {
 		query.InvalidateSpatialIndex(world)
 
 		sp := newSquadPlanner(newTestRNG())
-		ctx := &squadSnapshot{Grid: memberGrid, Squad: &gc.SquadAI{ViewDistance: 20}}
+		snap := &squadSnapshot{Grid: memberGrid, Squad: &gc.SquadAI{ViewDistance: 20}}
 
-		gotEntity, gotGrid, dist := sp.findNearestEnemy(world, member, ctx)
+		gotEntity, gotGrid, dist := sp.findNearestEnemy(world, member, snap)
 		require.NotNil(t, gotEntity)
 		assert.Equal(t, near, *gotEntity)
 		assert.NotEqual(t, far, *gotEntity)
@@ -715,9 +715,9 @@ func TestSquadPlanner_FindNearestEnemy(t *testing.T) {
 		query.InvalidateSpatialIndex(world)
 
 		sp := newSquadPlanner(newTestRNG())
-		ctx := &squadSnapshot{Grid: memberGrid, Squad: &gc.SquadAI{ViewDistance: 5}}
+		snap := &squadSnapshot{Grid: memberGrid, Squad: &gc.SquadAI{ViewDistance: 5}}
 
-		gotEntity, _, _ := sp.findNearestEnemy(world, member, ctx)
+		gotEntity, _, _ := sp.findNearestEnemy(world, member, snap)
 		assert.Nil(t, gotEntity)
 	})
 }
@@ -817,8 +817,8 @@ func TestSquadPlanner_TryRandomMove(t *testing.T) {
 		require.NoError(t, err)
 
 		sp := newSquadPlanner(newTestRNG())
-		ctx := &squadSnapshot{Grid: world.Components.GridElement.Get(member)}
-		_, ok := sp.tryRandomMove(world, member, ctx)
+		snap := &squadSnapshot{Grid: world.Components.GridElement.Get(member)}
+		_, ok := sp.tryRandomMove(world, member, snap)
 		assert.False(t, ok)
 	})
 
@@ -833,8 +833,8 @@ func TestSquadPlanner_TryRandomMove(t *testing.T) {
 		exploreAllTiles(world)
 
 		sp := newSquadPlanner(newTestRNG())
-		ctx := &squadSnapshot{Grid: world.Components.GridElement.Get(member)}
-		_, ok := sp.tryRandomMove(world, member, ctx)
+		snap := &squadSnapshot{Grid: world.Components.GridElement.Get(member)}
+		_, ok := sp.tryRandomMove(world, member, snap)
 		assert.True(t, ok)
 	})
 }

--- a/internal/aiinput/planner_squad_advanced_test.go
+++ b/internal/aiinput/planner_squad_advanced_test.go
@@ -34,7 +34,7 @@ func surroundWithWalls(world w.World, center consts.Coord[consts.Tile]) {
 	query.InvalidateSpatialIndex(world)
 }
 
-func TestSquadPlanner_GatherSquadContext(t *testing.T) {
+func TestSquadPlanner_GatherSquadSnapshot(t *testing.T) {
 	t.Parallel()
 
 	t.Run("SquadAIがなければfalse", func(t *testing.T) {

--- a/internal/aiinput/planner_squad_test.go
+++ b/internal/aiinput/planner_squad_test.go
@@ -33,7 +33,7 @@ func markExploredNeighbors(world w.World, grid *gc.GridElement) {
 	}
 }
 
-func TestGatherSquadContext(t *testing.T) {
+func TestGatherSquadSnapshot(t *testing.T) {
 	t.Parallel()
 
 	t.Run("隊員のコンテキストを正しく収集する", func(t *testing.T) {

--- a/internal/aiinput/planner_squad_test.go
+++ b/internal/aiinput/planner_squad_test.go
@@ -36,7 +36,7 @@ func markExploredNeighbors(world w.World, grid *gc.GridElement) {
 func TestGatherSquadSnapshot(t *testing.T) {
 	t.Parallel()
 
-	t.Run("隊員のコンテキストを正しく収集する", func(t *testing.T) {
+	t.Run("隊員のスナップショットを正しく収集する", func(t *testing.T) {
 		t.Parallel()
 		world := testutil.InitTestWorld(t)
 
@@ -103,7 +103,7 @@ func TestSquadPlanner_Plan(t *testing.T) {
 		assert.Nil(t, sp.Plan(world, member))
 	})
 
-	t.Run("コンテキストが揃っていれば行動を返す", func(t *testing.T) {
+	t.Run("スナップショットが揃っていれば行動を返す", func(t *testing.T) {
 		t.Parallel()
 		world := testutil.InitTestWorld(t)
 

--- a/internal/logger/logger_test.go
+++ b/internal/logger/logger_test.go
@@ -82,7 +82,7 @@ func TestLogLevelFiltering(t *testing.T) {
 }
 
 //nolint:paralleltest // modifies global config
-func TestContextLevelFiltering(t *testing.T) {
+func TestCategoryLevelFiltering(t *testing.T) {
 	// カテゴリ別設定
 	SetConfig(Config{
 		DefaultLevel: LevelWarn,

--- a/internal/states/overworld_map.go
+++ b/internal/states/overworld_map.go
@@ -47,8 +47,8 @@ func (st *OverworldMapState) OnStop(_ w.World) error { return nil }
 
 // マップ描画の寸法。1チャンクを1セルで描く。
 const (
-	mapCellPx    consts.ScreenPixel = 22 // 1チャンクのセルの一辺ピクセル
-	mapContextCh consts.Chunk       = 6  // 帯の東西に足す文脈チャンク数。この先の地形を先読みできる
+	mapCellPx consts.ScreenPixel = 22 // 1チャンクのセルの一辺ピクセル
+	marginCh  consts.Chunk       = 6  // 帯の東西に足す文脈チャンク数。この先の地形を先読みできる
 )
 
 // OnStart は現在地周辺の各チャンクの種別を算出して保持する。表示中はプレイヤーが動かないため
@@ -61,8 +61,8 @@ func (st *OverworldMapState) OnStart(world w.World) error {
 	rows := max(sb.Rows, 1)
 
 	// 帯の Rows 行と、Cols 列に東西の文脈チャンクを足した窓の各チャンクを種別文字にする
-	winChunksX := int(sb.Cols + 2*mapContextCh)
-	winX0 := sb.EastIndex - mapContextCh
+	winChunksX := int(sb.Cols + 2*marginCh)
+	winX0 := sb.EastIndex - marginCh
 
 	st.glyphs = make([][]rune, rows)
 	for cy := range rows {
@@ -73,14 +73,14 @@ func (st *OverworldMapState) OnStart(world w.World) error {
 		}
 	}
 
-	// 現在地のチャンク。プレイヤー座標は帯ローカルで、窓の原点は西へ mapContextCh
+	// 現在地のチャンク。プレイヤー座標は帯ローカルで、窓の原点は西へ marginCh
 	st.playerCol = -1
 	if player, err := query.GetPlayerEntity(world); err == nil && world.Components.GridElement.Has(player) {
 		g := world.Components.GridElement.Get(player)
-		// プレイヤーの帯ローカルなチャンク座標。窓ローカル列は西へ mapContextCh ぶんずらす
+		// プレイヤーの帯ローカルなチャンク座標。窓ローカル列は西へ marginCh ぶんずらす
 		localCol := consts.Chunk(int(g.X) / int(sb.ChunkW))
 		localRow := consts.Chunk(int(g.Y) / int(sb.ChunkH))
-		st.playerCol = localCol + mapContextCh
+		st.playerCol = localCol + marginCh
 		st.playerRow = localRow
 		st.playerAbs = consts.Coord[consts.Chunk]{X: sb.EastIndex + localCol, Y: localRow}
 	}

--- a/internal/states/overworld_map.go
+++ b/internal/states/overworld_map.go
@@ -48,7 +48,7 @@ func (st *OverworldMapState) OnStop(_ w.World) error { return nil }
 // マップ描画の寸法。1チャンクを1セルで描く。
 const (
 	mapCellPx consts.ScreenPixel = 22 // 1チャンクのセルの一辺ピクセル
-	marginCh  consts.Chunk       = 6  // 帯の東西に足す文脈チャンク数。この先の地形を先読みできる
+	marginCh  consts.Chunk       = 6  // 帯の東西に足す余白チャンク数。この先の地形を先読みできる
 )
 
 // OnStart は現在地周辺の各チャンクの種別を算出して保持する。表示中はプレイヤーが動かないため
@@ -60,7 +60,7 @@ func (st *OverworldMapState) OnStart(world w.World) error {
 	}
 	rows := max(sb.Rows, 1)
 
-	// 帯の Rows 行と、Cols 列に東西の文脈チャンクを足した窓の各チャンクを種別文字にする
+	// 帯の Rows 行と、Cols 列に東西の余白チャンクを足した窓の各チャンクを種別文字にする
 	winChunksX := int(sb.Cols + 2*marginCh)
 	winX0 := sb.EastIndex - marginCh
 

--- a/internal/states/overworld_map.go
+++ b/internal/states/overworld_map.go
@@ -47,8 +47,8 @@ func (st *OverworldMapState) OnStop(_ w.World) error { return nil }
 
 // マップ描画の寸法。1チャンクを1セルで描く。
 const (
-	mapCellPx consts.ScreenPixel = 22 // 1チャンクのセルの一辺ピクセル
-	marginCh  consts.Chunk       = 6  // 帯の東西に足す余白チャンク数。この先の地形を先読みできる
+	mapCellPx   consts.ScreenPixel = 22 // 1チャンクのセルの一辺ピクセル
+	marginChunk consts.Chunk       = 6  // 帯の東西に足す余白チャンク数。この先の地形を先読みできる
 )
 
 // OnStart は現在地周辺の各チャンクの種別を算出して保持する。表示中はプレイヤーが動かないため
@@ -61,8 +61,8 @@ func (st *OverworldMapState) OnStart(world w.World) error {
 	rows := max(sb.Rows, 1)
 
 	// 帯の Rows 行と、Cols 列に東西の余白チャンクを足した窓の各チャンクを種別文字にする
-	winChunksX := int(sb.Cols + 2*marginCh)
-	winX0 := sb.EastIndex - marginCh
+	winChunksX := int(sb.Cols + 2*marginChunk)
+	winX0 := sb.EastIndex - marginChunk
 
 	st.glyphs = make([][]rune, rows)
 	for cy := range rows {
@@ -73,14 +73,14 @@ func (st *OverworldMapState) OnStart(world w.World) error {
 		}
 	}
 
-	// 現在地のチャンク。プレイヤー座標は帯ローカルで、窓の原点は西へ marginCh
+	// 現在地のチャンク。プレイヤー座標は帯ローカルで、窓の原点は西へ marginChunk
 	st.playerCol = -1
 	if player, err := query.GetPlayerEntity(world); err == nil && world.Components.GridElement.Has(player) {
 		g := world.Components.GridElement.Get(player)
-		// プレイヤーの帯ローカルなチャンク座標。窓ローカル列は西へ marginCh ぶんずらす
+		// プレイヤーの帯ローカルなチャンク座標。窓ローカル列は西へ marginChunk ぶんずらす
 		localCol := consts.Chunk(int(g.X) / int(sb.ChunkW))
 		localRow := consts.Chunk(int(g.Y) / int(sb.ChunkH))
-		st.playerCol = localCol + marginCh
+		st.playerCol = localCol + marginChunk
 		st.playerRow = localRow
 		st.playerAbs = consts.Coord[consts.Chunk]{X: sb.EastIndex + localCol, Y: localRow}
 	}


### PR DESCRIPTION
## 概要

Go では `context` は `context.Context` を強く連想させる予約的な語彙で、キャンセル・期限・値伝播という具体的な契約を持つ。ドメインの状態束や余白を `ctx`/`context` と名付けると読み手が Go の context と取り違えるため、非 Go-context の命名を一掃する。

## 背景

aiinput の `squadContext`/`ctx` はこの問題の中心だったが、#554 で `squadSnapshot`/`snap` へリネーム済み。ただし取りこぼしがあり、本 PR で仕上げる。

## リネーム内訳

| ファイル | 変更 |
|---|---|
| `internal/aiinput/planner_squad_advanced_test.go` | 変数 `ctx`→`snap`（#554 の取りこぼし、61箇所） |
| `internal/aiinput/planner_squad_test.go` | `TestGatherSquadContext`→`TestGatherSquadSnapshot` |
| `internal/states/overworld_map.go` | `mapContextCh`→`marginCh`（東西対称の余白で context でなく margin） |
| `internal/logger/logger_test.go` | `TestContextLevelFiltering`→`TestCategoryLevelFiltering`（実際は `CategoryLevels` の検証） |

`internal/oapi/server.gen.go` の `r.Context()` は本物の `context.Context` かつ生成コードのため対象外。純粋なリネームで挙動は不変。

## 再発防止

非 context の `ctx`/`context` 命名を禁じる既存 linter は無い。golangci-lint の context 系（`containedctx`・`contextcheck`・`fatcontext`・`noctx`）はいずれも `context.Context` の使い方の正しさを見るもので命名は対象外。「名前が `ctx`/`context` だが型が `context.Context` でない識別子」を弾くカスタム go/analysis linter が機械化の打ち手になる。別 PR で検討する。

経緯と判断は `docs/design/20260730_76.md`。

## 検証

- `make check` 緑。build・test・lint 0 issues・govulncheck クリーン

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EKeiMykWodu21sc2JYen9D