### PR TITLE
test(world/query): カバレッジ増強

### DIFF
--- a/internal/world/query/active_test.go
+++ b/internal/world/query/active_test.go
@@ -46,3 +46,53 @@ func TestActiveFilter_退避中を除外し追加除外も効く(t *testing.T) {
 	assert.NotContains(t, got2, suspended, "Suspended は依然除外される")
 	assert.NotContains(t, got2, tile, "追加除外の Tile は外れる")
 }
+
+func TestActiveFilter3_退避中を除外する(t *testing.T) {
+	t.Parallel()
+	world := testutil.InitTestWorld(t)
+
+	active := world.ECS.NewEntity()
+	world.Components.GridElement.Add(active, &gc.GridElement{Coord: consts.Coord[consts.Tile]{X: 1, Y: 1}})
+	world.Components.Name.Add(active, &gc.Name{Name: "active"})
+	world.Components.Tile.Add(active, &gc.Tile{})
+
+	suspended := world.ECS.NewEntity()
+	world.Components.GridElement.Add(suspended, &gc.GridElement{Coord: consts.Coord[consts.Tile]{X: 2, Y: 2}})
+	world.Components.Name.Add(suspended, &gc.Name{Name: "suspended"})
+	world.Components.Tile.Add(suspended, &gc.Tile{})
+	world.Components.Suspended.Add(suspended, &gc.Suspended{})
+
+	var got []ecs.Entity
+	q := query.ActiveFilter3[gc.GridElement, gc.Name, gc.Tile](world).Query()
+	for q.Next() {
+		got = append(got, q.Entity())
+	}
+	assert.Contains(t, got, active, "現ステージのエンティティは含まれる")
+	assert.NotContains(t, got, suspended, "Suspended は除外される")
+}
+
+func TestActiveFilter4_退避中を除外する(t *testing.T) {
+	t.Parallel()
+	world := testutil.InitTestWorld(t)
+
+	active := world.ECS.NewEntity()
+	world.Components.GridElement.Add(active, &gc.GridElement{Coord: consts.Coord[consts.Tile]{X: 1, Y: 1}})
+	world.Components.Name.Add(active, &gc.Name{Name: "active"})
+	world.Components.Tile.Add(active, &gc.Tile{})
+	world.Components.FactionAlly.Add(active, &gc.FactionAlly{})
+
+	suspended := world.ECS.NewEntity()
+	world.Components.GridElement.Add(suspended, &gc.GridElement{Coord: consts.Coord[consts.Tile]{X: 2, Y: 2}})
+	world.Components.Name.Add(suspended, &gc.Name{Name: "suspended"})
+	world.Components.Tile.Add(suspended, &gc.Tile{})
+	world.Components.FactionAlly.Add(suspended, &gc.FactionAlly{})
+	world.Components.Suspended.Add(suspended, &gc.Suspended{})
+
+	var got []ecs.Entity
+	q := query.ActiveFilter4[gc.GridElement, gc.Name, gc.Tile, gc.FactionAlly](world).Query()
+	for q.Next() {
+		got = append(got, q.Entity())
+	}
+	assert.Contains(t, got, active, "現ステージのエンティティは含まれる")
+	assert.NotContains(t, got, suspended, "Suspended は除外される")
+}

