### PR TITLE
docs(design): 屋外の散布の設計 doc 82 を追加する

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ $ make help
 
 | status | 件数 |
 |---|---|
-| draft | 5 |
+| draft | 6 |
 | done | 72 |
 
 ### 未完了
@@ -71,6 +71,7 @@ $ make help
 | [79](docs/design/20260731_79.md) | draft | 施設内装の生成 —— doc 70 の未着手バックログ | 0/32 | worldgen |
 | [80](docs/design/20260731_80.md) | draft | 移動キューブのコア機構 実装設計 | 0/6（見送り1） | movement, ecs, save |
 | [81](docs/design/20260801_81.md) | draft | OSS 調査 2026-08 | 0/5 | meta, worldgen, combat, ui |
+| [82](docs/design/20260801_82.md) | draft | 屋外の散布 —— 開けた地表へ自然物とポスアポ人工物を撒く | 0/10（見送り1） | worldgen |
 
 
 ## Reference

--- a/docs/design/20260801_82.md
+++ b/docs/design/20260801_82.md
@@ -1,0 +1,274 @@
+---
+status: draft
+tags: [worldgen]
+auto: needs-decision
+---
+
+# 屋外の散布 —— 開けた地表へ自然物とポスアポ人工物を撒く
+
+## 背景
+
+オーバーワールドの屋外に何も配置されておらず、開けた地表が単調である。原因は配置系の構造にある。
+
+- 屋外の素地は一律 `dirt`。`internal/mapplanner/overworld_field.go` の `OverworldFieldPlanner` は `FillAll(dirt)`
+  のみで、壁も prop も置かない。バイオームや雪タイルは無い。世界観の「凍った日本」は、地表タイルでなく
+  `internal/worldstream/front.go` の東進する寒波前線と霜描画オーバーレイで表現する。屋外配置は均質な dirt 面へ
+  prop とタイル置換を重ねる設計になる。
+- 屋外の地物は疎なフィーチャだけ。`internal/overworld/feature.go` の `features()` は settlement・urban・
+  dungeon_entrance・wilderness POI・road の5種で、いずれも `Placement` の「1リージョンに高々1つ」の疎配置。
+  チャンク種別の大半を占める `wasteland` には何のフィーチャも当たらず、素地の dirt だけが残る。
+- `feature.go` は密散布の不在を自認している。`Placement` のドキュメントに「密な散布が要る地物が現れたら
+  Scatter モードをここに拡張する」と拡張点が予約済み。
+
+`20260725_70`、施設内装、が屋内向けに「密度場＋決定的間引き＋散布」の placement 意味論を実装済みである。本 doc は
+その自前の意味論を屋外の開けた領域へ流用し、予約済みの Scatter モードとして feature 系に載せる。屋外生成の
+先行事例として Cataclysm-DDA を参照したが、決定性モデルが根本的に違うため技法を翻案して採る。参照の一覧と翻案の
+方針は末尾の「参照と翻案」にまとめ、本文は ruins の要件を起点に述べる。
+
+## 要件
+
+- **決定的な純関数**。チャンク seed `ChunkSeed2D(runSeed, cx, cy)` から一括生成し、再訪で一致し serde 安全であること。
+  グローバル状態を持たない。散布の全確率判定は `hash(seed, x, y, channel) → [0,1)` の純関数で行い、実行時の反復乱数や
+  可変状態を使わない。
+- **doc 70 の密度場を流用**。Room 依存を解いて屋外の開領域へ density 配置を効かせる。車輪の再発明をしない。
+- **既存の疎フィーチャ系と共存**。Scatter を疎な `Placement` へ無理に畳まず、全チャンクを走る別経路として feature 系に
+  足す。v1 は `wasteland` チャンク限定にし、建物・POI 構造物との占有衝突を構造的に避ける。
+- **通行性を壊さない**。prop は既定で `BlockPass` を持つ、`spawn_prop.go`。散布が隊商の経路を壁化しないよう、密度の
+  希釈と経路マスクの二段で連結を保つ。散布後に入口間の flood-fill 到達を回帰テストで固定する。
+- **占有を壊さない**。散布は `dirt` かつ空きのタイルだけに置く。占有は `Filter2[GridElement, BlockPass]` の
+  エンティティ照会で引く、`driver.go:182` に前例。フィーチャ間で共有される占有索引は無い。
+- **チャンク境界をまたがない**。単タイル prop は端に置いてよい。複数タイルの束だけ POI と同じマージンで内側に収める。
+  タイルの継ぎ目は既存の `RecalcChunkSeams` に委ねる。
+- **ゾーン認識**。道・集落・市街地からの距離でカテゴリ重みと密度を変える。近傍地物の位置は既存の道結線と同じく
+  純関数 `WinnerOf` で生成せず算出する。
+- **仮画像を避ける**。実スプライトのある prop を優先する。`fence`・窓・シャッター・和家具は仮画像なので主役にしない。
+
+## 設計
+
+### スコープ —— v1 は wasteland チャンク限定
+
+`chunkTypeAt` は排他分類、urban > dungeon > settlement > poi > wasteland、で、1チャンクは1種別に属す。scatter を全種別へ
+走らせると urban・settlement 上で建物と競合し、フィーチャ間の占有共有が無いぶん複雑になる。v1 は `wasteland` 限定に
+する。道は wasteland チャンクも横切る、`road.go`、のでゾーン差は wasteland 内で表現できる。市街地の空き地や集落の
+外構への散布は、占有共有の仕組みが要るので後続にする。
+
+### Scatter フィーチャ
+
+`scatterFeature` を feature 系へ足す。全チャンクを評価し `wasteland` だけで density 場を走らせる。評価順は最後にし、
+道がタイルを置換した後の実状態を読み、`dirt` かつ `BlockPass` 非占有のタイルだけに置く。
+
+```go
+// scatterFeature は wasteland チャンクの開けた地表へ prop を密に散布する feature。疎な Placement と違い
+// density 場で撒く。他フィーチャの後に評価し、dirt かつ BlockPass 非占有のタイルだけに置く。
+type scatterFeature struct{}
+
+// features は登録済みの地物一覧。scatter は占有と道を読むため最後に評価する。
+func features() []feature {
+	return []feature{
+		settlementFeature{}, urbanFeature{}, dungeonEntranceFeature{}, wildernessPOIFeature{},
+		roadFeature{}, scatterFeature{},
+	}
+}
+
+// salt は iota で一意にする。scatter は必ず末尾へ足す。途中へ挿入すると後続の salt 値がずれ、既存地物の
+// 配置が変わって再訪一致が壊れる。poiSalt+1 のような手計算オフセットも並べ替えで壊れるので使わない。
+const (
+	settlementSalt uint64 = iota + 1
+	urbanSalt
+	dungeonEntranceSalt
+	poiSalt
+	scatterSalt
+)
+```
+
+### 密度場の屋外流用 —— Room 非依存の点セレクタを共有する
+
+doc 70 の `selectTiles(room, p, occupied, seed, count)` が Room から読むのは `Rect` と `Doorways` だけである。屋外は
+戸口を持たない開領域なので、密度場の芯を Room 非依存の純関数として切り出し、interior と overworld の双方から呼ぶ。
+これは doc 79、doc 70 のバックログ、の「地点セレクタ API への統一リファクタ」を屋外流用の要求で前倒しする。
+
+```go
+// ScatterArea は矩形 area の中から density 場と決定的間引きで count 個のタイルを選ぶ純関数。戸口も壁も
+// 前提にしない開領域向けで、interior の PlaceFullArea が持つ格子＋hash ジッタの芯だけを取り出す。
+// 候補の可否は accept 述語に委ね、dirt 判定や占有判定を ScatterArea 側に埋め込まない。
+func ScatterArea(area Rect, accept func(Vec) bool, seed uint64, count int) []Vec
+```
+
+`accept` を述語にするのは、屋内と屋外で「置ける条件」が違うのに density 場の芯は共通だからである。dirt 判定を
+`ScatterArea` に埋めると屋内では無意味な条件を負う。屋内は `func(v) bool { return !occupied[v] }`、屋外は
+`func(v) bool { return isDirt(v) && !blockPassOccupied(v) }` を渡し、芯は候補の意味を知らないまま純関数で保てる。
+
+- interior の `PlaceFullArea` はこの `ScatterArea` を `area = room.Rect` で呼ぶ薄いラッパへ置き換える。屋内挙動は
+  不変で、interior のゴールデンで担保する。
+- 屋内固有の `PlaceWall`・`PlaceRow`・`repairReachability`・戸口起点の flood は屋外では使わない。
+- seed は splitmix64 系の `childSeed` で導く。overworld の `ChunkSeed2D` と同じ定数系なので決定性が地続きになる。
+
+`ScatterArea` は選んだ各タイルへカタログから1個だけ置く。1タイルに複数の prop を重ねないので、大物が積み重なって
+通行を塞ぐことがない。「1タイル1物」は doc 70 の密度場が元から持つ性質で、別機構は要らない。撒く物は zone ごとの
+重み付きカタログから引き、置かない選択は null 重みで表す。
+
+```go
+// scatterEntry は散布物の1候補。実スプライトのある prop を優先する。Big は通行を塞ぐ大物の印で、位相格子と
+// 経路マスクの対象になる。Satellites があれば anchor 相対の小クラスタ、放置車両＋散乱物、として1回で置く。
+type scatterEntry struct {
+	Ref        string
+	Weight     int
+	Big        bool
+	Satellites []relSpot // 既存の relSpot を流用する
+}
+
+// scatterCatalog は zone ごとの散布定義。Density は面積あたり期待個数の係数で、count = round(area*Density)。
+// 個数を反復乱数でなく密度確率で決めるので純関数のまま。
+type scatterCatalog struct {
+	Zone    outdoorZone
+	Density float64
+	Entries []scatterEntry
+}
+```
+
+### 位相格子 —— 大物密度の希釈ダイヤル
+
+doc 70 のパリティ格子、`(x+y)%2==0`、を一般の P 位相へ広げる。候補タイルを `(x + k*y) mod P` の位相へ分け、`Big` の
+大物は1位相にだけ乗せる。実効密度が 1/P に希釈され、位相数 P が通行性のダイヤルになる。草・小物など通行を塞がない
+prop は位相制約を課さない。これは ruins が既に持つパリティ格子の自然な拡張である。
+
+### 経路マスク —— 通行性の構造保証
+
+密度の希釈は確率的で、経路の連結までは保証しない。隊商の動線を確実に空けるため、seed から決定的に引ける経路の
+タイル集合をマスクとして散布へ渡し、**経路セルでは `Big` の大物を置かない**。確率的希釈と合わせ二段で通行性を
+担保する。
+
+- 舗装された道は `road.go` が dirt を floor へ置換済みで、散布は dirt にしか置かないので**そもそも道上に大物は
+  乗らない**。経路マスクが守るのは、舗装路でない wasteland 内の横断レーンである。
+- 経路は `WinnerOf` で算出する近傍集落間の直線に**幅数タイルのバッファ**を持たせて近似する。道が折れても、
+  チャンク内で数タイルのずれは許容し、バッファ幅で吸収する。実際の道タイルを読んでマスクを作る案は、道生成順への
+  依存とコストが増えるので採らない、`road.go` の道自体は floor で既に除外されるため精度が要らない。
+- 最終的な連結は散布後の flood-fill 到達を回帰テストで固定し、近似の破れを検知する安全網にする。
+
+### ゾーン重み —— 人の手の残り具合で撒き分ける
+
+wasteland チャンクの「道・集落・市街地への近接度」を2ゾーンに分け、カタログと密度を切り替える。中間帯は必要が
+出てから足す、YAGNI。
+
+```go
+// outdoorZone は wasteland チャンクの人の手の残り具合。近傍の道・集落・市街地までの距離で決まる。
+type outdoorZone int
+
+const (
+	zoneRoadside outdoorZone = iota // 道・集落・市街に近い。放置車両・ドラム缶・瓦礫・自販機など人工物が主
+	zoneWild                        // 奥地。枯れ木・木立・岩・石柱など自然物が主
+)
+```
+
+- `zoneRoadside` は人工物カタログを主に密度高め、`zoneWild` は自然物カタログを主に密度低め。
+- 個数は密度確率で決め、`count = round(area * Density)` を `ScatterArea` へ渡す。`area` は候補タイル数、すなわち
+  チャンクの床タイル数で、interior の `selectTiles` が `Rect.W*Rect.H` を candidates にするのと同じ単位。`Density` は
+  1タイルあたりの期待個数の係数になる。
+
+### prop カタログ
+
+実スプライトのある prop を主役にする。仮画像は避ける。まず単品散布から、束は `Satellites` で足す。
+
+- **自然物**: `tree_a`・`tree_b`・`big_tree`・`plant`・`moving_stone`・`stone_pillar`。
+- **人工物**: `forklift`・`barrel`・`crate`・`debris`・`rubble`・ドラム缶各種・`generator`・`vending_machine`・
+  `bonfire`・`bench`。バリケード・電柱は実スプライトが起きてから足す。
+- 束の例: 焚き火跡は `bonfire` を anchor に `crate`・`bench` を随伴。放置車両は `forklift` を anchor に
+  `barrel`・`debris` を随伴。
+- 束の境界と失敗の責務は散布側、すなわち `scatterFeature` が持つ。`ScatterArea` は anchor タイルを選ぶだけで、
+  `Satellites` の展開はしない。束を持つ entry では anchor を束の外接ぶん内側マージンに絞り、それでも `dirt` 非占有に
+  収まらない衛星は落とす。anchor だけ置いて衛星を諦める、doc 70 の `Satellites` と同じ「尽きたら諦める」方針にする。
+
+### カタログの合成構造と将来の温度連携
+
+密度場・prop カタログ・ゾーン重みを独立テーブルに分け、チャンク種別ごとに参照で束ねる。現状は wasteland 単一だが、
+将来の拡張点になる。特に「既存タイルを別タイルへ写像する」写像テーブルを足せば、寒波前線 `worldstream/front.go` の
+温度でカタログを差し替え「寒いチャンクは枯れ版カタログ」を純関数で表せる。v1 は単一カタログで、温度連携は将来余地
+としてコメントに残す。
+
+### 決定性と縁の処理
+
+- 散布専用の `scatterSalt` でハッシュ入力を他地物と無相関にする。density 親 seed は
+  `ChunkSeed2D(runSeed^scatterSalt, cx, cy)` から導く。候補は slice に集め安定 sort してから seed で引く。Go の map を
+  抽選に使わない。同 seed 再訪一致をテストで固定する。
+- パッチを作る場合、縁セルを `hash < 0.5` で欠落させ、四角い塊感を消す。v1 は単品散布が主なので任意。
+
+### 参照と翻案 —— Cataclysm-DDA
+
+屋外生成の先行事例として CDDA を参照した。ただし **CDDA の再訪一致は純関数でなくセーブ保存で担保**しており、屋外
+散布はほぼ全て per-tile の `rng()`・`one_in()`・`pick()` の反復である。ruins は決定的純関数が要件なので技法は
+そのまま使えない。翻案の核は1点、**CDDA の per-tile `rng()` を `hash(seed, x, y, channel)` へ一般化して置換する**ことに
+集約される。CDDA 自身がこの hash 方式を使うのは森境界の1関数、`mapgen_functions.cpp:753-775`、だけで、それが移植
+テンプレートになる。個々の技法の扱いは下表のとおり。
+
+| CDDA の技法 | ruins での扱い |
+|---|---|
+| per-tile `rng()`／`one_in()`／`pick()`＋セーブ保存 | 不採用。全確率判定を `hash(seed,x,y,channel)` の純関数へ置換。最深部の分岐 |
+| 野原 `field.json` の位相格子 `123` | 裏付け。ruins 自前のパリティ格子を P 位相へ広げる設計の先例 |
+| 森の component 連鎖、`one_in`→pick、break | 不採用。doc 70 の重み付き密度選択に等価で冗長。null 重みで代替する |
+| 森の小道 `place_forest_trails` の flood-fill＋家具消去 | 翻案。実行時探索を捨て、seed 経路マスクで大物を置かない形に |
+| `repeat:[n,m]` の反復配置 | 翻案。`p = N/area` の全セル `hash` 判定へ |
+| `map_extra` の2層ロール | 不採用。「原野に稀な一場面」は ruins では既存の wilderness POI が担う層 |
+| 地形写像 `ter_furn_transform` | 将来余地。温度からカタログを差し替える写像テーブルに |
+| `regional_map_settings` の名前参照合成 | 翻案。カタログを独立テーブルにし種別で束ねる |
+| 実測重み、35000:6:2 等 | 初期値に借用。doc 70 の実測比率初期値化と同じ扱い |
+
+**ruins 固有で CDDA と違う点**。決定性を hash 純関数へ徹底し、再計算で一致させる、CDDA はセーブ保存。配置の芯は
+doc 70 の密度場、ruins 自前。通行性を位相格子の Big 希釈と seed 経路マスクの二段で構造保証する、CDDA は確率的希釈と
+実行時 flood-fill。スコープを wasteland 限定にし `BlockPass` 照会で占有を避ける。これらは CDDA に無いか別実装で、
+本 doc 独自の設計である。
+
+## 変更箇所
+
+| ファイル | 変更内容 |
+|---|---|
+| `internal/overworld/scatter.go`(新規) | `scatterFeature`・`outdoorZone` 判定・`scatterCatalog`/`scatterEntry`・位相格子・経路マスク |
+| `internal/overworld/feature.go` | `features()` へ `scatterFeature` を追加、`scatterSalt` を iota ブロックへ追加 |
+| `internal/mapplanner/interior/placement.go` | 密度場の芯を Room 非依存の `ScatterArea` へ切り出し、`PlaceFullArea` をその薄いラッパへ。屋内挙動は interior ゴールデンで不変を担保 |
+| `assets/metadata/entities/raw/raw.toml` | 屋外 prop の不足分があれば追加。多くは既存 prop を流用 |
+| `internal/overworld/scatter_test.go`(新規) | 決定性・境界非越え・ゾーン重み・占有回避・非 dirt 回避・経路連結の回帰テスト |
+| `internal/states/{mapgen_visualizer,golden_test}.go` | 散布を含む wasteland の VRT 目視と overworld 背景ゴールデン |
+| `docs/design/20260731_79.md` | 「地点セレクタ API 統一リファクタ」を本 doc の `ScatterArea` 切り出しで一部進めたと追記で接続 |
+
+## 採用しなかった方法
+
+- **CDDA の per-tile `rng()` 散布をそのまま写す** —— CDDA は結果をセーブに保存して再訪一致を担保するので純関数でない。
+  ruins は再計算で一致が要件。すべての確率判定を `hash(seed, x, y, channel)` へ置換して翻案する。
+- **CDDA の component 連鎖を独立機構として持つ** —— `one_in(chance)` の sequence で1タイル1物を保証する仕組みは、
+  doc 70 の密度場が「選んだタイルへ重み付きで1個」で既に満たす。null 重みで置かない選択も表せるので、別機構は冗長。
+  自前の密度場に畳む。
+- **バイオーム/雪タイルの導入** —— 素地の `dirt` を雪・草へ分岐する案。寒さは温度場オーバーレイで表現済みで、地表
+  タイルを増やすとオートタイル・描画・serde・縫合へ波及する。まず prop 散布と地形写像で質感を出し、タイル拡張は
+  効果を見てから別 doc にする。
+- **森の小道の flood-fill をそのまま移植** —— 反復的なグローバル探索で純関数と相性が悪い。seed から決定的に引ける
+  経路マスクへ翻案し、経路セルで大物を置かない形にする。
+- **`RuinsDebris` の距離ベース確率散布を流用** —— 廃墟プランナー専用でタイル置換のみ。エンティティ化・チャンク境界・
+  決定的 seed が未対応。密度場のほうが doc 70 と一貫し、占有回避・束・ゾーン重みを表せる。
+- **疎フィーチャ `Placement` を密散布へ拡張して1経路に統合** —— 「1リージョン高々1つ」を O(1) で保証する疎配置と、
+  全域を走る密散布は評価特性が違う。無理に1つの型へ畳むと両方が複雑化する。Scatter は別経路にする。
+- **v1 から全チャンク種別へ散布する** —— urban・settlement 上では建物との占有共有が要り複雑。v1 は wasteland 限定にし、
+  市街地の空き地への散布は占有共有の仕組みが整ってから。
+- **稀な一場面を散布層で表現する** —— 「原野に稀に出る一場面」は、ruins では既存の wilderness POI フィーチャが担う層
+  である。ambient な散布と稀イベントは層を分け、POI 側を伸ばす。
+
+## コメント
+
+- 本 doc は `20260725_70`、施設内装、と対をなす屋外の器であり、doc 70 の density placement の初の外部流用でもある。
+  屋内で作った純関数の配置意味論を Room 非依存へ薄く切り出して屋外へ効かせる。配置の芯は ruins 自前で、屋外生成の
+  先行事例 CDDA からは技法を翻案して補った。翻案の一覧は「参照と翻案」を見る。
+- 寒さは温度場、屋外の物は prop、と役割分担を保つ。将来、地形写像テーブルで温度からカタログを差し替え「寒い
+  チャンクは枯れ版」を純関数で表せる余地を残す。地表タイルの拡張には当面踏み込まない。
+- 仮画像 prop は避け実スプライトを優先する。`fence`・電柱・バリケードの実画像が起きたら人工物カタログを広げる。
+
+## 進捗
+
+- [ ] 密度場の芯を Room 非依存の `ScatterArea` へ切り出し、interior の `PlaceFullArea` を薄いラッパへ置き換える。屋内挙動の不変を interior ゴールデンで担保する
+- [ ] `scatterFeature` と `scatterSalt` を feature 系へ足し、`features()` の最後に評価する。v1 は `wasteland` 限定
+- [ ] `scatterCatalog`/`scatterEntry` の屋外カタログを実装する。実スプライトのある自然物・人工物を重み付きで、置かない選択は null 重みで表す。個数は `count = round(area * Density)` で密度確率から導く
+- [ ] 位相格子を実装し、`Big` の大物を1位相へ寄せて実効密度を 1/P に希釈する。doc 70 のパリティ格子の一般化
+- [ ] 経路マスクを実装し、`WinnerOf` で算出する経路セルで `Big` の大物を置かない。通行性の構造保証
+- [ ] `outdoorZone` を2ゾーンで判定する。`WinnerOf` で近傍の道・集落・市街地を算出し距離でゾーンを切る
+- [ ] 束の散布を `Satellites` で実装する。焚き火跡・放置車両の小クラスタ
+- [ ] 決定性・境界非越え・ゾーン重み・占有回避・非 dirt 回避・経路連結の回帰テストを足す
+- [ ] VRT か実ゲームで wasteland の道沿い・奥地の散布を目視し、密度とカテゴリ比を調整する
+- [ ] doc 79 の「地点セレクタ API 統一リファクタ」へ本 doc の `ScatterArea` 切り出しを追記で接続する
+- [~] 温度連携の地形写像カタログ差し替えは将来余地として見送る


