### PR TITLE
test(loader): カバレッジ増強

### DIFF
--- a/internal/loader/loader_test.go
+++ b/internal/loader/loader_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/kijimaD/ruins/internal/oapi"
 	"github.com/kijimaD/ruins/internal/raw"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -82,6 +83,52 @@ func TestLoadSpriteSheets(t *testing.T) {
 		// 合計518個のスプライトがあることを確認。基本65 と床材ダミー5 に、DawnLike フロアオートタイル28素材×16=448 を加えた数
 		assert.Len(t, tileSheet.Sprites, 518, "518個のタイルスプライトが存在すること")
 	})
+}
+
+func TestLoadUIResources_正常にUIリソースを構築できる(t *testing.T) {
+	t.Parallel()
+
+	fonts, err := LoadFonts()
+	require.NoError(t, err)
+
+	ui, err := LoadUIResources(fonts)
+
+	require.NoError(t, err)
+	assert.NotNil(t, ui.Fonts)
+	assert.NotNil(t, ui.Background)
+	assert.NotNil(t, ui.Button)
+	assert.NotNil(t, ui.Label)
+	assert.NotNil(t, ui.Checkbox)
+	assert.NotNil(t, ui.ComboButton)
+	assert.NotNil(t, ui.List)
+}
+
+func TestBuildFaces_フォントマップからFaceマップを構築できる(t *testing.T) {
+	t.Parallel()
+
+	fonts, err := LoadFonts()
+	require.NoError(t, err)
+
+	faces := BuildFaces(fonts)
+
+	require.Len(t, faces, 1)
+	require.Contains(t, faces, "dougenzaka")
+	assert.NotNil(t, faces["dougenzaka"])
+}
+
+func TestLoadSpriteSheets_存在しないパスを指定するとエラー(t *testing.T) {
+	t.Parallel()
+
+	raws := oapi.Raws{
+		SpriteSheets: &[]oapi.SpriteSheet{
+			{Name: "nonexistent", Path: "file/textures/dist/nonexistent.json"},
+		},
+	}
+
+	sheets, err := LoadSpriteSheets(raws)
+
+	require.ErrorContains(t, err, "スプライトシート 'nonexistent' の読み込みに失敗")
+	assert.Nil(t, sheets)
 }
 
 func TestLoadRaws(t *testing.T) {

--- a/internal/loader/loader_test.go
+++ b/internal/loader/loader_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/hajimehoshi/ebiten/v2/text/v2"
 	"github.com/kijimaD/ruins/internal/oapi"
 	"github.com/kijimaD/ruins/internal/raw"
 	"github.com/stretchr/testify/assert"
@@ -83,6 +84,21 @@ func TestLoadSpriteSheets(t *testing.T) {
 		// 合計518個のスプライトがあることを確認。基本65 と床材ダミー5 に、DawnLike フロアオートタイル28素材×16=448 を加えた数
 		assert.Len(t, tileSheet.Sprites, 518, "518個のタイルスプライトが存在すること")
 	})
+
+	t.Run("存在しないパスを指定するとエラー", func(t *testing.T) {
+		t.Parallel()
+
+		raws := oapi.Raws{
+			SpriteSheets: &[]oapi.SpriteSheet{
+				{Name: "nonexistent", Path: "file/textures/dist/nonexistent.json"},
+			},
+		}
+
+		sheets, err := LoadSpriteSheets(raws)
+
+		require.ErrorContains(t, err, "スプライトシート 'nonexistent' の読み込みに失敗")
+		assert.Nil(t, sheets)
+	})
 }
 
 func TestLoadUIResources_正常にUIリソースを構築できる(t *testing.T) {
@@ -90,6 +106,8 @@ func TestLoadUIResources_正常にUIリソースを構築できる(t *testing.T)
 
 	fonts, err := LoadFonts()
 	require.NoError(t, err)
+	require.Contains(t, fonts, "dougenzaka")
+	require.Contains(t, fonts, "nerd")
 
 	ui, err := LoadUIResources(fonts)
 
@@ -113,22 +131,10 @@ func TestBuildFaces_フォントマップからFaceマップを構築できる(t
 
 	require.Len(t, faces, 1)
 	require.Contains(t, faces, "dougenzaka")
-	assert.NotNil(t, faces["dougenzaka"])
-}
-
-func TestLoadSpriteSheets_存在しないパスを指定するとエラー(t *testing.T) {
-	t.Parallel()
-
-	raws := oapi.Raws{
-		SpriteSheets: &[]oapi.SpriteSheet{
-			{Name: "nonexistent", Path: "file/textures/dist/nonexistent.json"},
-		},
-	}
-
-	sheets, err := LoadSpriteSheets(raws)
-
-	require.ErrorContains(t, err, "スプライトシート 'nonexistent' の読み込みに失敗")
-	assert.Nil(t, sheets)
+	face, ok := faces["dougenzaka"].(*text.GoTextFace)
+	require.True(t, ok, "dougenzakaがtext.GoTextFaceであること")
+	assert.Equal(t, fonts["dougenzaka"].FaceSource, face.Source)
+	assert.Equal(t, float64(16), face.Size)
 }
 
 func TestLoadRaws(t *testing.T) {


### PR DESCRIPTION
## 概要

`internal/loader` パッケージのテストカバレッジを増強する。本体コードの変更はなし。

## カバレッジ

- 変更前: 76.5%
- 変更後: 84.3%

## 追加したテスト

- `LoadUIResources`: フォントマップから UI リソースを構築できることを検証する。変更前は 0% だった
- `BuildFaces`: フォントマップから Face マップを構築できることを検証する。変更前は 0% だった
- `LoadSpriteSheets`: 存在しないパスを指定した際にエラーになる異常系を追加する

## 検証

- `make test`
- `make lint` の golangci-lint 部分は通過。`go tool govulncheck` は実行環境のネットワーク制限で vuln.go.dev に到達できず未検証。CI 環境では別途確認されたい

---

Co-Authored-By: Claude <noreply@anthropic.com>


---
_Generated by [Claude Code](https://claude.ai/code/session_013eTCWeqSZTHHMk5WKWyy2u)_