--- a/internal/world/query/faction_test.go
+++ b/internal/world/query/faction_test.go
@@ -9,6 +9,22 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestIsNeutral_中立派閥コンポーネントを持つエンティティはtrue(t *testing.T) {
+	t.Parallel()
+	world := testutil.InitTestWorld(t)
+	neutral := world.ECS.NewEntity()
+	world.Components.FactionNeutral.Add(neutral, &gc.FactionNeutral{})
+	assert.True(t, query.IsNeutral(world, neutral))
+}
+
+func TestIsNeutral_中立派閥コンポーネントを持たないエンティティはfalse(t *testing.T) {
+	t.Parallel()
+	world := testutil.InitTestWorld(t)
+	ally := world.ECS.NewEntity()
+	world.Components.FactionAlly.Add(ally, &gc.FactionAlly{})
+	assert.False(t, query.IsNeutral(world, ally))
+}
+
 func TestFactionRelation(t *testing.T) {
 	t.Parallel()
 

--- a/internal/world/query/inventory_test.go
+++ b/internal/world/query/inventory_test.go
@@ -1,0 +1,103 @@
+package query_test
+
+import (
+	"testing"
+
+	gc "github.com/kijimaD/ruins/internal/components"
+	"github.com/kijimaD/ruins/internal/oapi"
+	"github.com/kijimaD/ruins/internal/testutil"
+	"github.com/kijimaD/ruins/internal/world/query"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFindStackableInInventory_名前が一致するバックパック内アイテムを返す(t *testing.T) {
+	t.Parallel()
+	world := testutil.InitTestWorld(t)
+
+	owner := world.ECS.NewEntity()
+	item := world.ECS.NewEntity()
+	world.Components.Stackable.Add(item, &gc.Stackable{Count: 3})
+	world.Components.LocationInBackpack.Add(item, &gc.LocationInBackpack{Owner: owner})
+	world.Components.Name.Add(item, &gc.Name{Name: "回復薬"})
+
+	got, found := query.FindStackableInInventory(world, "回復薬")
+	assert.True(t, found)
+	assert.Equal(t, item, got)
+}
+
+func TestFindStackableInInventory_名前が一致しなければ見つからない(t *testing.T) {
+	t.Parallel()
+	world := testutil.InitTestWorld(t)
+
+	owner := world.ECS.NewEntity()
+	item := world.ECS.NewEntity()
+	world.Components.Stackable.Add(item, &gc.Stackable{Count: 3})
+	world.Components.LocationInBackpack.Add(item, &gc.LocationInBackpack{Owner: owner})
+	world.Components.Name.Add(item, &gc.Name{Name: "回復薬"})
+
+	_, found := query.FindStackableInInventory(world, "毒薬")
+	assert.False(t, found)
+}
+
+func TestFindStackableInInventory_Stackableでなければ対象外(t *testing.T) {
+	t.Parallel()
+	world := testutil.InitTestWorld(t)
+
+	owner := world.ECS.NewEntity()
+	item := world.ECS.NewEntity()
+	world.Components.LocationInBackpack.Add(item, &gc.LocationInBackpack{Owner: owner})
+	world.Components.Name.Add(item, &gc.Name{Name: "回復薬"})
+
+	_, found := query.FindStackableInInventory(world, "回復薬")
+	assert.False(t, found)
+}
+
+func TestFindStackableInInventory_バックパック内でなければ対象外(t *testing.T) {
+	t.Parallel()
+	world := testutil.InitTestWorld(t)
+
+	item := world.ECS.NewEntity()
+	world.Components.Stackable.Add(item, &gc.Stackable{Count: 3})
+	world.Components.Name.Add(item, &gc.Name{Name: "回復薬"})
+
+	_, found := query.FindStackableInInventory(world, "回復薬")
+	assert.False(t, found)
+}
+
+func TestFindAmmoInInventory_口径タグが一致するバックパック内弾薬を返す(t *testing.T) {
+	t.Parallel()
+	world := testutil.InitTestWorld(t)
+
+	owner := world.ECS.NewEntity()
+	ammo := world.ECS.NewEntity()
+	world.Components.Stackable.Add(ammo, &gc.Stackable{Count: 10})
+	world.Components.LocationInBackpack.Add(ammo, &gc.LocationInBackpack{Owner: owner})
+	world.Components.Ammo.Add(ammo, &gc.Ammo{AmmoTag: oapi.N9mm})
+
+	got, found := query.FindAmmoInInventory(world, oapi.N9mm)
+	assert.True(t, found)
+	assert.Equal(t, ammo, got)
+}
+
+func TestFindAmmoInInventory_口径タグが一致しなければ見つからない(t *testing.T) {
+	t.Parallel()
+	world := testutil.InitTestWorld(t)
+
+	owner := world.ECS.NewEntity()
+	ammo := world.ECS.NewEntity()
+	world.Components.Stackable.Add(ammo, &gc.Stackable{Count: 10})
+	world.Components.LocationInBackpack.Add(ammo, &gc.LocationInBackpack{Owner: owner})
+	world.Components.Ammo.Add(ammo, &gc.Ammo{AmmoTag: oapi.N9mm})
+
+	_, found := query.FindAmmoInInventory(world, oapi.Rifle)
+	assert.False(t, found)
+}
+
+func TestFindAmmoInInventory_該当が無ければゼロ値エンティティを返す(t *testing.T) {
+	t.Parallel()
+	world := testutil.InitTestWorld(t)
+
+	got, found := query.FindAmmoInInventory(world, oapi.Shell)
+	assert.False(t, found)
+	assert.Zero(t, got)
+}

--- a/internal/world/query/location_test.go
+++ b/internal/world/query/location_test.go
@@ -1,0 +1,120 @@
+package query_test
+
+import (
+	"testing"
+
+	gc "github.com/kijimaD/ruins/internal/components"
+	"github.com/kijimaD/ruins/internal/consts"
+	"github.com/kijimaD/ruins/internal/testutil"
+	"github.com/kijimaD/ruins/internal/world/query"
+	"github.com/mlange-42/ark/ecs"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetStorageItems_収納内のアイテムだけを返す(t *testing.T) {
+	t.Parallel()
+	world := testutil.InitTestWorld(t)
+
+	storage := world.ECS.NewEntity()
+	otherStorage := world.ECS.NewEntity()
+
+	item := world.ECS.NewEntity()
+	world.Components.LocationInStorage.Add(item, &gc.LocationInStorage{Owner: storage})
+
+	otherItem := world.ECS.NewEntity()
+	world.Components.LocationInStorage.Add(otherItem, &gc.LocationInStorage{Owner: otherStorage})
+
+	items := query.GetStorageItems(world, storage)
+	assert.Equal(t, []ecs.Entity{item}, items)
+}
+
+func TestGetStorageItems_収納内が空なら空を返す(t *testing.T) {
+	t.Parallel()
+	world := testutil.InitTestWorld(t)
+
+	storage := world.ECS.NewEntity()
+	items := query.GetStorageItems(world, storage)
+	assert.Empty(t, items)
+}
+
+func TestGetStorageCurrentWeight_WeightCapacityがあれば現在重量を返す(t *testing.T) {
+	t.Parallel()
+	world := testutil.InitTestWorld(t)
+
+	storage := world.ECS.NewEntity()
+	world.Components.WeightCapacity.Add(storage, &gc.WeightCapacity{
+		Current: consts.MustParseWeight("3 kg"),
+		Max:     consts.MustParseWeight("10 kg"),
+	})
+
+	got := query.GetStorageCurrentWeight(world, storage)
+	assert.Equal(t, consts.MustParseWeight("3 kg"), got)
+}
+
+func TestGetStorageCurrentWeight_WeightCapacityが無ければ0(t *testing.T) {
+	t.Parallel()
+	world := testutil.InitTestWorld(t)
+
+	storage := world.ECS.NewEntity()
+	got := query.GetStorageCurrentWeight(world, storage)
+	assert.Equal(t, consts.Milligram(0), got)
+}
+
+func TestCanAddToStorage_容量内なら追加できる(t *testing.T) {
+	t.Parallel()
+	world := testutil.InitTestWorld(t)
+
+	storage := world.ECS.NewEntity()
+	world.Components.WeightCapacity.Add(storage, &gc.WeightCapacity{
+		Current: consts.MustParseWeight("3 kg"),
+		Max:     consts.MustParseWeight("10 kg"),
+	})
+
+	item := world.ECS.NewEntity()
+	world.Components.Weight.Add(item, &gc.Weight{Milligram: consts.MustParseWeight("5 kg")})
+
+	assert.True(t, query.CanAddToStorage(world, storage, item))
+}
+
+func TestCanAddToStorage_容量を超えるなら追加できない(t *testing.T) {
+	t.Parallel()
+	world := testutil.InitTestWorld(t)
+
+	storage := world.ECS.NewEntity()
+	world.Components.WeightCapacity.Add(storage, &gc.WeightCapacity{
+		Current: consts.MustParseWeight("8 kg"),
+		Max:     consts.MustParseWeight("10 kg"),
+	})
+
+	item := world.ECS.NewEntity()
+	world.Components.Weight.Add(item, &gc.Weight{Milligram: consts.MustParseWeight("5 kg")})
+
+	assert.False(t, query.CanAddToStorage(world, storage, item))
+}
+
+func TestCanAddToStorage_ちょうど上限なら追加できる(t *testing.T) {
+	t.Parallel()
+	world := testutil.InitTestWorld(t)
+
+	storage := world.ECS.NewEntity()
+	world.Components.WeightCapacity.Add(storage, &gc.WeightCapacity{
+		Current: consts.MustParseWeight("5 kg"),
+		Max:     consts.MustParseWeight("10 kg"),
+	})
+
+	item := world.ECS.NewEntity()
+	world.Components.Weight.Add(item, &gc.Weight{Milligram: consts.MustParseWeight("5 kg")})
+
+	assert.True(t, query.CanAddToStorage(world, storage, item))
+}
+
+func TestCanAddToStorage_WeightCapacityが無ければ追加できない(t *testing.T) {
+	t.Parallel()
+	world := testutil.InitTestWorld(t)
+
+	storage := world.ECS.NewEntity()
+	item := world.ECS.NewEntity()
+	world.Components.Weight.Add(item, &gc.Weight{Milligram: consts.MustParseWeight("1 kg")})
+
+	assert.False(t, query.CanAddToStorage(world, storage, item))
+}

--- a/internal/world/query/location_test.go
+++ b/internal/world/query/location_test.go
@@ -92,7 +92,7 @@ func TestCanAddToStorage_容量を超えるなら追加できない(t *testing.T
 	assert.False(t, query.CanAddToStorage(world, storage, item))
 }
 
-func TestCanAddToStorage_ちょうど上限なら追加できる(t *testing.T) {
+func TestCanAddToStorage_残量ちょうどなら追加できる(t *testing.T) {
 	t.Parallel()
 	world := testutil.InitTestWorld(t)
 
@@ -114,7 +114,6 @@ func TestCanAddToStorage_WeightCapacityが無ければ追加できない(t *test
 
 	storage := world.ECS.NewEntity()
 	item := world.ECS.NewEntity()
-	world.Components.Weight.Add(item, &gc.Weight{Milligram: consts.MustParseWeight("1 kg")})
 
 	assert.False(t, query.CanAddToStorage(world, storage, item))
 }


### PR DESCRIPTION
## 概要

`internal/world/query` パッケージのテストカバレッジを増強する。本体コードの変更は無く、テストファイルのみを追加・変更した。

## カバレッジ

- 変更前: 80.2%
- 変更後: 87.9%

## 追加・変更したテスト

- `inventory_test.go`（新規）: `FindStackableInInventory`・`FindAmmoInInventory` にテストが無かったため新規追加。名前/口径タグの一致、Stackableでない場合、バックパック内でない場合の除外を検証
- `location_test.go`（新規）: `GetStorageItems`・`GetStorageCurrentWeight`・`CanAddToStorage` にテストが無かったため新規追加。収納内アイテムの絞り込み、WeightCapacity 有無、容量境界での可否判定を検証
- `active_test.go`: `ActiveFilter3`・`ActiveFilter4` の Suspended 除外が未検証だったため追加
- `faction_test.go`: `IsNeutral` が未検証だったため追加

## 検証

- `make test` が通ることを確認
- `golangci-lint run ./internal/world/query/...` で 0 issues を確認

---
_Generated by [Claude Code](https://claude.ai/code/session_0149x7PWpbfmkEU5zfMutu8J)_