### PR TITLE
test(pagination): カバレッジ増強

### DIFF
--- a/internal/widgets/pagination/pagination_test.go
+++ b/internal/widgets/pagination/pagination_test.go
@@ -205,7 +205,9 @@ func TestPagination_GetPageText(t *testing.T) {
 		expected     string
 	}{
 		{"1ページのみは空文字", 0, 5, 10, ""},
+		{"最初のページ", 0, 15, 5, "1/3"},
 		{"中間ページ", 1, 15, 5, "2/3"},
+		{"最後のページ", 2, 15, 5, "3/3"},
 	}
 
 	for _, tt := range tests {
@@ -224,70 +226,58 @@ func TestPagination_GetPageText(t *testing.T) {
 func TestSliceVisible(t *testing.T) {
 	t.Parallel()
 
-	items := []string{"a", "b", "c", "d", "e", "f", "g"}
-	p := Pagination{Page: 1, ItemCount: 7, ItemsPerPage: 3}
+	tests := []struct {
+		name     string
+		items    []string
+		p        Pagination
+		expected []string
+	}{
+		{"通常ページ", []string{"a", "b", "c", "d", "e", "f", "g"}, Pagination{Page: 1, ItemCount: 7, ItemsPerPage: 3}, []string{"d", "e", "f"}},
+		{"開始位置がスライス長以上なら空スライス", []string{"a", "b"}, Pagination{Page: 1, ItemCount: 10, ItemsPerPage: 5}, []string{}},
+		{"終了位置をスライス長で切り詰める", []string{"a", "b"}, Pagination{Page: 0, ItemCount: 5, ItemsPerPage: 5}, []string{"a", "b"}},
+	}
 
-	visible := SliceVisible(items, p)
-	assert.Equal(t, []string{"d", "e", "f"}, visible)
-}
-
-func TestSliceVisible_開始位置がスライス長以上なら空スライスを返す(t *testing.T) {
-	t.Parallel()
-
-	// ページ計算上の開始位置5は実スライス長2以上になる
-	items := []string{"a", "b"}
-	p := Pagination{Page: 1, ItemCount: 10, ItemsPerPage: 5}
-
-	visible := SliceVisible(items, p)
-	assert.Equal(t, []string{}, visible)
-}
-
-func TestSliceVisible_終了位置をスライス長で切り詰める(t *testing.T) {
-	t.Parallel()
-
-	// ページ計算上の終了位置5は実スライス長2を超える
-	items := []string{"a", "b"}
-	p := Pagination{Page: 0, ItemCount: 5, ItemsPerPage: 5}
-
-	visible := SliceVisible(items, p)
-	assert.Equal(t, []string{"a", "b"}, visible)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.expected, SliceVisible(tt.items, tt.p))
+		})
+	}
 }
 
 func TestVisibleEntries(t *testing.T) {
 	t.Parallel()
 
-	items := []string{"a", "b", "c", "d", "e"}
-	p := Pagination{Page: 1, ItemCount: 5, ItemsPerPage: 3}
+	tests := []struct {
+		name     string
+		items    []string
+		p        Pagination
+		expected []IndexedItem[string]
+	}{
+		{
+			"通常ページ",
+			[]string{"a", "b", "c", "d", "e"},
+			Pagination{Page: 1, ItemCount: 5, ItemsPerPage: 3},
+			[]IndexedItem[string]{{Index: 3, Item: "d"}, {Index: 4, Item: "e"}},
+		},
+		{
+			"開始位置がスライス長以上ならnil",
+			[]string{"a", "b"},
+			Pagination{Page: 1, ItemCount: 10, ItemsPerPage: 5},
+			nil,
+		},
+		{
+			"終了位置をスライス長で切り詰める",
+			[]string{"a", "b"},
+			Pagination{Page: 0, ItemCount: 5, ItemsPerPage: 5},
+			[]IndexedItem[string]{{Index: 0, Item: "a"}, {Index: 1, Item: "b"}},
+		},
+	}
 
-	result := VisibleEntries(items, p)
-	assert.Len(t, result, 2)
-	assert.Equal(t, 3, result[0].Index)
-	assert.Equal(t, "d", result[0].Item)
-	assert.Equal(t, 4, result[1].Index)
-	assert.Equal(t, "e", result[1].Item)
-}
-
-func TestVisibleEntries_開始位置がスライス長以上ならnilを返す(t *testing.T) {
-	t.Parallel()
-
-	// ページ計算上の開始位置5は実スライス長2以上になる
-	items := []string{"a", "b"}
-	p := Pagination{Page: 1, ItemCount: 10, ItemsPerPage: 5}
-
-	result := VisibleEntries(items, p)
-	assert.Nil(t, result)
-}
-
-func TestVisibleEntries_終了位置をスライス長で切り詰める(t *testing.T) {
-	t.Parallel()
-
-	// ページ計算上の終了位置5は実スライス長2を超える
-	items := []string{"a", "b"}
-	p := Pagination{Page: 0, ItemCount: 5, ItemsPerPage: 5}
-
-	result := VisibleEntries(items, p)
-	assert.Equal(t, []IndexedItem[string]{
-		{Index: 0, Item: "a"},
-		{Index: 1, Item: "b"},
-	}, result)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.expected, VisibleEntries(tt.items, tt.p))
+		})
+	}
 }

