### PR TITLE
test(mapspawner): カバレッジ増強

### DIFF
--- a/internal/mapspawner/spawn_offset_test.go
+++ b/internal/mapspawner/spawn_offset_test.go
@@ -23,9 +23,8 @@ func TestSpawnAt_オフセット配置(t *testing.T) {
 	require.NoError(t, err)
 
 	const offX, offY consts.Tile = 100, 50
-	if _, err := SpawnAt(world, plan, offX, offY); err != nil {
-		require.NoError(t, err)
-	}
+	_, err = SpawnAt(world, plan, offX, offY)
+	require.NoError(t, err)
 
 	query := ecs.NewFilter1[gc.GridElement](world.ECS).Query()
 	count := 0
@@ -49,9 +48,8 @@ func TestSpawn_オフセットなしは原点配置(t *testing.T) {
 	plan, err := mapplanner.Plan(world, wdt, hgt, 1, mapplanner.PlannerTypeSmallRoom)
 	require.NoError(t, err)
 
-	if _, err := Spawn(world, plan); err != nil {
-		require.NoError(t, err)
-	}
+	_, err = Spawn(world, plan)
+	require.NoError(t, err)
 
 	query := ecs.NewFilter1[gc.GridElement](world.ECS).Query()
 	minX, minY := consts.Tile(1<<30), consts.Tile(1<<30)

--- a/internal/mapspawner/spawn_offset_test.go
+++ b/internal/mapspawner/spawn_offset_test.go
@@ -6,6 +6,7 @@ import (
 	gc "github.com/kijimaD/ruins/internal/components"
 	"github.com/kijimaD/ruins/internal/consts"
 	"github.com/kijimaD/ruins/internal/mapplanner"
+	"github.com/kijimaD/ruins/internal/oapi"
 	"github.com/kijimaD/ruins/internal/testutil"
 	"github.com/mlange-42/ark/ecs"
 	"github.com/stretchr/testify/assert"
@@ -63,4 +64,21 @@ func TestSpawn_オフセットなしは原点配置(t *testing.T) {
 	}
 	assert.Equal(t, consts.Tile(0), minX, "原点 X=0 のタイルが存在する")
 	assert.Equal(t, consts.Tile(0), minY, "原点 Y=0 のタイルが存在する")
+}
+
+// TestSpawnAt_タイル生成エラーを伝播する は SpawnAt が内部ステップのエラーを
+// そのまま呼び出し元へ返し、Level をゼロ値のまま打ち切ることを固定する。
+func TestSpawnAt_タイル生成エラーを伝播する(t *testing.T) {
+	t.Parallel()
+
+	world := testutil.InitTestWorld(t)
+	plan := &mapplanner.MetaPlan{
+		Level:     gc.Level{TileWidth: 1, TileHeight: 1},
+		RawMaster: &world.Resources.RawMaster,
+		Tiles:     []oapi.Tile{{Name: "存在しないタイル", BlockPass: false}},
+	}
+
+	level, err := SpawnAt(world, plan, 0, 0)
+	require.ErrorContains(t, err, "存在しないタイル")
+	assert.Equal(t, gc.Level{}, level, "エラー時はゼロ値のLevelを返す")
 }

--- a/internal/mapspawner/spawn_props_test.go
+++ b/internal/mapspawner/spawn_props_test.go
@@ -1,0 +1,119 @@
+package mapspawner
+
+import (
+	"math/rand/v2"
+	"testing"
+
+	gc "github.com/kijimaD/ruins/internal/components"
+	"github.com/kijimaD/ruins/internal/consts"
+	"github.com/kijimaD/ruins/internal/mapplanner"
+	"github.com/kijimaD/ruins/internal/oapi"
+	"github.com/kijimaD/ruins/internal/testutil"
+	w "github.com/kijimaD/ruins/internal/world"
+	"github.com/mlange-42/ark/ecs"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newTestDoorPlan は扉の向き判定を検証するための3x3マップを持つMetaPlanを生成する。
+// WWW
+// WDW
+// WWW
+// 中央がドアで左右が壁のため、縦向きと判定されるはず
+func newTestDoorPlan(world w.World) *mapplanner.MetaPlan {
+	tiles := make([]oapi.Tile, 9)
+	for i := range tiles {
+		tiles[i] = oapi.Tile{BlockPass: true}
+	}
+	tiles[4] = oapi.Tile{BlockPass: false}
+
+	return &mapplanner.MetaPlan{
+		Level:     gc.Level{TileWidth: 3, TileHeight: 3},
+		RawMaster: &world.Resources.RawMaster,
+		Tiles:     tiles,
+	}
+}
+
+func TestSpawnProps_未知のprops名はエラー(t *testing.T) {
+	t.Parallel()
+
+	world := testutil.InitTestWorld(t)
+	plan := newTestSpawnPlan(world)
+	plan.Props = []mapplanner.PropsSpec{
+		{Coord: consts.Coord[consts.Tile]{X: 1, Y: 1}, Name: "存在しないprops"},
+	}
+
+	err := spawnProps(world, plan, 0, 0)
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "存在しないprops")
+}
+
+func TestSpawnProps_有効なpropsをオフセット込みで生成する(t *testing.T) {
+	t.Parallel()
+
+	world := testutil.InitTestWorld(t)
+	plan := newTestSpawnPlan(world)
+	plan.Props = []mapplanner.PropsSpec{
+		{Coord: consts.Coord[consts.Tile]{X: 2, Y: 3}, Name: "alarm_clock"},
+	}
+
+	err := spawnProps(world, plan, 10, 20)
+	require.NoError(t, err)
+
+	query := ecs.NewFilter1[gc.GridElement](world.ECS).Query()
+	found := false
+	for query.Next() {
+		g := world.Components.GridElement.Get(query.Entity())
+		if g.X == 12 && g.Y == 23 {
+			found = true
+		}
+	}
+	assert.True(t, found, "propsはオフセット込みの座標に生成される")
+}
+
+func TestSpawnProps_扉は向きを設定して閉じた状態で生成される(t *testing.T) {
+	t.Parallel()
+
+	world := testutil.InitTestWorld(t)
+	plan := newTestDoorPlan(world)
+	plan.Props = []mapplanner.PropsSpec{
+		{Coord: consts.Coord[consts.Tile]{X: 1, Y: 1}, Name: "door"},
+	}
+
+	err := spawnProps(world, plan, 0, 0)
+	require.NoError(t, err)
+
+	query := ecs.NewFilter1[gc.Door](world.ECS).Query()
+	found := false
+	for query.Next() {
+		entity := query.Entity()
+		door := world.Components.Door.Get(entity)
+		assert.Equal(t, gc.DoorOrientationVertical, door.Orientation, "左右が壁なら縦向きになる")
+		assert.False(t, door.IsOpen, "生成直後は閉じている")
+		assert.True(t, world.Components.BlockPass.Has(entity), "閉じた扉はBlockPassを持つ")
+		found = true
+	}
+	assert.True(t, found, "扉エンティティが生成される")
+}
+
+func TestSpawnProps_収納propはルートテーブルからアイテムを収納する(t *testing.T) {
+	t.Parallel()
+
+	world := testutil.InitTestWorld(t)
+	plan := newTestSpawnPlan(world)
+	plan.RNG = rand.New(rand.NewPCG(1, 1))
+	plan.Depth = 1
+	plan.Props = []mapplanner.PropsSpec{
+		{Coord: consts.Coord[consts.Tile]{X: 4, Y: 4}, Name: "木箱"},
+	}
+
+	err := spawnProps(world, plan, 0, 0)
+	require.NoError(t, err)
+
+	query := ecs.NewFilter1[gc.LocationInStorage](world.ECS).Query()
+	count := 0
+	for query.Next() {
+		count++
+	}
+	assert.Positive(t, count, "収納アイテムが1つ以上生成される")
+}

--- a/internal/mapspawner/spawn_props_test.go
+++ b/internal/mapspawner/spawn_props_test.go
@@ -19,7 +19,7 @@ import (
 // WWW
 // WDW
 // WWW
-// 中央がドアで左右が壁のため、縦向きと判定されるはず
+// 中央がドアで左右が壁のため、縦向きと判定される
 func newTestDoorPlan(world w.World) *mapplanner.MetaPlan {
 	tiles := make([]oapi.Tile, 9)
 	for i := range tiles {


### PR DESCRIPTION
## 概要

`internal/mapspawner` パッケージにテストを追加し、カバレッジを 84.6% → 87.0% に引き上げる。本体コードの変更は無し。

## 狙った振る舞い

- `spawnProps`
  - 未知の props 名を渡すとエラーを返す
  - 有効な props をオフセット込みの座標へ生成する
  - Door コンポーネントを持つ props は向きを設定して閉じた状態で生成される
  - 収納 prop はルートテーブルからアイテムを収納する
- `spawnTiles` / `SpawnAt`
  - 未対応のタイル名でエラーが伝播し、`SpawnAt` はゼロ値の `Level` を返して打ち切る

## 検証

- `go test -v -cover ./internal/mapspawner/...` で全テスト成功、カバレッジ 84.6% → 87.0%
- `golangci-lint run ./...` でリポジトリ全体 0 issues
- `go build ./...` 成功

---
_Generated by [Claude Code](https://claude.ai/code/session_0198bkDfeVc5sAq1utY7xgLr)_