### PR DESCRIPTION
## 概要

オーバーワールドの屋外、特に `wasteland` チャンクに何も配置されず開けた地表が単調な問題に対し、自然物とポスアポ人工物を撒く器を設計した。`20260725_70`、施設内装、と対をなす屋外の器で、doc 70 の密度場配置の初の外部流用でもある。

採番は当初 doc 81 だったが、main へ先に入った #570「OSS 調査」と衝突したため doc 82 に採り直した。

## 設計の骨子

- **doc 70 の密度場を Room 非依存の `ScatterArea` へ切り出して屋外へ流用**。戸口・壁前提の屋内固有ロジックは引き込まない。doc 79 の「地点セレクタ API 統一リファクタ」を前倒しする
- **通行性を二段で構造保証**。位相格子で `Big` 大物の実効密度を 1/P に希釈、seed 経路マスクで隊商動線の大物を除外。prop は既定で `BlockPass` を持つため必須
- **v1 は wasteland 限定**。排他的なチャンク種別と建物占有の衝突を構造的に避ける
- **ゾーン重み**。道・集落からの近接度で人工物と自然物を撒き分ける
- 決定性は全確率判定を `hash(seed, x, y, channel)` の純関数で行い、`ChunkSeed2D` と地続き

## Cataclysm-DDA の参照と翻案

屋外生成の先行事例として CDDA を参照した。ただし **CDDA の再訪一致はセーブ保存＋グローバル `rng()` で、ruins の決定的純関数と根本的に違う**。技法はそのまま使えないため翻案し、doc 末尾の「参照と翻案」に借用・翻案・不採用・ruins 固有を一覧化した。核は「per-tile `rng()` を `hash(seed,x,y,channel)` へ一般化して置換する」1点。CDDA の component 連鎖は doc 70 密度場と冗長なため不採用にした。

## 検証

- `make generate` 成功、`OK: 78 件のドキュメントを検証`
- 実装はまだ。進捗に着手タスク10件＋見送り1件を列挙

🤖 Generated with [Claude Code](https://claude.com/claude-code)