### PR TITLE
docs(design): OSS 調査 2026-08

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ $ make help
 
 | status | 件数 |
 |---|---|
-| draft | 4 |
+| draft | 5 |
 | done | 72 |
 
 ### 未完了
@@ -70,6 +70,7 @@ $ make help
 | [77](docs/design/20260730_77.md) | draft | 拡張可能な移動拠点を中核に据える | - | gamedesign |
 | [79](docs/design/20260731_79.md) | draft | 施設内装の生成 —— doc 70 の未着手バックログ | 0/32 | worldgen |
 | [80](docs/design/20260731_80.md) | draft | 移動キューブのコア機構 実装設計 | 0/6（見送り1） | movement, ecs, save |
+| [81](docs/design/20260801_81.md) | draft | OSS 調査 2026-08 | 0/5 | meta, worldgen, combat, ui |
 
 
 ## Reference

--- a/docs/design/20260801_81.md
+++ b/docs/design/20260801_81.md
@@ -39,7 +39,7 @@ auto: needs-decision # mechanical=無人着手可 / needs-decision=人の判断�
 - リポジトリ: https://github.com/mlange-42/ark-tools
 - 概要: ruins が使う ECS 本体 `mlange-42/ark` と同じ作者が提供する補助ライブラリ。更新頻度の異なるシステムとUIを扱うスケジューラ、システム/オブザーバー向けインターフェース、PRNG やティック情報などの共有リソース、CSV出力や終了処理といった汎用システムを提供する。
 - ruins での用途: `internal/engine` や各 `*_system.go` にある自前のシステム実行順序管理・共有リソース管理の一部を、Ark 本体と設計思想が揃った既製の仕組みに置き換えられる可能性がある。
-- 成熟度: 13 スター、19 コミット。2026-04-09 更新。GitHub Actions でテストとカバレッジを継続。
+- 成熟度: 13 スター、19 コミット。2026-04-09 更新。GitHub Actions でテストとカバレッジを継続。ruins が依存する ark 本体ほどの実績はなく、小規模で今後もメンテが継続するかは不確か。
 - ライセンス: MIT
 
 #### 2. quasilyte/ebitengine-input
@@ -47,6 +47,7 @@ auto: needs-decision # mechanical=無人着手可 / needs-decision=人の判断�
 - リポジトリ: https://github.com/quasilyte/ebitengine-input
 - 概要: Ebitengine 向けの入力抽象化ライブラリ。キーボード・マウス・複数ゲームパッドの入力を「アクション」単位で扱える。修飾キー、キーバインドのスキャン、設定ファイルからのキーマップ読み込みに対応し、Ebitengine 以外への外部依存がない。
 - ruins での用途: 現状 `internal/input/keyboard.go` はキーボード専用の自前実装で、ゲームパッド対応がない。`go.mod` には Steam 対応の `go-steamworks` が既に入っており、Steam Deck 等のコントローラー操作を見据えると、入力層をこのライブラリに寄せてゲームパッド対応を追加する選択肢になる。
+- 採用時の注意: `go-steamworks` は Steam 側の実績・オーバーレイ等の機能を扱うもので、ゲームパッドの入力そのものはおそらく Ebitengine の標準入力経路を通る。両者が競合するか、Steam Input のリマップ機能と `ebitengine-input` のアクションマッピングをどう共存させるかは未検証で、採用前に実機で確認する必要がある。
 - 成熟度: 98 スター、90 コミット、Roboden・Cavebots 等 8 本の完成ゲームでの採用実績あり。オープンイシュー13件。2026-06-16 更新。
 - ライセンス: MIT
 
@@ -64,7 +65,7 @@ auto: needs-decision # mechanical=無人着手可 / needs-decision=人の判断�
 - リポジトリ: https://github.com/shawnridgeway/wfc
 - 概要: Wave Function Collapse アルゴリズムの Go 実装。サンプル画像からパターンを抽出する Overlapping Model と、タイルと接続制約から生成する Simple Tiled Model の両方に対応する。
 - ruins での用途: `internal/mapplanner` は部屋配置ベースの生成が中心。WFC はタイル同士の接続規則から模様的な地形を生成できるため、既存とは異なる生成手法の実験用途、たとえば地上ワールドや装飾タイルパターンの生成に使える可能性がある。
-- 成熟度: 79 スター、24 コミット。2026-04-17 更新。小規模ライブラリでメンテナンスは低頻度。
+- 成熟度: 79 スター、24 コミット。2019年作成で2026-04-17時点までの7年間で24コミットと更新頻度は低い。機能追加ではなく、必要時に細く保守されている段階と見られる。
 - ライセンス: MIT
 
 #### 5. aquilax/go-perlin