--- a/internal/widgets/pagination/pagination_test.go
+++ b/internal/widgets/pagination/pagination_test.go
@@ -173,6 +173,54 @@ func TestPagination_GetIndicatorText(t *testing.T) {
 	}
 }
 
+func TestPagination_IsSelectedInPage(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		index    int
+		expected bool
+	}{
+		{"選択中インデックスと一致すればtrue", 3, true},
+		{"選択中インデックスと不一致ならfalse", 4, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			p := Pagination{ItemIndex: 3}
+			assert.Equal(t, tt.expected, p.IsSelectedInPage(tt.index))
+		})
+	}
+}
+
+func TestPagination_GetPageText(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		page         int
+		itemCount    int
+		itemsPerPage int
+		expected     string
+	}{
+		{"1ページのみは空文字", 0, 5, 10, ""},
+		{"中間ページ", 1, 15, 5, "2/3"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			p := Pagination{
+				Page:         tt.page,
+				ItemCount:    tt.itemCount,
+				ItemsPerPage: tt.itemsPerPage,
+			}
+			assert.Equal(t, tt.expected, p.GetPageText())
+		})
+	}
+}
+
 func TestSliceVisible(t *testing.T) {
 	t.Parallel()
 
@@ -181,6 +229,28 @@ func TestSliceVisible(t *testing.T) {
 
 	visible := SliceVisible(items, p)
 	assert.Equal(t, []string{"d", "e", "f"}, visible)
+}
+
+func TestSliceVisible_開始位置がスライス長以上なら空スライスを返す(t *testing.T) {
+	t.Parallel()
+
+	// ページ計算上の開始位置5は実スライス長2以上になる
+	items := []string{"a", "b"}
+	p := Pagination{Page: 1, ItemCount: 10, ItemsPerPage: 5}
+
+	visible := SliceVisible(items, p)
+	assert.Equal(t, []string{}, visible)
+}
+
+func TestSliceVisible_終了位置をスライス長で切り詰める(t *testing.T) {
+	t.Parallel()
+
+	// ページ計算上の終了位置5は実スライス長2を超える
+	items := []string{"a", "b"}
+	p := Pagination{Page: 0, ItemCount: 5, ItemsPerPage: 5}
+
+	visible := SliceVisible(items, p)
+	assert.Equal(t, []string{"a", "b"}, visible)
 }
 
 func TestVisibleEntries(t *testing.T) {
@@ -195,4 +265,29 @@ func TestVisibleEntries(t *testing.T) {
 	assert.Equal(t, "d", result[0].Item)
 	assert.Equal(t, 4, result[1].Index)
 	assert.Equal(t, "e", result[1].Item)
+}
+
+func TestVisibleEntries_開始位置がスライス長以上ならnilを返す(t *testing.T) {
+	t.Parallel()
+
+	// ページ計算上の開始位置5は実スライス長2以上になる
+	items := []string{"a", "b"}
+	p := Pagination{Page: 1, ItemCount: 10, ItemsPerPage: 5}
+
+	result := VisibleEntries(items, p)
+	assert.Nil(t, result)
+}
+
+func TestVisibleEntries_終了位置をスライス長で切り詰める(t *testing.T) {
+	t.Parallel()
+
+	// ページ計算上の終了位置5は実スライス長2を超える
+	items := []string{"a", "b"}
+	p := Pagination{Page: 0, ItemCount: 5, ItemsPerPage: 5}
+
+	result := VisibleEntries(items, p)
+	assert.Equal(t, []IndexedItem[string]{
+		{Index: 0, Item: "a"},
+		{Index: 1, Item: "b"},
+	}, result)
 }


### PR DESCRIPTION
## 概要

`internal/widgets/pagination` のテストカバレッジを増強する。表示に依存しない純粋なロジックのパッケージで、未テストの関数と境界条件の抜けがあった。

## カバレッジ

- 変更前: 78.7%
- 変更後: 100.0%

## 狙った振る舞い

- `IsSelectedInPage`: 未テストだった選択判定を、一致・不一致の両ケースで検証する
- `GetPageText`: 未テストだったページテキスト生成を、無効時の空文字と通常ページの両ケースで検証する
- `SliceVisible`: ページ計算上の開始位置が実スライス長以上になる場合に空スライスを返すこと、終了位置がスライス長で切り詰められることを検証する
- `VisibleEntries`: 同様に開始位置が範囲外なら`nil`を返すこと、終了位置がスライス長で切り詰められることを検証する

いずれも `Pagination.ItemCount` と実際のスライス長が食い違う場合の防御的分岐で、既存テストでは踏んでいなかった箇所。

本体コードの変更はなく、`*_test.go` のみの差分。

## 検証

- `go test ./internal/widgets/pagination/... -v -cover` で全テストがパスし、カバレッジ100%を確認した
- `golangci-lint run ./...` で0 issuesを確認した
- `go build ./...` でビルドを確認した

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xqj7uq8Jn7hcojv9P5tiyd)_