--- a/docs/design/20260801_81.md
+++ b/docs/design/20260801_81.md
@@ -1,0 +1,104 @@
+---
+status: draft # draft|accepted|in-progress|done|superseded|dropped
+tags: [meta, worldgen, combat, ui]
+auto: needs-decision # mechanical=無人着手可 / needs-decision=人の判断必須
+---
+
+# OSS 調査 2026-08
+
+## 背景
+
+月次の OSS 調査ルーチンによる自動調査。GitHub の検索とトレンドから ruins に役立ちそうな OSS を探し、採否の判断材料として残す。コードの変更や依存追加は行わない。判断と実装は人が行う。
+
+## 要件
+
+- ruins に実際に役立つか。Ebiten・ECS・ゲーム・ローグライク、または Go の開発・テスト・CI・シリアライズ・生成に関わるものに絞る。
+- ある程度のスターとメンテ実績があり、ライセンスが MIT/BSD/Apache 等の使えるものに限る。
+- `go.mod` の既存依存と重複しない。ebiten・ebitenui・ark・ark-serde・testify・urfave/cli・goldie・BurntSushi/toml・pelletier/go-toml・yaml.v3・getkin/kin-openapi・oapi-codegen とは別のもの。
+- 既に自前実装がある領域は、単純な重複なら除外し、明確な優位性がある場合のみ注意書き付きで残す。
+
+## 設計
+
+### 調査方法
+
+1. `gh search repos` 相当の検索を `language:go` で複数ドメインに対して実行した。対象語: `ebiten` / `ecs entity component` / `roguelike` / `procedural generation` / `game engine` / `perlin noise` / `wave function collapse` / `golangci-lint custom linter`。
+2. GitHub Trends の Go 月間トレンドを取得した。Kubernetes・Terraform・LLM エージェント等の一般開発ツールが中心で、ruins に関係する候補は無かった。
+3. 候補ごとに README を確認し、`go.mod` および `internal/` の既存実装と重複しないか照合した。
+
+### 既存実装との重複チェック
+
+調査の過程で、以下がすでに ruins に自前実装されていることを確認した。これにより候補から除外・注意書きした項目がある。
+
+- 視界計算: `internal/systems/vision.go` がブレゼンハムアルゴリズムによる自前のタイルベース視線判定と光源処理を持つ。`norendren/go-fov`（再帰的シャドウキャスティング）は機能が重複し、光源処理を含まないため候補から除外した。
+- パスファインディング: `internal/mapplanner/pathfinder.go`（マップ生成の到達性判定用 BFS）と `internal/aiinput/planner_squad.go` の `tryMoveToward`（戦闘中の迂回移動用 BFS）が既にある。`quasilyte/pathing` は重複するが、ゼロアロケーションという明確な性能優位があるため注意書き付きで残した。
+
+### 候補
+
+#### 1. mlange-42/ark-tools
+
+- リポジトリ: https://github.com/mlange-42/ark-tools
+- 概要: ruins が使う ECS 本体 `mlange-42/ark` と同じ作者が提供する補助ライブラリ。更新頻度の異なるシステムとUIを扱うスケジューラ、システム/オブザーバー向けインターフェース、PRNG やティック情報などの共有リソース、CSV出力や終了処理といった汎用システムを提供する。
+- ruins での用途: `internal/engine` や各 `*_system.go` にある自前のシステム実行順序管理・共有リソース管理の一部を、Ark 本体と設計思想が揃った既製の仕組みに置き換えられる可能性がある。
+- 成熟度: 13 スター、19 コミット。2026-04-09 更新。GitHub Actions でテストとカバレッジを継続。
+- ライセンス: MIT
+
+#### 2. quasilyte/ebitengine-input
+
+- リポジトリ: https://github.com/quasilyte/ebitengine-input
+- 概要: Ebitengine 向けの入力抽象化ライブラリ。キーボード・マウス・複数ゲームパッドの入力を「アクション」単位で扱える。修飾キー、キーバインドのスキャン、設定ファイルからのキーマップ読み込みに対応し、Ebitengine 以外への外部依存がない。
+- ruins での用途: 現状 `internal/input/keyboard.go` はキーボード専用の自前実装で、ゲームパッド対応がない。`go.mod` には Steam 対応の `go-steamworks` が既に入っており、Steam Deck 等のコントローラー操作を見据えると、入力層をこのライブラリに寄せてゲームパッド対応を追加する選択肢になる。
+- 成熟度: 98 スター、90 コミット、Roboden・Cavebots 等 8 本の完成ゲームでの採用実績あり。オープンイシュー13件。2026-06-16 更新。
+- ライセンス: MIT
+
+#### 3. quasilyte/pathing
+
+- リポジトリ: https://github.com/quasilyte/pathing
+- 概要: グリッドベースのゼロアロケーション経路探索ライブラリ。Greedy BFS と A* に対応し、既存実装比でベンチマーク上大幅に高速。Ebitengine 製の商用ゲーム Roboden で採用実績がある。
+- ruins での用途: `internal/aiinput/planner_squad.go` の `tryMoveToward` は自前 BFS で毎ターン経路探索している。隊員数が増えた場合の GC 負荷対策として検討余地がある。
+- 採用時の注意: 1 グリッドあたり最大 8 タイル種・1 探索あたり最大 56 ステップという制約があり、ruins のマップやタイル種別の数によっては複数レイヤーへの分割や結果の連結が必要になる。既存 BFS を単純に差し替えられるとは限らない。
+- 成熟度: 135 スター、60 コミット。2026-06-20 更新。
+- ライセンス: MIT
+
+#### 4. shawnridgeway/wfc
+
+- リポジトリ: https://github.com/shawnridgeway/wfc
+- 概要: Wave Function Collapse アルゴリズムの Go 実装。サンプル画像からパターンを抽出する Overlapping Model と、タイルと接続制約から生成する Simple Tiled Model の両方に対応する。
+- ruins での用途: `internal/mapplanner` は部屋配置ベースの生成が中心。WFC はタイル同士の接続規則から模様的な地形を生成できるため、既存とは異なる生成手法の実験用途、たとえば地上ワールドや装飾タイルパターンの生成に使える可能性がある。
+- 成熟度: 79 スター、24 コミット。2026-04-17 更新。小規模ライブラリでメンテナンスは低頻度。
+- ライセンス: MIT
+
+#### 5. aquilax/go-perlin
+
+- リポジトリ: https://github.com/aquilax/go-perlin
+- 概要: 1D/2D/3D の Perlin ノイズ生成ライブラリ。GEGL プロジェクトのアルゴリズムを移植したもの。
+- ruins での用途: 現状の地形生成は乱数ベースの部屋配置で、ノイズ関数は使っていない。シームレスワールドの地上部やバイオーム境界のような、なだらかな変化を持つ地形生成のバリエーションとして使える可能性がある。
+- 成熟度: 93 スター、38 コミット。2026-07-16 更新と直近も動きがある。
+- ライセンス: MIT
+
+## 変更箇所
+
+本ドキュメントの新規作成のみ。コードおよび依存関係の変更はない。
+
+| ファイル | 変更内容 |
+| --- | --- |
+| `docs/design/20260801_81.md` | 新規作成 |
+
+## 採用しなかった方法
+
+- `norendren/go-fov`: 再帰的シャドウキャスティングによる視野計算。ruins は既に `internal/systems/vision.go` でブレゼンハムベースの視線判定と光源処理を自前実装しており、光源処理を含まない go-fov に置き換える明確な利点がないため見送った。
+- `oriumgames/bevi`: Ark ECS 向けの Bevy 風スケジューラ/イベントラッパー。7 スターと小規模で、ruins は既に独自の `w.Updater` ベースのシステム実行アーキテクチャを持つため、置き換えは規模の割に破壊的変更が大きいと判断した。
+- `mlange-42/ark-pixel`: Ark ECS 向け OpenGL 描画・プロットライブラリ。ruins は Ebiten を描画に使っており、生の OpenGL 層は不要。
+- `quasilyte/gdata`: クロスプラットフォームのゲームデータ保存パッケージ。ruins は既に `internal/save` と ark-serde・yaml.v3・go-toml でセーブ/設定を持っており重複する。
+- GitHub Trends（Go 月間）: argo-cd・tailscale・terraform・LLM エージェント関連等が中心で、ruins に関連する候補は無かった。
+
+## コメント
+
+いずれも人が採否を判断する。特に候補1・2はゲームプレイに直結する既存領域への追加提案であり、既存の自前実装をどこまで置き換えるかは設計判断が要る。候補3は制約の実測、候補4・5は具体的な使いどころの検証が採用前に必要。
+
+## 進捗
+
+- [ ] mlange-42/ark-tools の採用を検討する
+- [ ] quasilyte/ebitengine-input の採用を検討する
+- [ ] quasilyte/pathing の採用を検討する
+- [ ] shawnridgeway/wfc の採用を検討する
+- [ ] aquilax/go-perlin の採用を検討する


### PR DESCRIPTION
## 概要

月次の OSS 調査ルーチンによる自動調査です。GitHub 検索・トレンドから、ruins に役立ちそうな OSS を探し、`docs/design/20260801_81.md` にまとめました。

- Ebiten・ECS・procgen 領域を中心に候補を絞り込み、5 件を掲載しています。
- `go.mod` の既存依存、および `internal/systems/vision.go`・`internal/mapplanner/pathfinder.go`・`internal/aiinput` にある自前実装との重複を確認済みです。
- コードの変更・依存の追加は行っていません。ドキュメント1本のみの追加です。

## 候補

1. `mlange-42/ark-tools` — Ark ECS 向けスケジューラ/共有リソース拡張
2. `quasilyte/ebitengine-input` — Ebitengine 向け入力抽象化、ゲームパッド対応
3. `quasilyte/pathing` — ゼロアロケーションのグリッド経路探索
4. `shawnridgeway/wfc` — Wave Function Collapse による手続き生成
5. `aquilax/go-perlin` — Perlin ノイズ生成

これは提案であり、採否は人がレビューで判断します。

---
_Generated by [Claude Code](https://claude.ai/code/session_01F55FcQn6LfawKSasZCcSAW)_