### PR TITLE
refactor(activity): 継続処理を registry シングルトンに一本化し Reload の並行装填バグを直す

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,15 +59,13 @@ $ make help
 
 | status | 件数 |
 |---|---|
-| accepted | 1 |
 | draft | 3 |
-| done | 76 |
+| done | 77 |
 
 ### 未完了
 
 | No. | status | ドキュメント | 進捗 | tags |
 |---|---|---|---|---|
-| [84](docs/design/20260802_84.md) | accepted | 継続アクションの進捗を残りターンからAP累積へ統一する | 0/11 | refactor, ecs, gamedesign |
 | [67](docs/design/20260724_67.md) | draft | 難所調査から抽出した自走可能な改善のバックログ | 0/11（見送り3） | refactor, ci, ecs, combat, meta |
 | [79](docs/design/20260731_79.md) | draft | 施設内装の生成 —— doc 70 の未着手バックログ | 1/33 | worldgen |
 | [81](docs/design/20260801_81.md) | draft | OSS 調査 2026-08 | 0/5 | meta, worldgen, combat, ui |

--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ $ make help
 
 | status | 件数 |
 |---|---|
+| accepted | 1 |
 | draft | 3 |
 | done | 76 |
 
@@ -66,6 +67,7 @@ $ make help
 
 | No. | status | ドキュメント | 進捗 | tags |
 |---|---|---|---|---|
+| [84](docs/design/20260802_84.md) | accepted | 継続アクションの進捗を残りターンからAP累積へ統一する | 0/11 | refactor, ecs, gamedesign |
 | [67](docs/design/20260724_67.md) | draft | 難所調査から抽出した自走可能な改善のバックログ | 0/11（見送り3） | refactor, ci, ecs, combat, meta |
 | [79](docs/design/20260731_79.md) | draft | 施設内装の生成 —— doc 70 の未着手バックログ | 1/33 | worldgen |
 | [81](docs/design/20260801_81.md) | draft | OSS 調査 2026-08 | 0/5 | meta, worldgen, combat, ui |

--- a/docs/design/20260802_84.md
+++ b/docs/design/20260802_84.md
@@ -1,5 +1,5 @@
 ---
-status: accepted # draft|accepted|in-progress|done|superseded|dropped
+status: done # draft|accepted|in-progress|done|superseded|dropped
 tags: [refactor, ecs, gamedesign] # 領域ラベル
 auto: needs-decision # mechanical=無人着手可 / needs-decision=人の判断必須
 ---
@@ -61,103 +61,86 @@ type Activity struct {
 }
 ```
 
-### 注入量の定義
+### 注入量と完了は各 DoTurn が持つ
 
-毎ターンの注入量は Behavior ごとに変わるので、`Behavior` インターフェースへメソッドを足す。毎ターン再計算するため変動へ追従する。
+当初は注入量を `Behavior` インターフェースのメソッドにしてフレームワークで一律累積する案だったが、進捗の置き場が Behavior ごとに違うため見送った。read は中断再開のため本エンティティの `Effort` に、reload は自前で進捗を持ち、push/pull はパーティAPを注ぐ。これらを1つのメソッドへ押し込めると無理が出る。
 
-```go
-type Behavior interface {
-	// ...既存メソッド
-	// EffortPerTurn は継続アクションで今ターン注ぐ量を返す。毎ターン再計算し
-	// APや能力の変動へ追従する。即時アクションは 0 を返す。
-	EffortPerTurn(actor ecs.Entity, world w.World) int
-}
-```
-
-17 の Behavior 全てに実装を強制するとボイラープレートになるため、埋め込み用の既定を2つ用意して配る。
-
-- `immediateEffort`: `EffortPerTurn` が 0 を返す。即時アクション9種が埋め込む。
-- `apEffort`: `EffortPerTurn` がアクターの毎ターンAPを返す。rest・read・wait・disassemble が埋め込む。
-- reload は能力由来の `calcEffortPerTurn`、push/pull はパーティAPを独自実装する。
-
-### 累積と完了の一本化
-
-進捗の累積と完了判定はフレームワーク側 `stepActivity` へ集約する。DoTurn は毎ターンの副作用、たとえばHP回復や中断判定に専念する。
+そこで各継続 Behavior の `DoTurn` が「今ターンの注入量を `comp.Accumulated` へ足し、`comp.Accumulated >= comp.Required` なら `Complete` を呼ぶ」を自分で行う。即時アクションは従来どおり `DoTurn` の末尾で `Complete` を呼ぶ。フレームワーク `stepActivity` は `DoTurn` を呼んで完了なら `Finish` するだけの委譲に徹する。
 
 ```go
-// stepActivity 内の擬似コード
-comp.Accumulated += behavior.EffortPerTurn(entity, world) // 継続のみ意味を持つ
-if err := behavior.DoTurn(comp, entity, world); err != nil {
-	CancelActivity(...) // 従来どおり
-	return
-}
-if comp.Accumulated >= comp.Required { // Required==0 の即時は初回で必ず満たす
+// 継続 Behavior の DoTurn の骨子
+comp.Accumulated += 今ターンの注入量 // rest/disassemble=perTurnAP, reload=工数, push/pull=押し力, wait=1
+// 毎ターンの副作用。HP回復や中断判定など
+if comp.Accumulated >= comp.Required {
 	Complete(comp)
 }
-if IsCompleted(comp) {
-	behavior.Finish(...) // 従来どおり
-}
 ```
 
-- `IsCompleted(comp)` は `State == ActivityStateCompleted` のみで判定する。`TurnsLeft <= 0` 節を廃止する。早期完了、たとえば rest でHP満タンは従来どおり Behavior が `Complete(comp)` を呼ぶ。
+注入量は Behavior ごとに毎ターン再計算するため、APや能力の変動へ追従する。共通の毎ターンAPは `perTurnAP(actor, world)` ヘルパで取り、取得できない場合も進行が止まらないよう最低 1 を返す。
+
+- `IsCompleted(comp)` は `State == ActivityStateCompleted` のみで判定する。`TurnsLeft <= 0` 節を廃止する。早期完了、たとえば rest でHP満タンは Behavior が `Complete(comp)` を呼ぶ。
 - `GetProgressPercent(comp)` は `Accumulated / Required` で計算する。`Required == 0` は 100% を返す。
 - 即時判定は `Execute` の `TurnsTotal == 1` を `Required == 0` へ置き換える。即時アクションは全て `Required == 0` なので綺麗に対応する。
 
-### Behaviorごとの Required 設定
+### Behaviorごとの Required と注入量
 
 `Start` または `BuildActivity` で `comp.Required` を確定する。凍結するのは不変の「必要総量」だけで、これは元々途中で変わらない値である。
 
-| Behavior | Required の由来 | EffortPerTurn |
+| Behavior | Required の由来 | 毎ターンの注入量 |
 |---|---|---|
-| rest | `TotalRequiredAP`（1000） | 毎ターンAP |
-| wait | `TotalRequiredAP`（500） | 毎ターンAP |
-| read | 本由来の総量。現行の `CalculateRequiredTurns` 相当を総量へ | 毎ターンAP |
-| disassemble | レシピ由来の総量 | 毎ターンAP |
+| rest | `TotalRequiredAP`（1000） | `perTurnAP`。HP満タンで早期完了 |
+| wait | 待機回数（`Duration`、既定1） | 1。待機は作業でなく時間経過 |
+| read | 本の総工数 `book.Effort.Max` | `calcEffortPerTurn`。進捗は本の `Effort` に保持し再開可能 |
+| disassemble | レシピ由来の必要AP | `perTurnAP` |
 | reload | `fire.ReloadEffort` | `calcEffortPerTurn`（Base+DEX+skill） |
-| push, pull | 重量由来の総量。現行 `cubePushTurns` を総量へ | パーティAP |
+| push, pull | 重量由来の総コスト | `query.PartyPushPower` |
 
-`CalculateRequiredTurns`（AP量からターン数を割る関数）は不要になるため廃止する。ターン数への変換をやめ、総量と毎ターン注入量の比較へ寄せる。
+`CalculateRequiredTurns`（AP量からターン数を割る関数）は不要になるため廃止する。ターン数への変換をやめ、総量と毎ターン注入量の比較へ寄せる。read の進捗は本エンティティの `Effort` に持たせ、`comp.Accumulated` へも写して表示を揃える。
 
 ## 変更箇所
 
 | ファイル | 変更内容 |
 |---|---|
 | `internal/components/activity.go` | `TurnsTotal`/`TurnsLeft` を削除し `Required int` を追加する。`Accumulated` は維持 |
-| `internal/activity/activity.go` | `Behavior` に `EffortPerTurn` を追加。`immediateEffort`/`apEffort` の埋め込み既定を用意。`NewActivity` の引数を duration から required へ変更。`IsCompleted` を State のみに。`GetProgressPercent` を `Accumulated/Required` に。`CalculateRequiredTurns` を廃止 |
-| `internal/activity/activity_manager.go` | `stepActivity` で `EffortPerTurn` 累積と `Accumulated>=Required` 完了判定を行う。`Execute` の即時判定を `Required==0` へ。`consumePassCost` は現行維持 |
-| `internal/activity/rest.go` | `Start` で `Required=1000`。`DoTurn` から `TurnsLeft` 廃止。`apEffort` 埋め込み。5ターン毎ログは累積ベースへ |
-| `internal/activity/read.go` | 同様。Required を本由来総量へ。`apEffort` 埋め込み |
-| `internal/activity/wait.go` | 同様。Required=500。`apEffort` 埋め込み。5ターン毎ログは累積ベースへ |
-| `internal/activity/disassemble.go` | 同様。Required をレシピ由来総量へ。`apEffort` 埋め込み |
-| `internal/activity/reload.go` | `Start` で `Required=fire.ReloadEffort`。`DoTurn` の `TurnsLeft` 廃止。`calcEffortPerTurn` を `EffortPerTurn` として公開 |
-| `internal/activity/push.go` | `buildCubeMove` で Required を重量由来総量へ。`DoTurn` の `TurnsLeft` 廃止。push/pull で `EffortPerTurn` をパーティAPに |
-| 即時 Behavior 9種 | `move`/`attack`/`pickup`/`drop`/`talk`/`use_item`/`transfer`/`door`/`shoot` に `immediateEffort` を埋め込む |
+| `internal/activity/activity.go` | `NewActivity` の引数を duration から required へ変更。`ErrInvalidDuration` を `ErrInvalidRequired` へ。`IsCompleted` を State のみに。`GetProgressPercent` を `Accumulated/Required` に。`CalculateRequiredTurns` を廃止し `perTurnAP` ヘルパを追加 |
+| `internal/activity/activity_manager.go` | `stepActivity` は委譲に徹する。`Execute` の即時判定を `Required==0` へ。`consumePassCost` は現行維持 |
+| `internal/activity/rest.go` | `BuildActivity` で `Required=1000`。`DoTurn` で `perTurnAP` を累積し `Accumulated>=Required` で完了。`Duration` フィールドと5ターン毎ログを廃止 |
+| `internal/activity/read.go` | `Required` を `book.Effort.Max` へ。進捗は本の `Effort` に保持し `Accumulated` へ写す。完了は `book.IsCompleted()`。`Duration` フィールドを廃止 |
+| `internal/activity/wait.go` | `Required` を待機回数へ。`DoTurn` で 1 ずつ累積。環境観察の経過ターンログを廃止 |
+| `internal/activity/disassemble.go` | `Required` をレシピ由来の必要APへ。`DoTurn` で `perTurnAP` を累積 |
+| `internal/activity/reload.go` | `Start` で `Required=fire.ReloadEffort`。`DoTurn` で `calcEffortPerTurn` を累積し `Accumulated>=Required` で完了 |
+| `internal/activity/push.go` | `cubePushTurns` を総コスト返しの `cubePushCost` へ。`DoTurn` で `query.PartyPushPower` を累積 |
+| 即時 Behavior 9種 | `move`/`attack`/`pickup`/`drop`/`talk`/`use_item`/`transfer`/`door`/`shoot` の `NewActivity` を `0` へ。DoTurn 末尾の `Complete` は現行のまま |
+| `internal/states/inventory_menu.go` | 読書起動から `ReadBehavior.Duration` の指定を除去 |
 | `internal/activity/doc.go` | 継続アクションのモデル説明を残りターンからAP累積へ更新 |
 | テスト | `TurnsTotal`/`TurnsLeft` を参照するテストを Required/Accumulated ベースへ。AP変動で所要が伸縮する回帰テストを追加 |
 
 ## 採用しなかった方法
 
-- **注入量をオプショナルインターフェースの型アサーションで取る**。`ContinuousBehavior` を定義し `behavior.(ContinuousBehavior)` で判定する案。実装を強制せず即時アクションのボイラープレートを避けられるが、型アサーションは `ruins-review` で慎重に扱う対象であり、埋め込み既定のほうが静的で安全。よって埋め込みを採る。
+- **注入量を `Behavior` インターフェースのメソッドにしてフレームワークで一律累積する**。`EffortPerTurn` を足し `stepActivity` で `comp.Accumulated += EffortPerTurn` する案。DRYだが、read は本エンティティの `Effort` に、reload は自前で進捗を持つため、1つのメソッドへ押し込めると無理が出る。各 DoTurn が自分の注入量と完了を持つ形を採る。
 - **注入量を `Info` の静的フィールドにする**。`Info.EffortPerTurn int` を持たせる案。注入量はアクター依存で毎ターン変わるため静的値では変動へ追従できない。棄却。
 - **push/pull を現行の重量→ターン凍結のまま残す**。TurnsLeft を push 専用に残す折衷案。モデルが3つのままになり分裂が解消しない。今回の統一に含める。
 - **残りターンと累積を両方保持する**。互換のため TurnsLeft も残す案。二重管理でずれの温床になり、統一の意義が薄れる。純減させる。
 
 ## コメント
 
-- `EffortPerTurn` と DoTurn 副作用の責務分離は、`ruins-review` の観点で見ると Reload の ammo 装填を DoTurn に残すか Finish へ寄せるかで揺れる。実装時に確定する。累積が Required を跨いだターンに装填する現行挙動は Finish へ寄せると素直になる。
-- 毎ターンのAP消費は `turn_system` が固定 `StandardActionCost` を引く現行のまま。`EffortPerTurn` は進捗の通貨で、APプールの消費とは直交する。両者を一致させるかは別途の判断とし、本 doc の範囲外とする。
+- reload の ammo 装填は累積が Required に達したターンの `DoTurn` で行う現行挙動を維持した。DoTurn が完了判定と副作用を一体で持つため素直に収まる。
+- 毎ターンのAP消費は `turn_system` が固定 `StandardActionCost` を引く現行のまま。注入量は進捗の通貨で、APプールの消費とは直交する。両者を一致させるかは別途の判断とし、本 doc の範囲外とする。
+- 経過ターン依存の周期ログ、たとえば rest の5ターン毎回復ログや wait の環境観察は、経過ターンが可変注入量から復元できないため廃止した。
+- read の進捗は中断再開のため本エンティティの `Effort` に持たせる。`comp.Accumulated` へは表示用に写す。
 - `gc.Activity` はセーブの skip 対象のため、struct 変更に serde 互換の懸念はない。
 
 ## 進捗
 
-- [ ] `gc.Activity` を Required/Accumulated へ変更し `make generate`
-- [ ] `Behavior` に `EffortPerTurn` 追加、`immediateEffort`/`apEffort` 埋め込み既定を用意
-- [ ] `stepActivity` に累積と完了判定を集約、`Execute` の即時判定を `Required==0` へ
-- [ ] `IsCompleted`/`GetProgressPercent` を State/累積ベースへ、`CalculateRequiredTurns` 廃止
-- [ ] rest/read/wait/disassemble を Required/apEffort へ移行
-- [ ] reload を Required/EffortPerTurn へ移行
-- [ ] push/pull を重量由来 Required とパーティAP注入へ移行
-- [ ] 即時 Behavior 9種へ `immediateEffort` 埋め込み
-- [ ] `doc.go` のモデル説明更新
-- [ ] AP変動で所要が伸縮する回帰テスト追加、既存テストを移行
-- [ ] `make check` 全緑
+- [x] `gc.Activity` を Required/Accumulated へ変更
+- [x] `NewActivity` の引数を required へ、`ErrInvalidDuration` を `ErrInvalidRequired` へ
+- [x] `stepActivity` は委譲に徹し、各 DoTurn が累積と完了を持つ。`Execute` の即時判定を `Required==0` へ
+- [x] `IsCompleted`/`GetProgressPercent` を State/累積ベースへ、`CalculateRequiredTurns` 廃止、`perTurnAP` ヘルパ追加
+- [x] rest/wait/disassemble を Required/AP累積へ移行、経過ターンログ廃止
+- [x] read を本の Effort ベースへ移行、`ReadBehavior.Duration` 廃止と呼び出し元更新
+- [x] reload を Required 完了判定へ移行
+- [x] push/pull を重量由来 Required とパーティAP注入へ移行
+- [x] 即時 Behavior 9種を `NewActivity(_, 0)` へ
+- [x] `doc.go` のモデル説明更新
+- [x] 既存テストを移行、AP変動で所要が伸縮する回帰テスト追加
+- [x] `make check` 全緑

--- a/docs/design/20260802_84.md
+++ b/docs/design/20260802_84.md
@@ -52,7 +52,7 @@ type Activity struct {
 type Activity struct {
 	BehaviorName BehaviorName
 	State        ActivityState
-	Required     int // 完了に必要な総量。AP や工数の単位。即時アクションは 0
+	Required     int // 完了に必要な総量。AP や工数の単位。初回ステップで完了すれば即時アクションになる
 	Accumulated  int // 注ぎ込んだ総量。Required に達したら完了
 	Target       *ecs.Entity
 	Recipient    *ecs.Entity
@@ -80,7 +80,8 @@ if comp.Accumulated >= comp.Required {
 
 - `IsCompleted(comp)` は `State == ActivityStateCompleted` のみで判定する。`TurnsLeft <= 0` 節を廃止する。早期完了、たとえば rest でHP満タンは Behavior が `Complete(comp)` を呼ぶ。
 - `GetProgressPercent(comp)` は `Accumulated / Required` で計算する。`Required == 0` は 100% を返す。
-- 即時判定は `Execute` の `TurnsTotal == 1` を `Required == 0` へ置き換える。即時アクションは全て `Required == 0` なので綺麗に対応する。
+- 即時アクションは宣言せず創発させる。`Execute` は種別を問わず常に1ステップ進め、初回で完了すれば即時アクションとして同期結果を返し `consumePassCost` でコストを消費する。続くなら継続アクションとして `StandardActionCost` を消費し、残りは `ProcessContinuousActivities` が将来ティックで進める。`TurnsTotal == 1` や `Required == 0` のような即時判定は持たない。
+- この結果、AP がちょうど足りる軽いキューブの push/pull は初回ステップで完了し、その場で動く。重さで即時/継続が分かれる不整合が消える。
 
 ### Behaviorごとの Required と注入量
 
@@ -103,7 +104,7 @@ if comp.Accumulated >= comp.Required {
 |---|---|
 | `internal/components/activity.go` | `TurnsTotal`/`TurnsLeft` を削除し `Required int` を追加する。`Accumulated` は維持 |
 | `internal/activity/activity.go` | `NewActivity` の引数を duration から required へ変更。`ErrInvalidDuration` を `ErrInvalidRequired` へ。`IsCompleted` を State のみに。`GetProgressPercent` を `Accumulated/Required` に。`CalculateRequiredTurns` を廃止し `perTurnAP` ヘルパを追加 |
-| `internal/activity/activity_manager.go` | `stepActivity` は委譲に徹する。`Execute` の即時判定を `Required==0` へ。`consumePassCost` は現行維持 |
+| `internal/activity/activity_manager.go` | `stepActivity` は委譲に徹する。`Execute` は常に1ステップ進め、初回で完了すれば同期結果と `consumePassCost`、続くなら `StandardActionCost` を消費して継続。即時判定は持たない |
 | `internal/activity/rest.go` | `BuildActivity` で `Required=1000`。`DoTurn` で `perTurnAP` を累積し `Accumulated>=Required` で完了。`Duration` フィールドと5ターン毎ログを廃止 |
 | `internal/activity/read.go` | `Required` を `book.Effort.Max` へ。進捗は本の `Effort` に保持し `Accumulated` へ写す。完了は `book.IsCompleted()`。`Duration` フィールドを廃止 |
 | `internal/activity/wait.go` | `Required` を待機回数へ。`DoTurn` で 1 ずつ累積。環境観察の経過ターンログを廃止 |

--- a/docs/design/20260802_84.md
+++ b/docs/design/20260802_84.md
@@ -32,7 +32,7 @@ auto: needs-decision # mechanical=無人着手可 / needs-decision=人の判断�
 
 ### データ構造
 
-`gc.Activity` の残りターン2フィールドを、必要総量1フィールドへ置き換える。累積量 `Accumulated` は維持する。3フィールドが2フィールドへ純減する。
+`gc.Activity` の残りターン2フィールドと累積量を、進捗プール `Progress IntPool` 1本へ置き換える。Max が必要総量、Current が注ぎ込んだ量で、Current>=Max が完了。`TurnsTotal`/`TurnsLeft`/`Accumulated` の3フィールドが1フィールドへ純減する。
 
 ```go
 // 変更前
@@ -52,14 +52,15 @@ type Activity struct {
 type Activity struct {
 	BehaviorName BehaviorName
 	State        ActivityState
-	Required     int // 完了に必要な総量。AP や工数の単位。初回ステップで完了すれば即時アクションになる
-	Accumulated  int // 注ぎ込んだ総量。Required に達したら完了
+	Progress     IntPool // Max=完了に必要な総量、Current=注ぎ込んだ総量。Current>=Max で完了。初回ステップで満ちれば即時アクション
 	Target       *ecs.Entity
 	Recipient    *ecs.Entity
 	Destination  *GridElement
 	CancelReason string
 }
 ```
+
+進捗は `book.Effort`・`Skill.Exp`・`TurnBased.AP` と同じ `IntPool`（Max/Current）で表す。単位は Behavior ごとに AP・工数・回数と異なるため、専用の AP 型は作らず「累積して満ちたら完了」という構造だけを Pool で共有する。3フィールドが1フィールドへ純減する。
 
 ### 注入量と完了は各 DoTurn が持つ
 
@@ -102,7 +103,7 @@ if comp.Accumulated >= comp.Required {
 
 | ファイル | 変更内容 |
 |---|---|
-| `internal/components/activity.go` | `TurnsTotal`/`TurnsLeft` を削除し `Required int` を追加する。`Accumulated` は維持 |
+| `internal/components/activity.go` | `TurnsTotal`/`TurnsLeft`/`Accumulated` を削除し、進捗プール `Progress IntPool` へ統合する |
 | `internal/activity/activity.go` | `NewActivity` の引数を duration から required へ変更。`ErrInvalidDuration` を `ErrInvalidRequired` へ。`IsCompleted` を State のみに。`GetProgressPercent` を `Accumulated/Required` に。`CalculateRequiredTurns` を廃止し `perTurnAP` ヘルパを追加 |
 | `internal/activity/activity_manager.go` | `stepActivity` は委譲に徹する。`Execute` は常に1ステップ進め、初回で完了すれば同期結果と `consumePassCost`、続くなら `StandardActionCost` を消費して継続。即時判定は持たない |
 | `internal/activity/rest.go` | `BuildActivity` で `Required=1000`。`DoTurn` で `perTurnAP` を累積し `Accumulated>=Required` で完了。`Duration` フィールドと5ターン毎ログを廃止 |

--- a/docs/design/20260802_84.md
+++ b/docs/design/20260802_84.md
@@ -1,0 +1,163 @@
+---
+status: accepted # draft|accepted|in-progress|done|superseded|dropped
+tags: [refactor, ecs, gamedesign] # 領域ラベル
+auto: needs-decision # mechanical=無人着手可 / needs-decision=人の判断必須
+---
+
+# 継続アクションの進捗を残りターンからAP累積へ統一する
+
+## 背景
+
+継続アクションの進捗の表し方が3モデルに分裂している。
+
+| モデル | Behavior | 仕組み | 問題 |
+|---|---|---|---|
+| AP→ターン凍結 | rest, read, wait, disassemble | `TurnsTotal = ceil(TotalRequiredAP / characterAP)` を着手時に確定しカウントダウン | characterAP を着手時にスナップショットするため、途中でAPが変動すると所要が実態とずれる |
+| 重量→ターン凍結 | push, pull | `TurnsTotal = cubePushTurns(重量, パーティAP)` を着手時に確定しカウントダウン | 同じく着手時のAPで凍結される |
+| 工数累積 | reload | `Accumulated += effortPerTurn(actor)` を毎ターン再計算し `>= ReloadEffort` で完了 | 変動に追従できており、これが理想形 |
+
+「注ぎ込めるAPは変動する」以上、着手時に所要ターンを凍結する前2モデルは誤りを含む。疲労・負傷・バフでAPが変われば、凍結した残りターンは実態を反映しない。reload の工数累積モデルはすでに毎ターン再計算で変動へ追従している。これへ統一する。
+
+調査の結果、`TurnsTotal`/`TurnsLeft` を読むのは activity パッケージ内だけで、UI・systems・セーブは参照していない。`GetProgressPercent` の外部消費者も無い。影響範囲は activity パッケージと `gc.Activity` の struct に閉じている。
+
+## 要件
+
+- 継続アクションの進捗を「必要総量に対する累積量」で表し、残りターンの凍結を廃する。
+- 毎ターンの注入量は Behavior ごとに定義できる。既定はアクターの毎ターンAP、reload は能力由来の工数、push/pull はパーティAP。
+- 注入量は毎ターン再計算し、APや能力の変動へ追従する。
+- 即時アクションは従来どおり `Execute` の同じ呼び出しで完結する。
+- UI・セーブへの影響を出さない。struct 変更は activity パッケージ内で閉じる。
+
+## 設計
+
+### データ構造
+
+`gc.Activity` の残りターン2フィールドを、必要総量1フィールドへ置き換える。累積量 `Accumulated` は維持する。3フィールドが2フィールドへ純減する。
+
+```go
+// 変更前
+type Activity struct {
+	BehaviorName BehaviorName
+	State        ActivityState
+	TurnsTotal   consts.Turn // 総必要ターン数
+	TurnsLeft    consts.Turn // 残りターン数
+	Accumulated  int         // 継続アクションの累積量。reload のみ使用
+	Target       *ecs.Entity
+	Recipient    *ecs.Entity
+	Destination  *GridElement
+	CancelReason string
+}
+
+// 変更後
+type Activity struct {
+	BehaviorName BehaviorName
+	State        ActivityState
+	Required     int // 完了に必要な総量。AP や工数の単位。即時アクションは 0
+	Accumulated  int // 注ぎ込んだ総量。Required に達したら完了
+	Target       *ecs.Entity
+	Recipient    *ecs.Entity
+	Destination  *GridElement
+	CancelReason string
+}
+```
+
+### 注入量の定義
+
+毎ターンの注入量は Behavior ごとに変わるので、`Behavior` インターフェースへメソッドを足す。毎ターン再計算するため変動へ追従する。
+
+```go
+type Behavior interface {
+	// ...既存メソッド
+	// EffortPerTurn は継続アクションで今ターン注ぐ量を返す。毎ターン再計算し
+	// APや能力の変動へ追従する。即時アクションは 0 を返す。
+	EffortPerTurn(actor ecs.Entity, world w.World) int
+}
+```
+
+17 の Behavior 全てに実装を強制するとボイラープレートになるため、埋め込み用の既定を2つ用意して配る。
+
+- `immediateEffort`: `EffortPerTurn` が 0 を返す。即時アクション9種が埋め込む。
+- `apEffort`: `EffortPerTurn` がアクターの毎ターンAPを返す。rest・read・wait・disassemble が埋め込む。
+- reload は能力由来の `calcEffortPerTurn`、push/pull はパーティAPを独自実装する。
+
+### 累積と完了の一本化
+
+進捗の累積と完了判定はフレームワーク側 `stepActivity` へ集約する。DoTurn は毎ターンの副作用、たとえばHP回復や中断判定に専念する。
+
+```go
+// stepActivity 内の擬似コード
+comp.Accumulated += behavior.EffortPerTurn(entity, world) // 継続のみ意味を持つ
+if err := behavior.DoTurn(comp, entity, world); err != nil {
+	CancelActivity(...) // 従来どおり
+	return
+}
+if comp.Accumulated >= comp.Required { // Required==0 の即時は初回で必ず満たす
+	Complete(comp)
+}
+if IsCompleted(comp) {
+	behavior.Finish(...) // 従来どおり
+}
+```
+
+- `IsCompleted(comp)` は `State == ActivityStateCompleted` のみで判定する。`TurnsLeft <= 0` 節を廃止する。早期完了、たとえば rest でHP満タンは従来どおり Behavior が `Complete(comp)` を呼ぶ。
+- `GetProgressPercent(comp)` は `Accumulated / Required` で計算する。`Required == 0` は 100% を返す。
+- 即時判定は `Execute` の `TurnsTotal == 1` を `Required == 0` へ置き換える。即時アクションは全て `Required == 0` なので綺麗に対応する。
+
+### Behaviorごとの Required 設定
+
+`Start` または `BuildActivity` で `comp.Required` を確定する。凍結するのは不変の「必要総量」だけで、これは元々途中で変わらない値である。
+
+| Behavior | Required の由来 | EffortPerTurn |
+|---|---|---|
+| rest | `TotalRequiredAP`（1000） | 毎ターンAP |
+| wait | `TotalRequiredAP`（500） | 毎ターンAP |
+| read | 本由来の総量。現行の `CalculateRequiredTurns` 相当を総量へ | 毎ターンAP |
+| disassemble | レシピ由来の総量 | 毎ターンAP |
+| reload | `fire.ReloadEffort` | `calcEffortPerTurn`（Base+DEX+skill） |
+| push, pull | 重量由来の総量。現行 `cubePushTurns` を総量へ | パーティAP |
+
+`CalculateRequiredTurns`（AP量からターン数を割る関数）は不要になるため廃止する。ターン数への変換をやめ、総量と毎ターン注入量の比較へ寄せる。
+
+## 変更箇所
+
+| ファイル | 変更内容 |
+|---|---|
+| `internal/components/activity.go` | `TurnsTotal`/`TurnsLeft` を削除し `Required int` を追加する。`Accumulated` は維持 |
+| `internal/activity/activity.go` | `Behavior` に `EffortPerTurn` を追加。`immediateEffort`/`apEffort` の埋め込み既定を用意。`NewActivity` の引数を duration から required へ変更。`IsCompleted` を State のみに。`GetProgressPercent` を `Accumulated/Required` に。`CalculateRequiredTurns` を廃止 |
+| `internal/activity/activity_manager.go` | `stepActivity` で `EffortPerTurn` 累積と `Accumulated>=Required` 完了判定を行う。`Execute` の即時判定を `Required==0` へ。`consumePassCost` は現行維持 |
+| `internal/activity/rest.go` | `Start` で `Required=1000`。`DoTurn` から `TurnsLeft` 廃止。`apEffort` 埋め込み。5ターン毎ログは累積ベースへ |
+| `internal/activity/read.go` | 同様。Required を本由来総量へ。`apEffort` 埋め込み |
+| `internal/activity/wait.go` | 同様。Required=500。`apEffort` 埋め込み。5ターン毎ログは累積ベースへ |
+| `internal/activity/disassemble.go` | 同様。Required をレシピ由来総量へ。`apEffort` 埋め込み |
+| `internal/activity/reload.go` | `Start` で `Required=fire.ReloadEffort`。`DoTurn` の `TurnsLeft` 廃止。`calcEffortPerTurn` を `EffortPerTurn` として公開 |
+| `internal/activity/push.go` | `buildCubeMove` で Required を重量由来総量へ。`DoTurn` の `TurnsLeft` 廃止。push/pull で `EffortPerTurn` をパーティAPに |
+| 即時 Behavior 9種 | `move`/`attack`/`pickup`/`drop`/`talk`/`use_item`/`transfer`/`door`/`shoot` に `immediateEffort` を埋め込む |
+| `internal/activity/doc.go` | 継続アクションのモデル説明を残りターンからAP累積へ更新 |
+| テスト | `TurnsTotal`/`TurnsLeft` を参照するテストを Required/Accumulated ベースへ。AP変動で所要が伸縮する回帰テストを追加 |
+
+## 採用しなかった方法
+
+- **注入量をオプショナルインターフェースの型アサーションで取る**。`ContinuousBehavior` を定義し `behavior.(ContinuousBehavior)` で判定する案。実装を強制せず即時アクションのボイラープレートを避けられるが、型アサーションは `ruins-review` で慎重に扱う対象であり、埋め込み既定のほうが静的で安全。よって埋め込みを採る。
+- **注入量を `Info` の静的フィールドにする**。`Info.EffortPerTurn int` を持たせる案。注入量はアクター依存で毎ターン変わるため静的値では変動へ追従できない。棄却。
+- **push/pull を現行の重量→ターン凍結のまま残す**。TurnsLeft を push 専用に残す折衷案。モデルが3つのままになり分裂が解消しない。今回の統一に含める。
+- **残りターンと累積を両方保持する**。互換のため TurnsLeft も残す案。二重管理でずれの温床になり、統一の意義が薄れる。純減させる。
+
+## コメント
+
+- `EffortPerTurn` と DoTurn 副作用の責務分離は、`ruins-review` の観点で見ると Reload の ammo 装填を DoTurn に残すか Finish へ寄せるかで揺れる。実装時に確定する。累積が Required を跨いだターンに装填する現行挙動は Finish へ寄せると素直になる。
+- 毎ターンのAP消費は `turn_system` が固定 `StandardActionCost` を引く現行のまま。`EffortPerTurn` は進捗の通貨で、APプールの消費とは直交する。両者を一致させるかは別途の判断とし、本 doc の範囲外とする。
+- `gc.Activity` はセーブの skip 対象のため、struct 変更に serde 互換の懸念はない。
+
+## 進捗
+
+- [ ] `gc.Activity` を Required/Accumulated へ変更し `make generate`
+- [ ] `Behavior` に `EffortPerTurn` 追加、`immediateEffort`/`apEffort` 埋め込み既定を用意
+- [ ] `stepActivity` に累積と完了判定を集約、`Execute` の即時判定を `Required==0` へ
+- [ ] `IsCompleted`/`GetProgressPercent` を State/累積ベースへ、`CalculateRequiredTurns` 廃止
+- [ ] rest/read/wait/disassemble を Required/apEffort へ移行
+- [ ] reload を Required/EffortPerTurn へ移行
+- [ ] push/pull を重量由来 Required とパーティAP注入へ移行
+- [ ] 即時 Behavior 9種へ `immediateEffort` 埋め込み
+- [ ] `doc.go` のモデル説明更新
+- [ ] AP変動で所要が伸縮する回帰テスト追加、既存テストを移行
+- [ ] `make check` 全緑

--- a/internal/activity/activity.go
+++ b/internal/activity/activity.go
@@ -14,8 +14,10 @@ import (
 // log はactivityパッケージ用のロガー
 var log = logger.New(logger.CategoryAction)
 
-// behaviors はProcessContinuousActivities経由の継続アクション処理で使うシングルトンBehaviorのマップ。
-// Execute経路で使うBuildActivityはこのマップのインスタンスでは呼ばれない
+// behaviors は gc.Activity に永続化された BehaviorName から実装を復元するレジストリ。
+// 値はフィールドがゼロ値の共有シングルトンで、着手後のライフサイクル Validate/Start/DoTurn/Finish/Canceled は
+// すべてこのシングルトンで回る。呼び出し側インスタンスを使うのは着手時の BuildActivity だけ。
+// そのため per-アクティビティの状態はインスタンスのフィールドに持たず gc.Activity 側に持たせる。
 var behaviors = map[gc.BehaviorName]Behavior{
 	gc.BehaviorMove:      &MoveBehavior{},
 	gc.BehaviorAttack:    &AttackBehavior{},

--- a/internal/activity/activity.go
+++ b/internal/activity/activity.go
@@ -80,26 +80,28 @@ type Info struct {
 	TotalRequiredAP int    // アクティビティ完了に必要な総AP量
 }
 
-// NewActivity は新しいActivityコンポーネントを作成する
-func NewActivity(behavior Behavior, duration consts.Turn) (*gc.Activity, error) {
-	if duration <= 0 {
-		return nil, ErrInvalidDuration
+// NewActivity は新しいActivityコンポーネントを作成する。
+// required は完了に必要な総量。即時アクションは 0 を渡す。
+func NewActivity(behavior Behavior, required int) (*gc.Activity, error) {
+	if required < 0 {
+		return nil, ErrInvalidRequired
 	}
 
 	return &gc.Activity{
 		BehaviorName: behavior.Name(),
 		State:        gc.ActivityStateRunning,
-		TurnsTotal:   duration,
-		TurnsLeft:    duration,
+		Required:     required,
 	}, nil
 }
 
-// CalculateRequiredTurns はキャラクターのAP量に基づいて必要ターン数を計算する
-func CalculateRequiredTurns(behavior Behavior, characterAP int) consts.Turn {
-	if behavior.Info().TotalRequiredAP > 0 && characterAP > 0 {
-		return consts.Turn((behavior.Info().TotalRequiredAP + characterAP - 1) / characterAP)
+// perTurnAP はアクターが継続アクションへ今ターン注げるAPを返す。
+// 毎ターン再計算するためAPの変動へ追従する。取得できない場合も進行が止まらないよう最低 1 を返す。
+func perTurnAP(actor ecs.Entity, world w.World) int {
+	ap, err := getEntityMaxAP(actor, world)
+	if err != nil || ap < 1 {
+		return 1
 	}
-	return 1
+	return ap
 }
 
 // CanInterrupt はアクティビティが中断可能かを返す
@@ -156,7 +158,7 @@ func IsActive(comp *gc.Activity) bool {
 
 // IsCompleted はアクティビティが完了しているかを返す
 func IsCompleted(comp *gc.Activity) bool {
-	return comp.State == gc.ActivityStateCompleted || comp.TurnsLeft <= 0
+	return comp.State == gc.ActivityStateCompleted
 }
 
 // IsCanceled はアクティビティがキャンセルされているかを返す
@@ -166,17 +168,15 @@ func IsCanceled(comp *gc.Activity) bool {
 
 // GetProgressPercent は進捗率を0-100の値で返す
 func GetProgressPercent(comp *gc.Activity) float64 {
-	if comp.TurnsTotal <= 0 {
+	if comp.Required <= 0 {
 		return 100.0
 	}
-	completed := float64(comp.TurnsTotal - comp.TurnsLeft)
-	return (completed / float64(comp.TurnsTotal)) * 100.0
+	return (float64(comp.Accumulated) / float64(comp.Required)) * 100.0
 }
 
 // Complete はアクティビティを完了状態にする
 func Complete(comp *gc.Activity) {
 	comp.State = gc.ActivityStateCompleted
-	comp.TurnsLeft = 0
 }
 
 // Cancel はアクティビティをキャンセルする

--- a/internal/activity/activity.go
+++ b/internal/activity/activity.go
@@ -20,6 +20,9 @@ var log = logger.New(logger.CategoryAction)
 // Validate/Start/DoTurn/Finish/Canceled はこのゼロ値インスタンスで回るため、per-アクティビティの
 // 状態はインスタンスのフィールドに持たず gc.Activity 側に持たせる。着手パラメータを持つのは
 // BuildActivity へ渡す呼び出し側インスタンスだけ。
+//
+// default 句は置かない。新しい BehaviorName を足したとき case 追加漏れを exhaustive linter に
+// 検知させるため。未知の名前は switch を抜けた後のエラーで扱う。
 func GetBehavior(name gc.BehaviorName) (Behavior, error) {
 	switch name {
 	case gc.BehaviorMove:
@@ -56,9 +59,10 @@ func GetBehavior(name gc.BehaviorName) (Behavior, error) {
 		return &PushBehavior{}, nil
 	case gc.BehaviorPull:
 		return &PullBehavior{}, nil
-	default:
-		return nil, fmt.Errorf("未登録のBehavior: %s", name)
+	case gc.BehaviorPortal, gc.BehaviorDoorLock, gc.BehaviorStorage:
+		// ExecuteInteraction が直接処理する結果ラベルで、対応する Behavior 実装は持たない
 	}
+	return nil, fmt.Errorf("未登録のBehavior: %s", name)
 }
 
 // Behavior はアクティビティの実行を担当するインターフェース。

--- a/internal/activity/activity.go
+++ b/internal/activity/activity.go
@@ -14,54 +14,67 @@ import (
 // log はactivityパッケージ用のロガー
 var log = logger.New(logger.CategoryAction)
 
-// behaviors は gc.Activity に永続化された BehaviorName から実装を復元するレジストリ。
-// 値はフィールドがゼロ値の共有シングルトンで、着手後のライフサイクル Validate/Start/DoTurn/Finish/Canceled は
-// すべてこのシングルトンで回る。呼び出し側インスタンスを使うのは着手時の BuildActivity だけ。
-// そのため per-アクティビティの状態はインスタンスのフィールドに持たず gc.Activity 側に持たせる。
-var behaviors = map[gc.BehaviorName]Behavior{
-	gc.BehaviorMove:      &MoveBehavior{},
-	gc.BehaviorAttack:    &AttackBehavior{},
-	gc.BehaviorRest:      &RestBehavior{},
-	gc.BehaviorWait:      &WaitBehavior{},
-	gc.BehaviorPickup:    &PickupBehavior{},
-	gc.BehaviorDrop:      &DropBehavior{},
-	gc.BehaviorUseItem:   &UseItemBehavior{},
-	gc.BehaviorTalk:      &TalkBehavior{},
-	gc.BehaviorOpenDoor:  &OpenDoorBehavior{},
-	gc.BehaviorCloseDoor: &CloseDoorBehavior{},
-	gc.BehaviorRead:      &ReadBehavior{},
-	gc.BehaviorShoot:     &ShootBehavior{},
-	gc.BehaviorReload:    &ReloadBehavior{},
-	gc.BehaviorTransfer:  &TransferBehavior{},
-
-	gc.BehaviorDisassemble: &DisassembleBehavior{},
-	gc.BehaviorPush:        &PushBehavior{},
-	gc.BehaviorPull:        &PullBehavior{},
-}
-
-// GetBehavior は名前からBehavior実装を取得する
+// GetBehavior は gc.Activity に永続化された BehaviorName から実装を復元する。
+// 単なる名前と実装の対応付けで、毎回ゼロ値の新しいインスタンスを返す。
+// Behavior は状態を持たない振る舞いの束なので、これで問題ない。着手後のライフサイクル
+// Validate/Start/DoTurn/Finish/Canceled はこのゼロ値インスタンスで回るため、per-アクティビティの
+// 状態はインスタンスのフィールドに持たず gc.Activity 側に持たせる。着手パラメータを持つのは
+// BuildActivity へ渡す呼び出し側インスタンスだけ。
 func GetBehavior(name gc.BehaviorName) (Behavior, error) {
-	b, ok := behaviors[name]
-	if !ok {
+	switch name {
+	case gc.BehaviorMove:
+		return &MoveBehavior{}, nil
+	case gc.BehaviorAttack:
+		return &AttackBehavior{}, nil
+	case gc.BehaviorRest:
+		return &RestBehavior{}, nil
+	case gc.BehaviorWait:
+		return &WaitBehavior{}, nil
+	case gc.BehaviorPickup:
+		return &PickupBehavior{}, nil
+	case gc.BehaviorDrop:
+		return &DropBehavior{}, nil
+	case gc.BehaviorUseItem:
+		return &UseItemBehavior{}, nil
+	case gc.BehaviorTalk:
+		return &TalkBehavior{}, nil
+	case gc.BehaviorOpenDoor:
+		return &OpenDoorBehavior{}, nil
+	case gc.BehaviorCloseDoor:
+		return &CloseDoorBehavior{}, nil
+	case gc.BehaviorRead:
+		return &ReadBehavior{}, nil
+	case gc.BehaviorShoot:
+		return &ShootBehavior{}, nil
+	case gc.BehaviorReload:
+		return &ReloadBehavior{}, nil
+	case gc.BehaviorTransfer:
+		return &TransferBehavior{}, nil
+	case gc.BehaviorDisassemble:
+		return &DisassembleBehavior{}, nil
+	case gc.BehaviorPush:
+		return &PushBehavior{}, nil
+	case gc.BehaviorPull:
+		return &PullBehavior{}, nil
+	default:
 		return nil, fmt.Errorf("未登録のBehavior: %s", name)
 	}
-	return b, nil
 }
 
 // Behavior はアクティビティの実行を担当するインターフェース。
 //
 // メソッドは2種類に分かれる。BuildActivity だけは着手時に呼び出し側が生成した
 // インスタンスで呼ばれ、そのフィールドを着手パラメータとして読んでよい。残りの
-// Validate/Start/DoTurn/Finish/Canceled は behaviors レジストリの共有シングルトンで
+// Validate/Start/DoTurn/Finish/Canceled は GetBehavior が毎回作るゼロ値インスタンスで
 // 回るため、インスタンスのフィールドはゼロ値であり読んではいけない。継続する状態は
 // すべて gc.Activity に持たせる。
 //
-// この非対称ゆえ BuildActivity をシングルトンで呼んではならない。着手パラメータが
-// ゼロ値になり、Duration 依存の Behavior などがエラーになる。
+// この非対称ゆえ GetBehavior が返すインスタンスで BuildActivity を呼んではならない。
+// 着手パラメータがゼロ値になり、Duration 依存の Behavior などがエラーになる。
 type Behavior interface {
 	Info() Info
 	Name() gc.BehaviorName
-	// BuildActivity は着手時の呼び出し側インスタンスでのみ呼ぶ。シングルトンで呼ばない
+	// BuildActivity は着手時の呼び出し側インスタンスでのみ呼ぶ。GetBehavior が返すインスタンスで呼ばない
 	BuildActivity(actor ecs.Entity, world w.World) (*gc.Activity, error)
 	Validate(comp *gc.Activity, actor ecs.Entity, world w.World) error
 	Start(comp *gc.Activity, actor ecs.Entity, world w.World) error

--- a/internal/activity/activity.go
+++ b/internal/activity/activity.go
@@ -81,7 +81,7 @@ type Info struct {
 }
 
 // NewActivity は新しいActivityコンポーネントを作成する。
-// required は完了に必要な総量。即時アクションは 0 を渡す。
+// required は完了に必要な総量。初回ステップで満ちれば即時アクションになる。
 func NewActivity(behavior Behavior, required int) (*gc.Activity, error) {
 	if required < 0 {
 		return nil, ErrInvalidRequired
@@ -90,7 +90,7 @@ func NewActivity(behavior Behavior, required int) (*gc.Activity, error) {
 	return &gc.Activity{
 		BehaviorName: behavior.Name(),
 		State:        gc.ActivityStateRunning,
-		Required:     required,
+		Progress:     gc.IntPool{Max: required},
 	}, nil
 }
 
@@ -168,10 +168,10 @@ func IsCanceled(comp *gc.Activity) bool {
 
 // GetProgressPercent は進捗率を0-100の値で返す
 func GetProgressPercent(comp *gc.Activity) float64 {
-	if comp.Required <= 0 {
+	if comp.Progress.Max <= 0 {
 		return 100.0
 	}
-	return (float64(comp.Accumulated) / float64(comp.Required)) * 100.0
+	return (float64(comp.Progress.Current) / float64(comp.Progress.Max)) * 100.0
 }
 
 // Complete はアクティビティを完了状態にする

--- a/internal/activity/activity.go
+++ b/internal/activity/activity.go
@@ -18,7 +18,8 @@ var log = logger.New(logger.CategoryAction)
 // 単なる名前と実装の対応付けで、毎回ゼロ値の新しいインスタンスを返す。
 // Behavior は状態を持たない振る舞いの束なので、これで問題ない。着手後のライフサイクル
 // Validate/Start/DoTurn/Finish/Canceled はこのゼロ値インスタンスで回るため、per-アクティビティの
-// 状態はインスタンスのフィールドに持たず gc.Activity 側に持たせる。着手パラメータを持つのは
+// 状態はインスタンスのフィールドに持たず gc.Activity 側に持たせる。着手パラメータは
+// NewXxxActivity 構築関数が引数から gc.Activity の Params へ書き込む。
 //
 // default 句は置かない。新しい BehaviorName を足したとき case 追加漏れを exhaustive linter に
 // 検知させるため。未知の名前は switch を抜けた後のエラーで扱う。
@@ -191,13 +192,14 @@ func Cancel(comp *gc.Activity, reason string) {
 	comp.CancelReason = reason
 }
 
-// requireDestination はActivityのDestinationからタイル座標を取得する。
-// Destinationが未設定の場合はエラーを返す
+// requireDestination はActivityのPlaceParamsからタイル座標を取得する。
+// PlaceParamsが未設定の場合はエラーを返す
 func requireDestination(comp *gc.Activity) (consts.Coord[consts.Tile], error) {
-	if comp.Destination == nil {
+	p, ok := comp.Params.(*gc.PlaceParams)
+	if !ok {
 		return consts.Coord[consts.Tile]{}, fmt.Errorf("目的地が指定されていません")
 	}
-	return consts.Coord[consts.Tile]{X: comp.Destination.X, Y: comp.Destination.Y}, nil
+	return consts.Coord[consts.Tile]{X: p.Destination.X, Y: p.Destination.Y}, nil
 }
 
 // isAreaSafe はアクターの周囲に敵対エンティティがいないかチェックする

--- a/internal/activity/activity.go
+++ b/internal/activity/activity.go
@@ -48,10 +48,20 @@ func GetBehavior(name gc.BehaviorName) (Behavior, error) {
 	return b, nil
 }
 
-// Behavior はアクティビティの実行を担当するインターフェース
+// Behavior はアクティビティの実行を担当するインターフェース。
+//
+// メソッドは2種類に分かれる。BuildActivity だけは着手時に呼び出し側が生成した
+// インスタンスで呼ばれ、そのフィールドを着手パラメータとして読んでよい。残りの
+// Validate/Start/DoTurn/Finish/Canceled は behaviors レジストリの共有シングルトンで
+// 回るため、インスタンスのフィールドはゼロ値であり読んではいけない。継続する状態は
+// すべて gc.Activity に持たせる。
+//
+// この非対称ゆえ BuildActivity をシングルトンで呼んではならない。着手パラメータが
+// ゼロ値になり、Duration 依存の Behavior などがエラーになる。
 type Behavior interface {
 	Info() Info
 	Name() gc.BehaviorName
+	// BuildActivity は着手時の呼び出し側インスタンスでのみ呼ぶ。シングルトンで呼ばない
 	BuildActivity(actor ecs.Entity, world w.World) (*gc.Activity, error)
 	Validate(comp *gc.Activity, actor ecs.Entity, world w.World) error
 	Start(comp *gc.Activity, actor ecs.Entity, world w.World) error

--- a/internal/activity/activity.go
+++ b/internal/activity/activity.go
@@ -91,16 +91,8 @@ type Info struct {
 }
 
 // NewActivity は名前と必要総量から新しいActivityコンポーネントを作成する。
-// required は完了に必要な総量。初回ステップで満ちれば即時アクションになる。
-func NewActivity(name gc.BehaviorName, required int) (*gc.Activity, error) {
-	if required < 0 {
-		return nil, ErrInvalidRequired
-	}
-	return newActivity(name, required), nil
-}
-
-// newActivity は検証なしでActivityを組む内部ヘルパ。required が静的に非負な構築関数から使う。
-func newActivity(name gc.BehaviorName, required int) *gc.Activity {
+// required は完了に必要な総量で、各構築関数が常に0以上を渡す。初回ステップで満ちれば即時アクションになる。
+func NewActivity(name gc.BehaviorName, required int) *gc.Activity {
 	return &gc.Activity{
 		BehaviorName: name,
 		State:        gc.ActivityStateRunning,

--- a/internal/activity/activity.go
+++ b/internal/activity/activity.go
@@ -19,7 +19,6 @@ var log = logger.New(logger.CategoryAction)
 // Behavior は状態を持たない振る舞いの束なので、これで問題ない。着手後のライフサイクル
 // Validate/Start/DoTurn/Finish/Canceled はこのゼロ値インスタンスで回るため、per-アクティビティの
 // 状態はインスタンスのフィールドに持たず gc.Activity 側に持たせる。着手パラメータを持つのは
-// BuildActivity へ渡す呼び出し側インスタンスだけ。
 //
 // default 句は置かない。新しい BehaviorName を足したとき case 追加漏れを exhaustive linter に
 // 検知させるため。未知の名前は switch を抜けた後のエラーで扱う。
@@ -67,19 +66,13 @@ func GetBehavior(name gc.BehaviorName) (Behavior, error) {
 
 // Behavior はアクティビティの実行を担当するインターフェース。
 //
-// メソッドは2種類に分かれる。BuildActivity だけは着手時に呼び出し側が生成した
-// インスタンスで呼ばれ、そのフィールドを着手パラメータとして読んでよい。残りの
-// Validate/Start/DoTurn/Finish/Canceled は GetBehavior が毎回作るゼロ値インスタンスで
-// 回るため、インスタンスのフィールドはゼロ値であり読んではいけない。継続する状態は
-// すべて gc.Activity に持たせる。
-//
-// この非対称ゆえ GetBehavior が返すインスタンスで BuildActivity を呼んではならない。
-// 着手パラメータがゼロ値になり、Duration 依存の Behavior などがエラーになる。
+// 全メソッドは GetBehavior が毎回作るゼロ値インスタンスで回る。インスタンスは状態を持たず、
+// per-アクティビティの状態はすべて gc.Activity に持たせる。着手時のパラメータは Behavior の
+// フィールドではなく、NewXxxActivity 構築関数が引数から gc.Activity へ書き込む。
+// そのため Behavior は状態を持たない振る舞いの束であり、構築とライフサイクルが分離している。
 type Behavior interface {
 	Info() Info
 	Name() gc.BehaviorName
-	// BuildActivity は着手時の呼び出し側インスタンスでのみ呼ぶ。GetBehavior が返すインスタンスで呼ばない
-	BuildActivity(actor ecs.Entity, world w.World) (*gc.Activity, error)
 	Validate(comp *gc.Activity, actor ecs.Entity, world w.World) error
 	Start(comp *gc.Activity, actor ecs.Entity, world w.World) error
 	DoTurn(comp *gc.Activity, actor ecs.Entity, world w.World) error
@@ -97,18 +90,22 @@ type Info struct {
 	TotalRequiredAP int    // アクティビティ完了に必要な総AP量
 }
 
-// NewActivity は新しいActivityコンポーネントを作成する。
+// NewActivity は名前と必要総量から新しいActivityコンポーネントを作成する。
 // required は完了に必要な総量。初回ステップで満ちれば即時アクションになる。
-func NewActivity(behavior Behavior, required int) (*gc.Activity, error) {
+func NewActivity(name gc.BehaviorName, required int) (*gc.Activity, error) {
 	if required < 0 {
 		return nil, ErrInvalidRequired
 	}
+	return newActivity(name, required), nil
+}
 
+// newActivity は検証なしでActivityを組む内部ヘルパ。required が静的に非負な構築関数から使う。
+func newActivity(name gc.BehaviorName, required int) *gc.Activity {
 	return &gc.Activity{
-		BehaviorName: behavior.Name(),
+		BehaviorName: name,
 		State:        gc.ActivityStateRunning,
 		Progress:     gc.IntPool{Max: required},
-	}, nil
+	}
 }
 
 // perTurnAP はアクターが継続アクションへ今ターン注げるAPを返す。

--- a/internal/activity/activity_manager.go
+++ b/internal/activity/activity_manager.go
@@ -51,14 +51,16 @@ func Execute(behavior Behavior, actor ecs.Entity, world w.World) (*ActionResult,
 		return result, err
 	}
 
-	// 即座実行アクション（1ターン）は、登録済みアクティビティを1ターン進めてその場で完結させる。
+	// 即座実行アクション（1ターン）は、呼び出し側が同じ呼び出しで結果を必要とするため、
+	// ここで1ターン進めてその場で完結させる。継続アクションとの唯一の本質的な差はこの同期性で、
+	// 継続アクションは ProcessContinuousActivities が将来ティックで進める。
 	// アクター1体だけを対象にするため、入れ子処理（攻撃→被弾側の処理など）で他エンティティが
 	// 消えても影響を受けない。全エンティティを回すと処理中コンポーネントの再利用で panic しうる。
 	if comp.TurnsTotal == 1 {
-		stepActivity(behavior, actor, world)
+		stepActivity(actor, world)
 
 		// ターン管理システムに移動コストを通知
-		consumePassCost(world, behavior, actor, comp.Destination)
+		consumePassCost(world, behaviorName, actor, comp.Destination)
 
 		// 結果を確認
 		currentActivity := query.GetActivity(world, actor)
@@ -99,16 +101,27 @@ func Execute(behavior Behavior, actor ecs.Entity, world w.World) (*ActionResult,
 // （ProcessContinuousActivities）の両方から呼ばれ、両者で「1ターン進める」
 // ロジックを一本化する。即時アクションは1ステップで完結する継続アクションの特殊ケースとして扱う。
 //
+// 実行する Behavior は永続化された BehaviorName から behaviors レジストリの共有シングルトンを
+// 引く。着手時の呼び出し側インスタンスはここでは使わない。ライフサイクルを常にシングルトンで
+// 回すことで、per-アクティビティの状態は gc.Activity に置くという規律が経路によらず一貫する。
+//
 // DoTurn が失敗すればキャンセルし、完了していれば Finish して直近結果を記録し除去する。
 // アクター1体のみを直接処理するため、DoTurn 内の入れ子処理で他エンティティが
 // 消えても走査中コンポーネントの破壊による panic を招かない。
-func stepActivity(behavior Behavior, entity ecs.Entity, world w.World) {
+func stepActivity(entity ecs.Entity, world w.World) {
 	stored := query.GetActivity(world, entity)
 	if stored == nil {
 		return
 	}
 
-	behaviorName := behavior.Name()
+	behaviorName := stored.BehaviorName
+	behavior, err := GetBehavior(behaviorName)
+	if err != nil {
+		log.Error("Behaviorの取得に失敗", "entity", entity, "error", err.Error())
+		query.RemoveActivity(world, entity)
+		return
+	}
+
 	if err := behavior.DoTurn(stored, entity, world); err != nil {
 		log.Error("アクティビティターン処理エラー", "entity", entity, "type", behaviorName, "error", err.Error())
 		CancelActivity(entity, fmt.Sprintf("エラー: %s", err.Error()), world)
@@ -287,24 +300,23 @@ func ProcessContinuousActivities(world w.World) {
 			continue
 		}
 
-		behavior, err := GetBehavior(comp.BehaviorName)
-		if err != nil {
-			log.Error("Behaviorの取得に失敗", "entity", entity, "error", err.Error())
-			query.RemoveActivity(world, entity)
-			continue
-		}
-
-		stepActivity(behavior, entity, world)
+		stepActivity(entity, world)
 	}
 }
 
-// consumePassCost はアクションのAPコストを消費する
-func consumePassCost(world w.World, behavior Behavior, actor ecs.Entity, destination *gc.GridElement) {
+// consumePassCost はアクションのAPコストを消費する。
+// Behavior は behaviorName から behaviors レジストリのシングルトンを引く。
+func consumePassCost(world w.World, behaviorName gc.BehaviorName, actor ecs.Entity, destination *gc.GridElement) {
+	behavior, err := GetBehavior(behaviorName)
+	if err != nil {
+		log.Error("Behaviorの取得に失敗", "actor", actor, "error", err.Error())
+		return
+	}
 	info := behavior.Info()
 	cost := info.ActionPointCost
 
 	// 移動行動の場合、移動先タイルのPassCostを加算する
-	if behavior.Name() == gc.BehaviorMove && destination != nil {
+	if behaviorName == gc.BehaviorMove && destination != nil {
 		cost += getPassCostAt(world, int(destination.X), int(destination.Y))
 	}
 

--- a/internal/activity/activity_manager.go
+++ b/internal/activity/activity_manager.go
@@ -51,12 +51,12 @@ func Execute(behavior Behavior, actor ecs.Entity, world w.World) (*ActionResult,
 		return result, err
 	}
 
-	// 即座実行アクション（1ターン）は、呼び出し側が同じ呼び出しで結果を必要とするため、
+	// 即座実行アクション（Required==0）は、呼び出し側が同じ呼び出しで結果を必要とするため、
 	// ここで1ターン進めてその場で完結させる。継続アクションとの唯一の本質的な差はこの同期性で、
 	// 継続アクションは ProcessContinuousActivities が将来ティックで進める。
 	// アクター1体だけを対象にするため、入れ子処理（攻撃→被弾側の処理など）で他エンティティが
 	// 消えても影響を受けない。全エンティティを回すと処理中コンポーネントの再利用で panic しうる。
-	if comp.TurnsTotal == 1 {
+	if comp.Required == 0 {
 		stepActivity(actor, world)
 
 		// ターン管理システムに移動コストを通知
@@ -206,7 +206,7 @@ func StartActivity(comp *gc.Activity, actor ecs.Entity, world w.World) error {
 	log.Debug("アクティビティ開始",
 		"entity", actor,
 		"type", behavior.Name(),
-		"duration", stored.TurnsTotal)
+		"required", stored.Required)
 
 	return nil
 }
@@ -277,7 +277,7 @@ func CancelActivity(entity ecs.Entity, reason string, world w.World) {
 }
 
 // ProcessContinuousActivities は継続中の全アクティビティを1ターン分進める。
-// 即時アクション（TurnsTotal==1）は Execute がその場で完結させるため、ここに残るのは継続実行アクションのみ。
+// 即時アクション（Required==0）は Execute がその場で完結させるため、ここに残るのは継続実行アクションのみ。
 // 走査中に他エンティティのアクティビティが削除されても、各要素で生存確認するため安全。
 func ProcessContinuousActivities(world w.World) {
 	var entities []ecs.Entity

--- a/internal/activity/activity_manager.go
+++ b/internal/activity/activity_manager.go
@@ -19,26 +19,17 @@ type ActionResult struct {
 	Message      string           // 結果メッセージ
 }
 
-// Execute は指定されたアクティビティを実行する
-// 即座実行アクション（移動、攻撃等）も継続アクション（休息等）も統一的に処理する
-func Execute(behavior Behavior, actor ecs.Entity, world w.World) (*ActionResult, error) {
-	behaviorName := behavior.Name()
+// Execute は構築済みのアクティビティを実行する。
+// 即座実行アクション（移動、攻撃等）も継続アクション（休息等）も統一的に処理する。
+// comp は NewXxxActivity 構築関数で作る。
+func Execute(comp *gc.Activity, actor ecs.Entity, world w.World) (*ActionResult, error) {
+	if comp == nil {
+		return nil, ErrActivityNil
+	}
+	behaviorName := comp.BehaviorName
 	log.Debug("アクション実行開始",
 		"type", behaviorName,
 		"actor", actor)
-
-	// アクティビティを作成
-	comp, err := behavior.BuildActivity(actor, world)
-	if err != nil {
-		result := &ActionResult{
-			Success:      false,
-			State:        gc.ActivityStateCanceled,
-			ActivityName: behaviorName,
-			Message:      err.Error(),
-		}
-		setLastResult(actor, result, world)
-		return result, err
-	}
 
 	// アクティビティを開始
 	if err := StartActivity(comp, actor, world); err != nil {
@@ -61,37 +52,21 @@ func Execute(behavior Behavior, actor ecs.Entity, world w.World) (*ActionResult,
 
 	currentActivity := query.GetActivity(world, actor)
 
-	// 初回で完了も中断もしなければ継続アクション。この初回ターン分のコストを消費し、
-	// 残りは ProcessContinuousActivities が将来ティックで進める。
+	// 出口は「継続」か「初回で解決」かの2分岐。結果の中身だけが違い、
+	// setLastResult と return は共通なので末尾へ1回だけ置く。
+	var result *ActionResult
 	if currentActivity != nil && !IsCompleted(currentActivity) && !IsCanceled(currentActivity) {
+		// 継続アクション。この初回ターン分のコストを消費し、残りは ProcessContinuousActivities が進める
 		query.ConsumeActionPoints(world, actor, consts.StandardActionCost)
-		result := &ActionResult{
-			Success:      true,
-			State:        gc.ActivityStateRunning,
-			ActivityName: behaviorName,
-			Message:      "アクション開始",
+		result = &ActionResult{Success: true, State: gc.ActivityStateRunning, ActivityName: behaviorName, Message: "アクション開始"}
+	} else {
+		// 初回で解決した即時アクション。移動コストなど behavior 固有のコストを消費する
+		consumePassCost(world, behaviorName, actor, comp.Destination)
+		if currentActivity != nil && IsCanceled(currentActivity) {
+			result = &ActionResult{Success: false, State: gc.ActivityStateCanceled, ActivityName: behaviorName, Message: currentActivity.CancelReason}
+		} else {
+			result = &ActionResult{Success: true, State: gc.ActivityStateCompleted, ActivityName: behaviorName, Message: "アクション完了"}
 		}
-		setLastResult(actor, result, world)
-		return result, nil
-	}
-
-	// 初回で解決した即時アクション。移動コストなど behavior 固有のコストを消費する
-	consumePassCost(world, behaviorName, actor, comp.Destination)
-	if currentActivity != nil && IsCanceled(currentActivity) {
-		result := &ActionResult{
-			Success:      false,
-			State:        gc.ActivityStateCanceled,
-			ActivityName: behaviorName,
-			Message:      currentActivity.CancelReason,
-		}
-		setLastResult(actor, result, world)
-		return result, nil
-	}
-	result := &ActionResult{
-		Success:      true,
-		State:        gc.ActivityStateCompleted,
-		ActivityName: behaviorName,
-		Message:      "アクション完了",
 	}
 	setLastResult(actor, result, world)
 	return result, nil

--- a/internal/activity/activity_manager.go
+++ b/internal/activity/activity_manager.go
@@ -61,7 +61,7 @@ func Execute(comp *gc.Activity, actor ecs.Entity, world w.World) (*ActionResult,
 		result = &ActionResult{Success: true, State: gc.ActivityStateRunning, ActivityName: behaviorName, Message: "アクション開始"}
 	} else {
 		// 初回で解決した即時アクション。移動コストなど behavior 固有のコストを消費する
-		consumePassCost(world, behaviorName, actor, comp.Destination)
+		consumePassCost(world, behaviorName, actor, comp)
 		if currentActivity != nil && IsCanceled(currentActivity) {
 			result = &ActionResult{Success: false, State: gc.ActivityStateCanceled, ActivityName: behaviorName, Message: currentActivity.CancelReason}
 		} else {
@@ -282,7 +282,7 @@ func ProcessContinuousActivities(world w.World) {
 
 // consumePassCost はアクションのAPコストを消費する。
 // Behavior は behaviorName から GetBehavior で引く。
-func consumePassCost(world w.World, behaviorName gc.BehaviorName, actor ecs.Entity, destination *gc.GridElement) {
+func consumePassCost(world w.World, behaviorName gc.BehaviorName, actor ecs.Entity, comp *gc.Activity) {
 	behavior, err := GetBehavior(behaviorName)
 	if err != nil {
 		log.Error("Behaviorの取得に失敗", "actor", actor, "error", err.Error())
@@ -292,8 +292,8 @@ func consumePassCost(world w.World, behaviorName gc.BehaviorName, actor ecs.Enti
 	cost := info.ActionPointCost
 
 	// 移動行動の場合、移動先タイルのPassCostを加算する
-	if behaviorName == gc.BehaviorMove && destination != nil {
-		cost += getPassCostAt(world, int(destination.X), int(destination.Y))
+	if mp, ok := comp.Params.(*gc.MoveParams); ok && behaviorName == gc.BehaviorMove {
+		cost += getPassCostAt(world, int(mp.Destination.X), int(mp.Destination.Y))
 	}
 
 	if !query.ConsumeActionPoints(world, actor, cost) {

--- a/internal/activity/activity_manager.go
+++ b/internal/activity/activity_manager.go
@@ -61,7 +61,7 @@ func Execute(comp *gc.Activity, actor ecs.Entity, world w.World) (*ActionResult,
 		result = &ActionResult{Success: true, State: gc.ActivityStateRunning, ActivityName: behaviorName, Message: "アクション開始"}
 	} else {
 		// 初回で解決した即時アクション。移動コストなど behavior 固有のコストを消費する
-		consumePassCost(world, behaviorName, actor, comp)
+		consumePassCost(world, actor, comp)
 		if currentActivity != nil && IsCanceled(currentActivity) {
 			result = &ActionResult{Success: false, State: gc.ActivityStateCanceled, ActivityName: behaviorName, Message: currentActivity.CancelReason}
 		} else {
@@ -281,18 +281,17 @@ func ProcessContinuousActivities(world w.World) {
 }
 
 // consumePassCost はアクションのAPコストを消費する。
-// Behavior は behaviorName から GetBehavior で引く。
-func consumePassCost(world w.World, behaviorName gc.BehaviorName, actor ecs.Entity, comp *gc.Activity) {
-	behavior, err := GetBehavior(behaviorName)
+// Behavior は comp.BehaviorName から GetBehavior で引く。
+func consumePassCost(world w.World, actor ecs.Entity, comp *gc.Activity) {
+	behavior, err := GetBehavior(comp.BehaviorName)
 	if err != nil {
 		log.Error("Behaviorの取得に失敗", "actor", actor, "error", err.Error())
 		return
 	}
-	info := behavior.Info()
-	cost := info.ActionPointCost
+	cost := behavior.Info().ActionPointCost
 
-	// 移動行動の場合、移動先タイルのPassCostを加算する
-	if mp, ok := comp.Params.(*gc.MoveParams); ok && behaviorName == gc.BehaviorMove {
+	// 移動行動の場合、移動先タイルのPassCostを加算する。MoveParams を持つのは移動だけ
+	if mp, ok := comp.Params.(*gc.MoveParams); ok {
 		cost += getPassCostAt(world, int(mp.Destination.X), int(mp.Destination.Y))
 	}
 

--- a/internal/activity/activity_manager.go
+++ b/internal/activity/activity_manager.go
@@ -102,9 +102,9 @@ func Execute(behavior Behavior, actor ecs.Entity, world w.World) (*ActionResult,
 // （ProcessContinuousActivities）の両方から呼ばれ、両者で「1ターン進める」
 // ロジックを一本化する。即時アクションは1ステップで完結する継続アクションの特殊ケースとして扱う。
 //
-// 実行する Behavior は永続化された BehaviorName から behaviors レジストリの共有シングルトンを
-// 引く。着手時の呼び出し側インスタンスはここでは使わない。ライフサイクルを常にシングルトンで
-// 回すことで、per-アクティビティの状態は gc.Activity に置くという規律が経路によらず一貫する。
+// 実行する Behavior は永続化された BehaviorName から GetBehavior で引く。毎回ゼロ値の新しい
+// インスタンスなので、着手時の呼び出し側インスタンスはここでは使わない。ライフサイクルを常に
+// ゼロ値インスタンスで回すことで、per-アクティビティの状態は gc.Activity に置くという規律が経路によらず一貫する。
 //
 // DoTurn が失敗すればキャンセルし、完了していれば Finish して直近結果を記録し除去する。
 // アクター1体のみを直接処理するため、DoTurn 内の入れ子処理で他エンティティが
@@ -306,7 +306,7 @@ func ProcessContinuousActivities(world w.World) {
 }
 
 // consumePassCost はアクションのAPコストを消費する。
-// Behavior は behaviorName から behaviors レジストリのシングルトンを引く。
+// Behavior は behaviorName から GetBehavior で引く。
 func consumePassCost(world w.World, behaviorName gc.BehaviorName, actor ecs.Entity, destination *gc.GridElement) {
 	behavior, err := GetBehavior(behaviorName)
 	if err != nil {

--- a/internal/activity/activity_manager.go
+++ b/internal/activity/activity_manager.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	gc "github.com/kijimaD/ruins/internal/components"
+	"github.com/kijimaD/ruins/internal/consts"
 	w "github.com/kijimaD/ruins/internal/world"
 
 	"github.com/kijimaD/ruins/internal/world/query"
@@ -51,46 +52,46 @@ func Execute(behavior Behavior, actor ecs.Entity, world w.World) (*ActionResult,
 		return result, err
 	}
 
-	// 即座実行アクション（Required==0）は、呼び出し側が同じ呼び出しで結果を必要とするため、
-	// ここで1ターン進めてその場で完結させる。継続アクションとの唯一の本質的な差はこの同期性で、
-	// 継続アクションは ProcessContinuousActivities が将来ティックで進める。
+	// 全アクションを継続アクションとして扱い、常にここで1ターン進める。
+	// たまたま初回ステップで完了したものが即時アクションになる。特別な即時判定は持たない。
+	// 呼び出し側が同じ呼び出しで結果を必要とするため、初回で解決すれば同期的に結果を返す。
 	// アクター1体だけを対象にするため、入れ子処理（攻撃→被弾側の処理など）で他エンティティが
 	// 消えても影響を受けない。全エンティティを回すと処理中コンポーネントの再利用で panic しうる。
-	if comp.Required == 0 {
-		stepActivity(actor, world)
+	stepActivity(actor, world)
 
-		// ターン管理システムに移動コストを通知
-		consumePassCost(world, behaviorName, actor, comp.Destination)
+	currentActivity := query.GetActivity(world, actor)
 
-		// 結果を確認
-		currentActivity := query.GetActivity(world, actor)
-		if currentActivity == nil || IsCompleted(currentActivity) {
-			result := &ActionResult{
-				Success:      true,
-				State:        gc.ActivityStateCompleted,
-				ActivityName: behaviorName,
-				Message:      "アクション完了",
-			}
-			setLastResult(actor, result, world)
-			return result, nil
-		} else if IsCanceled(currentActivity) {
-			result := &ActionResult{
-				Success:      false,
-				State:        gc.ActivityStateCanceled,
-				ActivityName: behaviorName,
-				Message:      currentActivity.CancelReason,
-			}
-			setLastResult(actor, result, world)
-			return result, nil
+	// 初回で完了も中断もしなければ継続アクション。この初回ターン分のコストを消費し、
+	// 残りは ProcessContinuousActivities が将来ティックで進める。
+	if currentActivity != nil && !IsCompleted(currentActivity) && !IsCanceled(currentActivity) {
+		query.ConsumeActionPoints(world, actor, consts.StandardActionCost)
+		result := &ActionResult{
+			Success:      true,
+			State:        gc.ActivityStateRunning,
+			ActivityName: behaviorName,
+			Message:      "アクション開始",
 		}
+		setLastResult(actor, result, world)
+		return result, nil
 	}
 
-	// 継続アクションの場合は開始成功を返す
+	// 初回で解決した即時アクション。移動コストなど behavior 固有のコストを消費する
+	consumePassCost(world, behaviorName, actor, comp.Destination)
+	if currentActivity != nil && IsCanceled(currentActivity) {
+		result := &ActionResult{
+			Success:      false,
+			State:        gc.ActivityStateCanceled,
+			ActivityName: behaviorName,
+			Message:      currentActivity.CancelReason,
+		}
+		setLastResult(actor, result, world)
+		return result, nil
+	}
 	result := &ActionResult{
 		Success:      true,
-		State:        gc.ActivityStateRunning,
+		State:        gc.ActivityStateCompleted,
 		ActivityName: behaviorName,
-		Message:      "アクション開始",
+		Message:      "アクション完了",
 	}
 	setLastResult(actor, result, world)
 	return result, nil

--- a/internal/activity/activity_manager.go
+++ b/internal/activity/activity_manager.go
@@ -207,7 +207,7 @@ func StartActivity(comp *gc.Activity, actor ecs.Entity, world w.World) error {
 	log.Debug("アクティビティ開始",
 		"entity", actor,
 		"type", behavior.Name(),
-		"required", stored.Required)
+		"required", stored.Progress.Max)
 
 	return nil
 }

--- a/internal/activity/activity_manager_test.go
+++ b/internal/activity/activity_manager_test.go
@@ -49,7 +49,7 @@ func TestStartActivity(t *testing.T) {
 	world.Components.TurnBased.Add(actor, &gc.TurnBased{})
 
 	// アクティビティを作成
-	comp, err := NewActivity(&WaitBehavior{}, 5)
+	comp, err := NewActivity(gc.BehaviorWait, 5)
 	require.NoError(t, err)
 
 	// アクティビティ開始
@@ -79,9 +79,9 @@ func TestMultipleActivities(t *testing.T) {
 	world.Components.TurnBased.Add(actor2, &gc.TurnBased{})
 
 	// 複数のアクターでアクティビティを開始
-	comp1, err := NewActivity(&WaitBehavior{}, 10)
+	comp1, err := NewActivity(gc.BehaviorWait, 10)
 	require.NoError(t, err)
-	comp2, err := NewActivity(&WaitBehavior{}, 5)
+	comp2, err := NewActivity(gc.BehaviorWait, 5)
 	require.NoError(t, err)
 
 	err = StartActivity(comp1, actor1, world)
@@ -109,7 +109,7 @@ func TestReplaceActivity(t *testing.T) {
 	world.Components.TurnBased.Add(actor, &gc.TurnBased{})
 
 	// 最初のアクティビティを開始
-	comp1, err := NewActivity(&WaitBehavior{}, 10)
+	comp1, err := NewActivity(gc.BehaviorWait, 10)
 	require.NoError(t, err)
 	err = StartActivity(comp1, actor, world)
 	require.NoError(t, err)
@@ -118,7 +118,7 @@ func TestReplaceActivity(t *testing.T) {
 	assert.Equal(t, gc.ActivityStateRunning, comp1.State, "Expected first activity to be running")
 
 	// 新しいアクティビティを開始（古いものを置き換え）
-	comp2, err := NewActivity(&WaitBehavior{}, 5)
+	comp2, err := NewActivity(gc.BehaviorWait, 5)
 	require.NoError(t, err)
 	err = StartActivity(comp2, actor, world)
 	require.NoError(t, err)
@@ -138,7 +138,7 @@ func TestInterruptAndResume(t *testing.T) {
 	world.Components.TurnBased.Add(actor, &gc.TurnBased{})
 
 	// アクティビティを開始
-	comp, err := NewActivity(&WaitBehavior{}, 10)
+	comp, err := NewActivity(gc.BehaviorWait, 10)
 	require.NoError(t, err)
 	err = StartActivity(comp, actor, world)
 	require.NoError(t, err)
@@ -177,7 +177,7 @@ func TestCancelActivity(t *testing.T) {
 	world.Components.TurnBased.Add(actor, &gc.TurnBased{})
 
 	// アクティビティを開始
-	comp, err := NewActivity(&WaitBehavior{}, 5)
+	comp, err := NewActivity(gc.BehaviorWait, 5)
 	require.NoError(t, err)
 	err = StartActivity(comp, actor, world)
 	require.NoError(t, err)
@@ -210,9 +210,9 @@ func TestProcessContinuousActivities(t *testing.T) {
 	world.Components.GridElement.Add(actor2, &gc.GridElement{Coord: consts.Coord[consts.Tile]{X: 6, Y: 5}})
 
 	// 短いアクティビティと長いアクティビティを開始
-	shortComp, err := NewActivity(&WaitBehavior{}, 2) // 2ターンで完了
+	shortComp, err := NewActivity(gc.BehaviorWait, 2) // 2ターンで完了
 	require.NoError(t, err)
-	longComp, err := NewActivity(&WaitBehavior{}, 5) // 5ターンで完了
+	longComp, err := NewActivity(gc.BehaviorWait, 5) // 5ターンで完了
 	require.NoError(t, err)
 
 	err = StartActivity(shortComp, actor1, world)
@@ -264,9 +264,9 @@ func TestActivitySummary(t *testing.T) {
 	actor2 := world.ECS.NewEntity()
 	world.Components.TurnBased.Add(actor2, &gc.TurnBased{})
 
-	comp1, err := NewActivity(&WaitBehavior{}, 10)
+	comp1, err := NewActivity(gc.BehaviorWait, 10)
 	require.NoError(t, err)
-	comp2, err := NewActivity(&WaitBehavior{}, 5)
+	comp2, err := NewActivity(gc.BehaviorWait, 5)
 	require.NoError(t, err)
 
 	err = StartActivity(comp1, actor1, world)
@@ -339,7 +339,7 @@ func TestConsumePassCostWithPassCost(t *testing.T) {
 		// ExecuteはArchetypeを変える構造変更を伴うため、TurnBasedは都度取り直す
 		apBefore := world.Components.TurnBased.Get(player).AP.Current
 
-		_, err = Execute(&MoveBehavior{Destination: gc.GridElement{Coord: consts.Coord[consts.Tile]{X: 11, Y: 10}}}, player, world)
+		_, err = Execute(NewMoveActivity(gc.GridElement{Coord: consts.Coord[consts.Tile]{X: 11, Y: 10}}), player, world)
 		require.NoError(t, err)
 
 		normalCost := apBefore - world.Components.TurnBased.Get(player).AP.Current
@@ -352,7 +352,7 @@ func TestConsumePassCostWithPassCost(t *testing.T) {
 		world.Components.GridElement.Add(prop, &gc.GridElement{Coord: consts.Coord[consts.Tile]{X: 12, Y: 10}})
 		world.Components.PassCost.Add(prop, &gc.PassCost{Value: 50})
 
-		_, err = Execute(&MoveBehavior{Destination: gc.GridElement{Coord: consts.Coord[consts.Tile]{X: 12, Y: 10}}}, player, world)
+		_, err = Execute(NewMoveActivity(gc.GridElement{Coord: consts.Coord[consts.Tile]{X: 12, Y: 10}}), player, world)
 		require.NoError(t, err)
 
 		modCost := apBefore - world.Components.TurnBased.Get(player).AP.Current
@@ -371,7 +371,7 @@ func TestLastActivity(t *testing.T) {
 		player, err := lifecycle.SpawnPlayer(world, consts.Coord[consts.Tile]{X: 5, Y: 5}, "Ash")
 		require.NoError(t, err)
 
-		_, err = Execute(&WaitBehavior{Duration: 1, Reason: "テスト"}, player, world)
+		_, err = Execute(NewWaitActivity(1), player, world)
 		require.NoError(t, err)
 
 		// 待機回数1は初回ステップで Required に達するので即時アクションとして完了する
@@ -393,7 +393,7 @@ func TestLastActivity(t *testing.T) {
 		require.NoError(t, err)
 
 		// 待機
-		_, err = Execute(&WaitBehavior{Duration: 1, Reason: "待機"}, player, world)
+		_, err = Execute(NewWaitActivity(1), player, world)
 		require.NoError(t, err)
 
 		// 待機回数1は初回ステップで完了する即時アクション
@@ -407,7 +407,7 @@ func TestLastActivity(t *testing.T) {
 		assert.Equal(t, expected, result)
 
 		// 移動
-		_, err = Execute(&MoveBehavior{Destination: gc.GridElement{Coord: consts.Coord[consts.Tile]{X: 10, Y: 9}}}, player, world)
+		_, err = Execute(NewMoveActivity(gc.GridElement{Coord: consts.Coord[consts.Tile]{X: 10, Y: 9}}), player, world)
 		require.NoError(t, err)
 
 		result = GetLastResult(player, world)
@@ -429,7 +429,7 @@ func TestLastActivity(t *testing.T) {
 
 		// 存在しないターゲットへの攻撃（失敗する）
 		nonExistentEntity := gc.InvalidEntity
-		_, _ = Execute(&AttackBehavior{Target: nonExistentEntity}, player, world)
+		_, _ = Execute(NewAttackActivity(nonExistentEntity), player, world)
 
 		result := GetLastResult(player, world)
 		expected := &gc.LastActivity{

--- a/internal/activity/activity_manager_test.go
+++ b/internal/activity/activity_manager_test.go
@@ -128,7 +128,7 @@ func TestReplaceActivity(t *testing.T) {
 	currentActivity := query.GetActivity(world, actor)
 	require.NotNil(t, currentActivity)
 	assert.Equal(t, gc.ActivityStateRunning, currentActivity.State, "Expected replaced activity to be running")
-	assert.Equal(t, comp2.TurnsTotal, currentActivity.TurnsTotal, "Expected current activity to be the second activity")
+	assert.Equal(t, comp2.Required, currentActivity.Required, "Expected current activity to be the second activity")
 }
 
 func TestInterruptAndResume(t *testing.T) {
@@ -228,16 +228,16 @@ func TestProcessContinuousActivities(t *testing.T) {
 	// 1ターン目処理
 	ProcessContinuousActivities(world)
 
-	// 両方まだ実行中。Arkは値で格納するため格納側を取り直して検証する
-	assert.Equal(t, consts.Turn(1), query.GetActivity(world, actor1).TurnsLeft, "Expected short activity to have 1 turn left")
-	assert.Equal(t, consts.Turn(4), query.GetActivity(world, actor2).TurnsLeft, "Expected long activity to have 4 turns left")
+	// 両方まだ実行中。Arkは値で格納するため格納側を取り直して検証する。待機は毎ターン 1 累積する
+	assert.Equal(t, 1, query.GetActivity(world, actor1).Accumulated, "Expected short activity to have accumulated 1")
+	assert.Equal(t, 1, query.GetActivity(world, actor2).Accumulated, "Expected long activity to have accumulated 1")
 
 	// 2ターン目処理
 	ProcessContinuousActivities(world)
 
 	// 短いアクティビティが完了。完了時は削除されるため結果コンポーネントで確認する
 	assert.Equal(t, gc.ActivityStateCompleted, GetLastResult(actor1, world).State, "Expected short activity to be completed")
-	assert.Equal(t, consts.Turn(3), query.GetActivity(world, actor2).TurnsLeft, "Expected long activity to have 3 turns left")
+	assert.Equal(t, 2, query.GetActivity(world, actor2).Accumulated, "Expected long activity to have accumulated 2")
 
 	// 完了したアクティビティは管理対象から削除される
 	assert.Nil(t, query.GetActivity(world, actor1), "Expected completed activity to be removed")
@@ -374,12 +374,13 @@ func TestLastActivity(t *testing.T) {
 		_, err = Execute(&WaitBehavior{Duration: 1, Reason: "テスト"}, player, world)
 		require.NoError(t, err)
 
+		// 待機は Required>0 の継続アクションなので Execute では開始のみ記録される
 		result := GetLastResult(player, world)
 		expected := &gc.LastActivity{
 			BehaviorName: gc.BehaviorWait,
-			State:        gc.ActivityStateCompleted,
+			State:        gc.ActivityStateRunning,
 			Success:      true,
-			Message:      "アクション完了",
+			Message:      "アクション開始",
 		}
 		assert.Equal(t, expected, result)
 	})
@@ -395,12 +396,13 @@ func TestLastActivity(t *testing.T) {
 		_, err = Execute(&WaitBehavior{Duration: 1, Reason: "待機"}, player, world)
 		require.NoError(t, err)
 
+		// 待機は継続アクションなので開始のみ記録される
 		result := GetLastResult(player, world)
 		expected := &gc.LastActivity{
 			BehaviorName: gc.BehaviorWait,
-			State:        gc.ActivityStateCompleted,
+			State:        gc.ActivityStateRunning,
 			Success:      true,
-			Message:      "アクション完了",
+			Message:      "アクション開始",
 		}
 		assert.Equal(t, expected, result)
 

--- a/internal/activity/activity_manager_test.go
+++ b/internal/activity/activity_manager_test.go
@@ -128,7 +128,7 @@ func TestReplaceActivity(t *testing.T) {
 	currentActivity := query.GetActivity(world, actor)
 	require.NotNil(t, currentActivity)
 	assert.Equal(t, gc.ActivityStateRunning, currentActivity.State, "Expected replaced activity to be running")
-	assert.Equal(t, comp2.Required, currentActivity.Required, "Expected current activity to be the second activity")
+	assert.Equal(t, comp2.Progress.Max, currentActivity.Progress.Max, "Expected current activity to be the second activity")
 }
 
 func TestInterruptAndResume(t *testing.T) {
@@ -229,15 +229,15 @@ func TestProcessContinuousActivities(t *testing.T) {
 	ProcessContinuousActivities(world)
 
 	// 両方まだ実行中。Arkは値で格納するため格納側を取り直して検証する。待機は毎ターン 1 累積する
-	assert.Equal(t, 1, query.GetActivity(world, actor1).Accumulated, "Expected short activity to have accumulated 1")
-	assert.Equal(t, 1, query.GetActivity(world, actor2).Accumulated, "Expected long activity to have accumulated 1")
+	assert.Equal(t, 1, query.GetActivity(world, actor1).Progress.Current, "Expected short activity to have accumulated 1")
+	assert.Equal(t, 1, query.GetActivity(world, actor2).Progress.Current, "Expected long activity to have accumulated 1")
 
 	// 2ターン目処理
 	ProcessContinuousActivities(world)
 
 	// 短いアクティビティが完了。完了時は削除されるため結果コンポーネントで確認する
 	assert.Equal(t, gc.ActivityStateCompleted, GetLastResult(actor1, world).State, "Expected short activity to be completed")
-	assert.Equal(t, 2, query.GetActivity(world, actor2).Accumulated, "Expected long activity to have accumulated 2")
+	assert.Equal(t, 2, query.GetActivity(world, actor2).Progress.Current, "Expected long activity to have accumulated 2")
 
 	// 完了したアクティビティは管理対象から削除される
 	assert.Nil(t, query.GetActivity(world, actor1), "Expected completed activity to be removed")

--- a/internal/activity/activity_manager_test.go
+++ b/internal/activity/activity_manager_test.go
@@ -374,13 +374,13 @@ func TestLastActivity(t *testing.T) {
 		_, err = Execute(&WaitBehavior{Duration: 1, Reason: "テスト"}, player, world)
 		require.NoError(t, err)
 
-		// 待機は Required>0 の継続アクションなので Execute では開始のみ記録される
+		// 待機回数1は初回ステップで Required に達するので即時アクションとして完了する
 		result := GetLastResult(player, world)
 		expected := &gc.LastActivity{
 			BehaviorName: gc.BehaviorWait,
-			State:        gc.ActivityStateRunning,
+			State:        gc.ActivityStateCompleted,
 			Success:      true,
-			Message:      "アクション開始",
+			Message:      "アクション完了",
 		}
 		assert.Equal(t, expected, result)
 	})
@@ -396,13 +396,13 @@ func TestLastActivity(t *testing.T) {
 		_, err = Execute(&WaitBehavior{Duration: 1, Reason: "待機"}, player, world)
 		require.NoError(t, err)
 
-		// 待機は継続アクションなので開始のみ記録される
+		// 待機回数1は初回ステップで完了する即時アクション
 		result := GetLastResult(player, world)
 		expected := &gc.LastActivity{
 			BehaviorName: gc.BehaviorWait,
-			State:        gc.ActivityStateRunning,
+			State:        gc.ActivityStateCompleted,
 			Success:      true,
-			Message:      "アクション開始",
+			Message:      "アクション完了",
 		}
 		assert.Equal(t, expected, result)
 

--- a/internal/activity/activity_manager_test.go
+++ b/internal/activity/activity_manager_test.go
@@ -49,11 +49,10 @@ func TestStartActivity(t *testing.T) {
 	world.Components.TurnBased.Add(actor, &gc.TurnBased{})
 
 	// アクティビティを作成
-	comp, err := NewActivity(gc.BehaviorWait, 5)
-	require.NoError(t, err)
+	comp := NewActivity(gc.BehaviorWait, 5)
 
 	// アクティビティ開始
-	err = StartActivity(comp, actor, world)
+	err := StartActivity(comp, actor, world)
 	require.NoError(t, err)
 
 	// アクティビティが登録されているかチェック
@@ -79,12 +78,10 @@ func TestMultipleActivities(t *testing.T) {
 	world.Components.TurnBased.Add(actor2, &gc.TurnBased{})
 
 	// 複数のアクターでアクティビティを開始
-	comp1, err := NewActivity(gc.BehaviorWait, 10)
-	require.NoError(t, err)
-	comp2, err := NewActivity(gc.BehaviorWait, 5)
-	require.NoError(t, err)
+	comp1 := NewActivity(gc.BehaviorWait, 10)
+	comp2 := NewActivity(gc.BehaviorWait, 5)
 
-	err = StartActivity(comp1, actor1, world)
+	err := StartActivity(comp1, actor1, world)
 	require.NoError(t, err)
 
 	err = StartActivity(comp2, actor2, world)
@@ -109,17 +106,15 @@ func TestReplaceActivity(t *testing.T) {
 	world.Components.TurnBased.Add(actor, &gc.TurnBased{})
 
 	// 最初のアクティビティを開始
-	comp1, err := NewActivity(gc.BehaviorWait, 10)
-	require.NoError(t, err)
-	err = StartActivity(comp1, actor, world)
+	comp1 := NewActivity(gc.BehaviorWait, 10)
+	err := StartActivity(comp1, actor, world)
 	require.NoError(t, err)
 
 	// 最初のアクティビティが実行中であることを確認
 	assert.Equal(t, gc.ActivityStateRunning, comp1.State, "Expected first activity to be running")
 
 	// 新しいアクティビティを開始（古いものを置き換え）
-	comp2, err := NewActivity(gc.BehaviorWait, 5)
-	require.NoError(t, err)
+	comp2 := NewActivity(gc.BehaviorWait, 5)
 	err = StartActivity(comp2, actor, world)
 	require.NoError(t, err)
 
@@ -138,9 +133,8 @@ func TestInterruptAndResume(t *testing.T) {
 	world.Components.TurnBased.Add(actor, &gc.TurnBased{})
 
 	// アクティビティを開始
-	comp, err := NewActivity(gc.BehaviorWait, 10)
-	require.NoError(t, err)
-	err = StartActivity(comp, actor, world)
+	comp := NewActivity(gc.BehaviorWait, 10)
+	err := StartActivity(comp, actor, world)
 	require.NoError(t, err)
 
 	// アクティビティを中断
@@ -177,9 +171,8 @@ func TestCancelActivity(t *testing.T) {
 	world.Components.TurnBased.Add(actor, &gc.TurnBased{})
 
 	// アクティビティを開始
-	comp, err := NewActivity(gc.BehaviorWait, 5)
-	require.NoError(t, err)
-	err = StartActivity(comp, actor, world)
+	comp := NewActivity(gc.BehaviorWait, 5)
+	err := StartActivity(comp, actor, world)
 	require.NoError(t, err)
 
 	// アクティビティをキャンセル
@@ -210,12 +203,10 @@ func TestProcessContinuousActivities(t *testing.T) {
 	world.Components.GridElement.Add(actor2, &gc.GridElement{Coord: consts.Coord[consts.Tile]{X: 6, Y: 5}})
 
 	// 短いアクティビティと長いアクティビティを開始
-	shortComp, err := NewActivity(gc.BehaviorWait, 2) // 2ターンで完了
-	require.NoError(t, err)
-	longComp, err := NewActivity(gc.BehaviorWait, 5) // 5ターンで完了
-	require.NoError(t, err)
+	shortComp := NewActivity(gc.BehaviorWait, 2) // 2ターンで完了
+	longComp := NewActivity(gc.BehaviorWait, 5)  // 5ターンで完了
 
-	err = StartActivity(shortComp, actor1, world)
+	err := StartActivity(shortComp, actor1, world)
 	require.NoError(t, err)
 	err = StartActivity(longComp, actor2, world)
 	require.NoError(t, err)
@@ -264,12 +255,10 @@ func TestActivitySummary(t *testing.T) {
 	actor2 := world.ECS.NewEntity()
 	world.Components.TurnBased.Add(actor2, &gc.TurnBased{})
 
-	comp1, err := NewActivity(gc.BehaviorWait, 10)
-	require.NoError(t, err)
-	comp2, err := NewActivity(gc.BehaviorWait, 5)
-	require.NoError(t, err)
+	comp1 := NewActivity(gc.BehaviorWait, 10)
+	comp2 := NewActivity(gc.BehaviorWait, 5)
 
-	err = StartActivity(comp1, actor1, world)
+	err := StartActivity(comp1, actor1, world)
 	require.NoError(t, err)
 	err = StartActivity(comp2, actor2, world)
 	require.NoError(t, err)

--- a/internal/activity/activity_test.go
+++ b/internal/activity/activity_test.go
@@ -20,8 +20,8 @@ func TestActivityCreation(t *testing.T) {
 
 	assert.Equal(t, gc.BehaviorRest, behavior.Name(), "Expected behavior to be Rest")
 	assert.Equal(t, gc.ActivityStateRunning, comp.State, "Expected initial state to be Running")
-	assert.Equal(t, 10, comp.Required, "Expected required 10")
-	assert.Equal(t, 0, comp.Accumulated, "Expected accumulated 0")
+	assert.Equal(t, 10, comp.Progress.Max, "Expected required 10")
+	assert.Equal(t, 0, comp.Progress.Current, "Expected accumulated 0")
 }
 
 func TestActivityInfo(t *testing.T) {
@@ -109,12 +109,12 @@ func TestActivityProgressCalculation(t *testing.T) {
 	assert.Equal(t, 0.0, progress, "Expected initial progress 0%%")
 
 	// 半分注いだ（50%）
-	comp.Accumulated = 5
+	comp.Progress.Current = 5
 	progress = GetProgressPercent(comp)
 	assert.Equal(t, 50.0, progress, "Expected progress 50%%")
 
 	// 必要量に達した（100%）
-	comp.Accumulated = 10
+	comp.Progress.Current = 10
 	progress = GetProgressPercent(comp)
 	assert.Equal(t, 100.0, progress, "Expected progress 100%%")
 }
@@ -134,18 +134,18 @@ func TestActivityDoTurn(t *testing.T) {
 	// 1ターン目
 	err = behavior.DoTurn(comp, actor, world)
 	require.NoError(t, err, "Unexpected error in turn 1")
-	assert.Equal(t, 1, comp.Accumulated, "Expected accumulated 1 after turn 1")
+	assert.Equal(t, 1, comp.Progress.Current, "Expected accumulated 1 after turn 1")
 	assert.False(t, IsCompleted(comp), "Expected activity not to be completed after turn 1")
 
 	// 2ターン目
 	err = behavior.DoTurn(comp, actor, world)
 	require.NoError(t, err, "Unexpected error in turn 2")
-	assert.Equal(t, 2, comp.Accumulated, "Expected accumulated 2 after turn 2")
+	assert.Equal(t, 2, comp.Progress.Current, "Expected accumulated 2 after turn 2")
 
 	// 3ターン目（完了）
 	err = behavior.DoTurn(comp, actor, world)
 	require.NoError(t, err, "Unexpected error in turn 3")
-	assert.Equal(t, 3, comp.Accumulated, "Expected accumulated 3 after turn 3")
+	assert.Equal(t, 3, comp.Progress.Current, "Expected accumulated 3 after turn 3")
 	assert.True(t, IsCompleted(comp), "Expected activity to be completed after turn 3")
 }
 
@@ -173,7 +173,7 @@ func TestNewActivityInvalidRequired(t *testing.T) {
 		t.Parallel()
 		comp, err := NewActivity(&WaitBehavior{}, 0)
 		require.NoError(t, err)
-		assert.Equal(t, 0, comp.Required)
+		assert.Equal(t, 0, comp.Progress.Max)
 	})
 
 	t.Run("負のrequiredでエラー", func(t *testing.T) {
@@ -188,7 +188,7 @@ func TestGetProgressPercentEdgeCases(t *testing.T) {
 
 	t.Run("Required 0の場合は100%を返す", func(t *testing.T) {
 		t.Parallel()
-		comp := &gc.Activity{Required: 0}
+		comp := &gc.Activity{Progress: gc.IntPool{Max: 0}}
 		assert.Equal(t, 100.0, GetProgressPercent(comp))
 	})
 }

--- a/internal/activity/activity_test.go
+++ b/internal/activity/activity_test.go
@@ -20,8 +20,8 @@ func TestActivityCreation(t *testing.T) {
 
 	assert.Equal(t, gc.BehaviorRest, behavior.Name(), "Expected behavior to be Rest")
 	assert.Equal(t, gc.ActivityStateRunning, comp.State, "Expected initial state to be Running")
-	assert.Equal(t, consts.Turn(10), comp.TurnsTotal, "Expected turns total 10")
-	assert.Equal(t, consts.Turn(10), comp.TurnsLeft, "Expected turns left 10")
+	assert.Equal(t, 10, comp.Required, "Expected required 10")
+	assert.Equal(t, 0, comp.Accumulated, "Expected accumulated 0")
 }
 
 func TestActivityInfo(t *testing.T) {
@@ -95,7 +95,6 @@ func TestActivityComplete(t *testing.T) {
 	Complete(comp)
 
 	assert.Equal(t, gc.ActivityStateCompleted, comp.State, "Expected state to be Completed after complete")
-	assert.Equal(t, consts.Turn(0), comp.TurnsLeft, "Expected turns left 0 after complete")
 	assert.True(t, IsCompleted(comp), "Expected IsCompleted() to return true")
 }
 
@@ -109,13 +108,13 @@ func TestActivityProgressCalculation(t *testing.T) {
 	progress := GetProgressPercent(comp)
 	assert.Equal(t, 0.0, progress, "Expected initial progress 0%%")
 
-	// 5ターン進行（50%）
-	comp.TurnsLeft = 5
+	// 半分注いだ（50%）
+	comp.Accumulated = 5
 	progress = GetProgressPercent(comp)
 	assert.Equal(t, 50.0, progress, "Expected progress 50%%")
 
-	// 完了（100%）
-	comp.TurnsLeft = 0
+	// 必要量に達した（100%）
+	comp.Accumulated = 10
 	progress = GetProgressPercent(comp)
 	assert.Equal(t, 100.0, progress, "Expected progress 100%%")
 }
@@ -131,21 +130,22 @@ func TestActivityDoTurn(t *testing.T) {
 	comp, err := NewActivity(behavior, 3)
 	require.NoError(t, err)
 
+	// 待機は毎ターン 1 ずつ注ぐ純タイマー。Required 3 なので3ターンで完了する
 	// 1ターン目
 	err = behavior.DoTurn(comp, actor, world)
 	require.NoError(t, err, "Unexpected error in turn 1")
-	assert.Equal(t, consts.Turn(2), comp.TurnsLeft, "Expected 2 turns left after turn 1")
+	assert.Equal(t, 1, comp.Accumulated, "Expected accumulated 1 after turn 1")
 	assert.False(t, IsCompleted(comp), "Expected activity not to be completed after turn 1")
 
 	// 2ターン目
 	err = behavior.DoTurn(comp, actor, world)
 	require.NoError(t, err, "Unexpected error in turn 2")
-	assert.Equal(t, consts.Turn(1), comp.TurnsLeft, "Expected 1 turn left after turn 2")
+	assert.Equal(t, 2, comp.Accumulated, "Expected accumulated 2 after turn 2")
 
 	// 3ターン目（完了）
 	err = behavior.DoTurn(comp, actor, world)
 	require.NoError(t, err, "Unexpected error in turn 3")
-	assert.Equal(t, consts.Turn(0), comp.TurnsLeft, "Expected 0 turns left after turn 3")
+	assert.Equal(t, 3, comp.Accumulated, "Expected accumulated 3 after turn 3")
 	assert.True(t, IsCompleted(comp), "Expected activity to be completed after turn 3")
 }
 
@@ -166,57 +166,30 @@ func TestGetBehavior(t *testing.T) {
 	})
 }
 
-func TestNewActivityInvalidDuration(t *testing.T) {
+func TestNewActivityInvalidRequired(t *testing.T) {
 	t.Parallel()
 
-	t.Run("duration 0でエラー", func(t *testing.T) {
+	t.Run("required 0は即時アクションとして正常", func(t *testing.T) {
 		t.Parallel()
-		_, err := NewActivity(&WaitBehavior{}, 0)
-		assert.Error(t, err)
+		comp, err := NewActivity(&WaitBehavior{}, 0)
+		require.NoError(t, err)
+		assert.Equal(t, 0, comp.Required)
 	})
 
-	t.Run("負のdurationでエラー", func(t *testing.T) {
+	t.Run("負のrequiredでエラー", func(t *testing.T) {
 		t.Parallel()
 		_, err := NewActivity(&WaitBehavior{}, -1)
-		assert.Error(t, err)
+		assert.ErrorIs(t, err, ErrInvalidRequired)
 	})
 }
 
 func TestGetProgressPercentEdgeCases(t *testing.T) {
 	t.Parallel()
 
-	t.Run("TurnsTotal 0の場合は100%を返す", func(t *testing.T) {
+	t.Run("Required 0の場合は100%を返す", func(t *testing.T) {
 		t.Parallel()
-		comp := &gc.Activity{TurnsTotal: 0, TurnsLeft: 0}
+		comp := &gc.Activity{Required: 0}
 		assert.Equal(t, 100.0, GetProgressPercent(comp))
-	})
-}
-
-func TestCalculateRequiredTurns(t *testing.T) {
-	t.Parallel()
-
-	t.Run("APベースの計算", func(t *testing.T) {
-		t.Parallel()
-		behavior := &RestBehavior{}
-		info := behavior.Info()
-		if info.TotalRequiredAP > 0 {
-			turns := CalculateRequiredTurns(behavior, 100)
-			assert.GreaterOrEqual(t, turns, consts.Turn(1))
-		}
-	})
-
-	t.Run("APとcharacterAPで正しく切り上げ除算する", func(t *testing.T) {
-		t.Parallel()
-		behavior := &WaitBehavior{} // TotalRequiredAP=500
-		turns := CalculateRequiredTurns(behavior, 100)
-		assert.Equal(t, consts.Turn(5), turns) // 500 / 100 = 5
-	})
-
-	t.Run("characterAPが0の場合は1を返す", func(t *testing.T) {
-		t.Parallel()
-		behavior := &RestBehavior{}
-		turns := CalculateRequiredTurns(behavior, 0)
-		assert.Equal(t, consts.Turn(1), turns)
 	})
 }
 
@@ -260,9 +233,13 @@ func TestIsActive(t *testing.T) {
 	})
 }
 
-func TestIsCompleted_TurnsLeftZero(t *testing.T) {
+func TestIsCompleted_StateBased(t *testing.T) {
 	t.Parallel()
 
-	comp := &gc.Activity{State: gc.ActivityStateRunning, TurnsLeft: 0}
-	assert.True(t, IsCompleted(comp), "TurnsLeftが0ならCompletedとみなす")
+	// 完了は State のみで判定する。残りターンという概念は廃止した
+	running := &gc.Activity{State: gc.ActivityStateRunning}
+	assert.False(t, IsCompleted(running), "Running は未完了")
+
+	completed := &gc.Activity{State: gc.ActivityStateCompleted}
+	assert.True(t, IsCompleted(completed), "Completed は完了")
 }

--- a/internal/activity/activity_test.go
+++ b/internal/activity/activity_test.go
@@ -15,8 +15,7 @@ func TestActivityCreation(t *testing.T) {
 
 	// 休息アクティビティの作成テスト
 	behavior := &RestBehavior{}
-	comp, err := NewActivity(gc.BehaviorRest, 10)
-	require.NoError(t, err)
+	comp := NewActivity(gc.BehaviorRest, 10)
 
 	assert.Equal(t, gc.BehaviorRest, behavior.Name(), "Expected behavior to be Rest")
 	assert.Equal(t, gc.ActivityStateRunning, comp.State, "Expected initial state to be Running")
@@ -38,14 +37,13 @@ func TestActivityInfo(t *testing.T) {
 func TestActivityInterruptAndResume(t *testing.T) {
 	t.Parallel()
 
-	comp, err := NewActivity(gc.BehaviorRest, 10)
-	require.NoError(t, err)
+	comp := NewActivity(gc.BehaviorRest, 10)
 
 	// 初期状態での中断可能性チェック
 	assert.True(t, CanInterrupt(comp), "Expected activity to be interruptible initially")
 
 	// 中断実行
-	err = Interrupt(comp, "テスト中断")
+	err := Interrupt(comp, "テスト中断")
 	require.NoError(t, err, "Unexpected error during interrupt")
 	assert.Equal(t, gc.ActivityStatePaused, comp.State, "Expected state to be Paused after interrupt")
 	assert.Equal(t, "テスト中断", comp.CancelReason, "Expected cancel reason 'テスト中断'")
@@ -67,8 +65,7 @@ func TestActivityInterruptAndResume(t *testing.T) {
 func TestActivityCancel(t *testing.T) {
 	t.Parallel()
 
-	comp, err := NewActivity(gc.BehaviorWait, 5)
-	require.NoError(t, err)
+	comp := NewActivity(gc.BehaviorWait, 5)
 
 	// キャンセル前はIsCanceledがfalse
 	assert.False(t, IsCanceled(comp), "Expected IsCanceled to be false before cancel")
@@ -88,8 +85,7 @@ func TestActivityCancel(t *testing.T) {
 func TestActivityComplete(t *testing.T) {
 	t.Parallel()
 
-	comp, err := NewActivity(gc.BehaviorWait, 5)
-	require.NoError(t, err)
+	comp := NewActivity(gc.BehaviorWait, 5)
 
 	// 完了実行
 	Complete(comp)
@@ -101,8 +97,7 @@ func TestActivityComplete(t *testing.T) {
 func TestActivityProgressCalculation(t *testing.T) {
 	t.Parallel()
 
-	comp, err := NewActivity(gc.BehaviorRest, 10)
-	require.NoError(t, err)
+	comp := NewActivity(gc.BehaviorRest, 10)
 
 	// 初期進捗（0%）
 	progress := GetProgressPercent(comp)
@@ -127,12 +122,11 @@ func TestActivityDoTurn(t *testing.T) {
 	// 長い待機の敵接近チェックは位置を前提とするため、実際のアクターと同様に座標を与える
 	world.Components.GridElement.Add(actor, &gc.GridElement{Coord: consts.Coord[consts.Tile]{X: 5, Y: 5}})
 	behavior := &WaitBehavior{}
-	comp, err := NewActivity(gc.BehaviorWait, 3)
-	require.NoError(t, err)
+	comp := NewActivity(gc.BehaviorWait, 3)
 
 	// 待機は毎ターン 1 ずつ注ぐ純タイマー。Required 3 なので3ターンで完了する
 	// 1ターン目
-	err = behavior.DoTurn(comp, actor, world)
+	err := behavior.DoTurn(comp, actor, world)
 	require.NoError(t, err, "Unexpected error in turn 1")
 	assert.Equal(t, 1, comp.Progress.Current, "Expected accumulated 1 after turn 1")
 	assert.False(t, IsCompleted(comp), "Expected activity not to be completed after turn 1")
@@ -166,21 +160,11 @@ func TestGetBehavior(t *testing.T) {
 	})
 }
 
-func TestNewActivityInvalidRequired(t *testing.T) {
+func TestNewActivity(t *testing.T) {
 	t.Parallel()
-
-	t.Run("required 0は即時アクションとして正常", func(t *testing.T) {
-		t.Parallel()
-		comp, err := NewActivity(gc.BehaviorWait, 0)
-		require.NoError(t, err)
-		assert.Equal(t, 0, comp.Progress.Max)
-	})
-
-	t.Run("負のrequiredでエラー", func(t *testing.T) {
-		t.Parallel()
-		_, err := NewActivity(gc.BehaviorWait, -1)
-		assert.ErrorIs(t, err, ErrInvalidRequired)
-	})
+	comp := NewActivity(gc.BehaviorWait, 0)
+	assert.Equal(t, gc.BehaviorWait, comp.BehaviorName)
+	assert.Equal(t, 0, comp.Progress.Max)
 }
 
 func TestGetProgressPercentEdgeCases(t *testing.T) {

--- a/internal/activity/activity_test.go
+++ b/internal/activity/activity_test.go
@@ -15,7 +15,7 @@ func TestActivityCreation(t *testing.T) {
 
 	// 休息アクティビティの作成テスト
 	behavior := &RestBehavior{}
-	comp, err := NewActivity(behavior, 10)
+	comp, err := NewActivity(gc.BehaviorRest, 10)
 	require.NoError(t, err)
 
 	assert.Equal(t, gc.BehaviorRest, behavior.Name(), "Expected behavior to be Rest")
@@ -38,7 +38,7 @@ func TestActivityInfo(t *testing.T) {
 func TestActivityInterruptAndResume(t *testing.T) {
 	t.Parallel()
 
-	comp, err := NewActivity(&RestBehavior{}, 10)
+	comp, err := NewActivity(gc.BehaviorRest, 10)
 	require.NoError(t, err)
 
 	// 初期状態での中断可能性チェック
@@ -67,7 +67,7 @@ func TestActivityInterruptAndResume(t *testing.T) {
 func TestActivityCancel(t *testing.T) {
 	t.Parallel()
 
-	comp, err := NewActivity(&WaitBehavior{}, 5)
+	comp, err := NewActivity(gc.BehaviorWait, 5)
 	require.NoError(t, err)
 
 	// キャンセル前はIsCanceledがfalse
@@ -88,7 +88,7 @@ func TestActivityCancel(t *testing.T) {
 func TestActivityComplete(t *testing.T) {
 	t.Parallel()
 
-	comp, err := NewActivity(&WaitBehavior{}, 5)
+	comp, err := NewActivity(gc.BehaviorWait, 5)
 	require.NoError(t, err)
 
 	// 完了実行
@@ -101,7 +101,7 @@ func TestActivityComplete(t *testing.T) {
 func TestActivityProgressCalculation(t *testing.T) {
 	t.Parallel()
 
-	comp, err := NewActivity(&RestBehavior{}, 10)
+	comp, err := NewActivity(gc.BehaviorRest, 10)
 	require.NoError(t, err)
 
 	// 初期進捗（0%）
@@ -127,7 +127,7 @@ func TestActivityDoTurn(t *testing.T) {
 	// 長い待機の敵接近チェックは位置を前提とするため、実際のアクターと同様に座標を与える
 	world.Components.GridElement.Add(actor, &gc.GridElement{Coord: consts.Coord[consts.Tile]{X: 5, Y: 5}})
 	behavior := &WaitBehavior{}
-	comp, err := NewActivity(behavior, 3)
+	comp, err := NewActivity(gc.BehaviorWait, 3)
 	require.NoError(t, err)
 
 	// 待機は毎ターン 1 ずつ注ぐ純タイマー。Required 3 なので3ターンで完了する
@@ -171,14 +171,14 @@ func TestNewActivityInvalidRequired(t *testing.T) {
 
 	t.Run("required 0は即時アクションとして正常", func(t *testing.T) {
 		t.Parallel()
-		comp, err := NewActivity(&WaitBehavior{}, 0)
+		comp, err := NewActivity(gc.BehaviorWait, 0)
 		require.NoError(t, err)
 		assert.Equal(t, 0, comp.Progress.Max)
 	})
 
 	t.Run("負のrequiredでエラー", func(t *testing.T) {
 		t.Parallel()
-		_, err := NewActivity(&WaitBehavior{}, -1)
+		_, err := NewActivity(gc.BehaviorWait, -1)
 		assert.ErrorIs(t, err, ErrInvalidRequired)
 	})
 }

--- a/internal/activity/attack.go
+++ b/internal/activity/attack.go
@@ -46,13 +46,14 @@ func (ab *AttackBehavior) Name() gc.BehaviorName {
 // NewAttackActivity は攻撃対象を指定して攻撃アクティビティを組む。
 func NewAttackActivity(target ecs.Entity) *gc.Activity {
 	comp := NewActivity(gc.BehaviorAttack, 0)
-	comp.Target = &target
+	comp.Params = &gc.TargetParams{Target: target}
 	return comp
 }
 
 // Validate はBehaviorの実装
 func (ab *AttackBehavior) Validate(comp *gc.Activity, actor ecs.Entity, world w.World) error {
-	if comp.Target == nil {
+	p, ok := comp.Params.(*gc.TargetParams)
+	if !ok {
 		return ErrAttackTargetNotSet
 	}
 
@@ -61,19 +62,19 @@ func (ab *AttackBehavior) Validate(comp *gc.Activity, actor ecs.Entity, world w.
 	}
 
 	// ゼロ値・死亡エンティティはArkのHasでパニックするため先に弾く
-	if !world.ECS.Alive(*comp.Target) {
+	if !world.ECS.Alive(p.Target) {
 		return ErrAttackTargetNotExists
 	}
 
-	if !world.Components.GridElement.Has(*comp.Target) {
+	if !world.Components.GridElement.Has(p.Target) {
 		return ErrAttackTargetNotExists
 	}
 
-	if world.Components.Dead.Has(*comp.Target) {
+	if world.Components.Dead.Has(p.Target) {
 		return ErrAttackTargetDead
 	}
 
-	if !ab.isInRange(actor, *comp.Target, world) {
+	if !ab.isInRange(actor, p.Target, world) {
 		return ErrAttackOutOfRange
 	}
 
@@ -86,13 +87,15 @@ func (ab *AttackBehavior) Validate(comp *gc.Activity, actor ecs.Entity, world w.
 
 // Start はBehaviorの実装
 func (ab *AttackBehavior) Start(comp *gc.Activity, actor ecs.Entity, _ w.World) error {
-	log.Debug("攻撃開始", "actor", actor, "target", *comp.Target)
+	if p, ok := comp.Params.(*gc.TargetParams); ok {
+		log.Debug("攻撃開始", "actor", actor, "target", p.Target)
+	}
 	return nil
 }
 
 // DoTurn はBehaviorの実装
 func (ab *AttackBehavior) DoTurn(comp *gc.Activity, actor ecs.Entity, world w.World) error {
-	if comp.Target == nil {
+	if _, ok := comp.Params.(*gc.TargetParams); !ok {
 		Cancel(comp, "攻撃対象が設定されていません")
 		return ErrAttackTargetNotSet
 	}
@@ -113,13 +116,14 @@ func (ab *AttackBehavior) DoTurn(comp *gc.Activity, actor ecs.Entity, world w.Wo
 
 // Finish はBehaviorの実装
 func (ab *AttackBehavior) Finish(comp *gc.Activity, actor ecs.Entity, _ w.World) error {
-	if comp.Target == nil {
+	p, ok := comp.Params.(*gc.TargetParams)
+	if !ok {
 		log.Debug("攻撃対象が未設定のまま完了処理に到達した。攻撃は実行されていない", "actor", actor)
 		return nil
 	}
 	log.Debug("攻撃アクティビティ完了",
 		"actor", actor,
-		"target", *comp.Target)
+		"target", p.Target)
 
 	return nil
 }
@@ -131,7 +135,11 @@ func (ab *AttackBehavior) Canceled(comp *gc.Activity, actor ecs.Entity, _ w.Worl
 }
 
 func (ab *AttackBehavior) performAttack(comp *gc.Activity, actor ecs.Entity, world w.World) error {
-	target := *comp.Target
+	p, ok := comp.Params.(*gc.TargetParams)
+	if !ok {
+		return ErrAttackTargetNotSet
+	}
+	target := p.Target
 
 	log.Debug("攻撃実行", "attacker", actor, "target", target)
 
@@ -144,7 +152,7 @@ func (ab *AttackBehavior) performAttack(comp *gc.Activity, actor ecs.Entity, wor
 }
 
 func (ab *AttackBehavior) canAttack(comp *gc.Activity, actor ecs.Entity, world w.World) bool {
-	if comp.Target == nil {
+	if _, ok := comp.Params.(*gc.TargetParams); !ok {
 		return false
 	}
 

--- a/internal/activity/attack.go
+++ b/internal/activity/attack.go
@@ -45,7 +45,7 @@ func (ab *AttackBehavior) Name() gc.BehaviorName {
 
 // NewAttackActivity は攻撃対象を指定して攻撃アクティビティを組む。
 func NewAttackActivity(target ecs.Entity) *gc.Activity {
-	comp := newActivity(gc.BehaviorAttack, 0)
+	comp := NewActivity(gc.BehaviorAttack, 0)
 	comp.Target = &target
 	return comp
 }

--- a/internal/activity/attack.go
+++ b/internal/activity/attack.go
@@ -47,7 +47,7 @@ func (ab *AttackBehavior) Name() gc.BehaviorName {
 
 // BuildActivity はBehaviorの実装
 func (ab *AttackBehavior) BuildActivity(_ ecs.Entity, _ w.World) (*gc.Activity, error) {
-	comp, err := NewActivity(ab, 1)
+	comp, err := NewActivity(ab, 0)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/activity/attack.go
+++ b/internal/activity/attack.go
@@ -24,9 +24,7 @@ const (
 )
 
 // AttackBehavior はBehaviorの実装
-type AttackBehavior struct {
-	Target ecs.Entity
-}
+type AttackBehavior struct{}
 
 // Info はBehaviorの実装
 func (ab *AttackBehavior) Info() Info {
@@ -45,14 +43,11 @@ func (ab *AttackBehavior) Name() gc.BehaviorName {
 	return gc.BehaviorAttack
 }
 
-// BuildActivity はBehaviorの実装
-func (ab *AttackBehavior) BuildActivity(_ ecs.Entity, _ w.World) (*gc.Activity, error) {
-	comp, err := NewActivity(ab, 0)
-	if err != nil {
-		return nil, err
-	}
-	comp.Target = &ab.Target
-	return comp, nil
+// NewAttackActivity は攻撃対象を指定して攻撃アクティビティを組む。
+func NewAttackActivity(target ecs.Entity) *gc.Activity {
+	comp := newActivity(gc.BehaviorAttack, 0)
+	comp.Target = &target
+	return comp
 }
 
 // Validate はBehaviorの実装

--- a/internal/activity/attack.go
+++ b/internal/activity/attack.go
@@ -46,13 +46,13 @@ func (ab *AttackBehavior) Name() gc.BehaviorName {
 // NewAttackActivity は攻撃対象を指定して攻撃アクティビティを組む。
 func NewAttackActivity(target ecs.Entity) *gc.Activity {
 	comp := NewActivity(gc.BehaviorAttack, 0)
-	comp.Params = &gc.TargetParams{Target: target}
+	comp.Params = &gc.AttackParams{Target: target}
 	return comp
 }
 
 // Validate はBehaviorの実装
 func (ab *AttackBehavior) Validate(comp *gc.Activity, actor ecs.Entity, world w.World) error {
-	p, ok := comp.Params.(*gc.TargetParams)
+	p, ok := comp.Params.(*gc.AttackParams)
 	if !ok {
 		return ErrAttackTargetNotSet
 	}
@@ -87,7 +87,7 @@ func (ab *AttackBehavior) Validate(comp *gc.Activity, actor ecs.Entity, world w.
 
 // Start はBehaviorの実装
 func (ab *AttackBehavior) Start(comp *gc.Activity, actor ecs.Entity, _ w.World) error {
-	if p, ok := comp.Params.(*gc.TargetParams); ok {
+	if p, ok := comp.Params.(*gc.AttackParams); ok {
 		log.Debug("攻撃開始", "actor", actor, "target", p.Target)
 	}
 	return nil
@@ -95,7 +95,7 @@ func (ab *AttackBehavior) Start(comp *gc.Activity, actor ecs.Entity, _ w.World) 
 
 // DoTurn はBehaviorの実装
 func (ab *AttackBehavior) DoTurn(comp *gc.Activity, actor ecs.Entity, world w.World) error {
-	if _, ok := comp.Params.(*gc.TargetParams); !ok {
+	if _, ok := comp.Params.(*gc.AttackParams); !ok {
 		Cancel(comp, "攻撃対象が設定されていません")
 		return ErrAttackTargetNotSet
 	}
@@ -116,7 +116,7 @@ func (ab *AttackBehavior) DoTurn(comp *gc.Activity, actor ecs.Entity, world w.Wo
 
 // Finish はBehaviorの実装
 func (ab *AttackBehavior) Finish(comp *gc.Activity, actor ecs.Entity, _ w.World) error {
-	p, ok := comp.Params.(*gc.TargetParams)
+	p, ok := comp.Params.(*gc.AttackParams)
 	if !ok {
 		log.Debug("攻撃対象が未設定のまま完了処理に到達した。攻撃は実行されていない", "actor", actor)
 		return nil
@@ -135,7 +135,7 @@ func (ab *AttackBehavior) Canceled(comp *gc.Activity, actor ecs.Entity, _ w.Worl
 }
 
 func (ab *AttackBehavior) performAttack(comp *gc.Activity, actor ecs.Entity, world w.World) error {
-	p, ok := comp.Params.(*gc.TargetParams)
+	p, ok := comp.Params.(*gc.AttackParams)
 	if !ok {
 		return ErrAttackTargetNotSet
 	}
@@ -152,7 +152,7 @@ func (ab *AttackBehavior) performAttack(comp *gc.Activity, actor ecs.Entity, wor
 }
 
 func (ab *AttackBehavior) canAttack(comp *gc.Activity, actor ecs.Entity, world w.World) bool {
-	if _, ok := comp.Params.(*gc.TargetParams); !ok {
+	if _, ok := comp.Params.(*gc.AttackParams); !ok {
 		return false
 	}
 

--- a/internal/activity/attack_test.go
+++ b/internal/activity/attack_test.go
@@ -317,8 +317,7 @@ func TestApplyAttackDamage_InterruptsActivity(t *testing.T) {
 		})
 
 		// 中断可能なアクティビティ（休息）を設定
-		ra := &RestBehavior{}
-		comp, err := NewActivity(ra, 10)
+		comp, err := NewActivity(gc.BehaviorRest, 10)
 		require.NoError(t, err)
 		comp.State = gc.ActivityStateRunning
 		world.Components.Activity.Add(target, comp)
@@ -358,8 +357,7 @@ func TestApplyAttackDamage_InterruptsActivity(t *testing.T) {
 		})
 
 		// 中断不可のアクティビティ（攻撃）を設定
-		aa := &AttackBehavior{}
-		comp, err := NewActivity(aa, 0)
+		comp, err := NewActivity(gc.BehaviorAttack, 0)
 		require.NoError(t, err)
 		comp.State = gc.ActivityStateRunning
 		world.Components.Activity.Add(target, comp)
@@ -395,8 +393,7 @@ func TestApplyAttackDamage_InterruptsActivity(t *testing.T) {
 		})
 
 		// 中断不可のアクティビティ（攻撃）を設定
-		aa := &AttackBehavior{}
-		comp, err := NewActivity(aa, 0)
+		comp, err := NewActivity(gc.BehaviorAttack, 0)
 		require.NoError(t, err)
 		comp.State = gc.ActivityStateRunning
 		world.Components.Activity.Add(target, comp)

--- a/internal/activity/attack_test.go
+++ b/internal/activity/attack_test.go
@@ -317,8 +317,7 @@ func TestApplyAttackDamage_InterruptsActivity(t *testing.T) {
 		})
 
 		// 中断可能なアクティビティ（休息）を設定
-		comp, err := NewActivity(gc.BehaviorRest, 10)
-		require.NoError(t, err)
+		comp := NewActivity(gc.BehaviorRest, 10)
 		comp.State = gc.ActivityStateRunning
 		world.Components.Activity.Add(target, comp)
 
@@ -357,8 +356,7 @@ func TestApplyAttackDamage_InterruptsActivity(t *testing.T) {
 		})
 
 		// 中断不可のアクティビティ（攻撃）を設定
-		comp, err := NewActivity(gc.BehaviorAttack, 0)
-		require.NoError(t, err)
+		comp := NewActivity(gc.BehaviorAttack, 0)
 		comp.State = gc.ActivityStateRunning
 		world.Components.Activity.Add(target, comp)
 
@@ -393,8 +391,7 @@ func TestApplyAttackDamage_InterruptsActivity(t *testing.T) {
 		})
 
 		// 中断不可のアクティビティ（攻撃）を設定
-		comp, err := NewActivity(gc.BehaviorAttack, 0)
-		require.NoError(t, err)
+		comp := NewActivity(gc.BehaviorAttack, 0)
 		comp.State = gc.ActivityStateRunning
 		world.Components.Activity.Add(target, comp)
 

--- a/internal/activity/attack_test.go
+++ b/internal/activity/attack_test.go
@@ -359,7 +359,7 @@ func TestApplyAttackDamage_InterruptsActivity(t *testing.T) {
 
 		// 中断不可のアクティビティ（攻撃）を設定
 		aa := &AttackBehavior{}
-		comp, err := NewActivity(aa, 1)
+		comp, err := NewActivity(aa, 0)
 		require.NoError(t, err)
 		comp.State = gc.ActivityStateRunning
 		world.Components.Activity.Add(target, comp)
@@ -396,7 +396,7 @@ func TestApplyAttackDamage_InterruptsActivity(t *testing.T) {
 
 		// 中断不可のアクティビティ（攻撃）を設定
 		aa := &AttackBehavior{}
-		comp, err := NewActivity(aa, 1)
+		comp, err := NewActivity(aa, 0)
 		require.NoError(t, err)
 		comp.State = gc.ActivityStateRunning
 		world.Components.Activity.Add(target, comp)

--- a/internal/activity/disassemble.go
+++ b/internal/activity/disassemble.go
@@ -54,19 +54,20 @@ func NewDisassembleActivity(target, actor ecs.Entity, world w.World) (*gc.Activi
 
 	requiredAP := RequiredDisassemblyAP(int(def.BaseAP), mechanicSkillValue(actor, world), grade)
 	comp := NewActivity(gc.BehaviorDisassemble, requiredAP)
-	comp.Target = &target
+	comp.Params = &gc.TargetParams{Target: target}
 	return comp, nil
 }
 
 // Validate は分解アクティビティの検証を行う
 func (db *DisassembleBehavior) Validate(comp *gc.Activity, actor ecs.Entity, world w.World) error {
-	if comp.Target == nil {
+	p, ok := comp.Params.(*gc.TargetParams)
+	if !ok {
 		return fmt.Errorf("分解対象が指定されていません")
 	}
-	if !world.ECS.Alive(*comp.Target) {
+	if !world.ECS.Alive(p.Target) {
 		return fmt.Errorf("分解対象が存在しません")
 	}
-	def, ok := findDisassemblyDef(*comp.Target, world)
+	def, ok := findDisassemblyDef(p.Target, world)
 	if !ok {
 		return fmt.Errorf("対象は分解定義を持っていません")
 	}
@@ -81,7 +82,11 @@ func (db *DisassembleBehavior) Validate(comp *gc.Activity, actor ecs.Entity, wor
 
 // Start は分解開始時の処理を実行する
 func (db *DisassembleBehavior) Start(comp *gc.Activity, actor ecs.Entity, world w.World) error {
-	def, ok := findDisassemblyDef(*comp.Target, world)
+	p, ok := comp.Params.(*gc.TargetParams)
+	if !ok {
+		return fmt.Errorf("分解対象が指定されていません")
+	}
+	def, ok := findDisassemblyDef(p.Target, world)
 	if !ok {
 		return fmt.Errorf("分解定義が見つかりません")
 	}
@@ -90,7 +95,7 @@ func (db *DisassembleBehavior) Start(comp *gc.Activity, actor ecs.Entity, world 
 		return fmt.Errorf("分解に必要な工具を持っていません")
 	}
 
-	name := query.GetEntityName(*comp.Target, world)
+	name := query.GetEntityName(p.Target, world)
 	gamelog.New(query.GetGameLog(world)).
 		ItemName(toolName).
 		Append("で").
@@ -105,7 +110,12 @@ func (db *DisassembleBehavior) Start(comp *gc.Activity, actor ecs.Entity, world 
 // DoTurn は分解アクティビティの1ターン分の処理を実行する。
 // 対象が消えている可能性があるため、毎ターン先頭で生存を確認する
 func (db *DisassembleBehavior) DoTurn(comp *gc.Activity, actor ecs.Entity, world w.World) error {
-	if !world.ECS.Alive(*comp.Target) {
+	p, ok := comp.Params.(*gc.TargetParams)
+	if !ok {
+		Cancel(comp, "分解対象が指定されていません")
+		return nil
+	}
+	if !world.ECS.Alive(p.Target) {
 		Cancel(comp, "分解対象が消えたため中断")
 		return nil
 	}
@@ -113,7 +123,7 @@ func (db *DisassembleBehavior) DoTurn(comp *gc.Activity, actor ecs.Entity, world
 		Cancel(comp, "周囲に敵がいるため分解を中断")
 		return nil
 	}
-	def, ok := findDisassemblyDef(*comp.Target, world)
+	def, ok := findDisassemblyDef(p.Target, world)
 	if !ok {
 		Cancel(comp, "分解定義が見つからないため中断")
 		return nil
@@ -134,7 +144,11 @@ func (db *DisassembleBehavior) DoTurn(comp *gc.Activity, actor ecs.Entity, world
 // Finish は分解完了時の処理を実行する。産出を抽選し、propは足元へ落として
 // エンティティを除去、アイテムは1個消費して所持品へ加える
 func (db *DisassembleBehavior) Finish(comp *gc.Activity, actor ecs.Entity, world w.World) error {
-	target := *comp.Target
+	p, ok := comp.Params.(*gc.TargetParams)
+	if !ok {
+		return nil
+	}
+	target := p.Target
 	if !world.ECS.Alive(target) {
 		return nil
 	}
@@ -191,8 +205,8 @@ func (db *DisassembleBehavior) Finish(comp *gc.Activity, actor ecs.Entity, world
 func (db *DisassembleBehavior) Canceled(comp *gc.Activity, actor ecs.Entity, world w.World) error {
 	if world.Components.Player.Has(actor) {
 		logger := gamelog.New(query.GetGameLog(world))
-		if comp.Target != nil && world.ECS.Alive(*comp.Target) {
-			logger.ItemName(query.GetEntityName(*comp.Target, world)).Append("の分解を中断した")
+		if p, ok := comp.Params.(*gc.TargetParams); ok && world.ECS.Alive(p.Target) {
+			logger.ItemName(query.GetEntityName(p.Target, world)).Append("の分解を中断した")
 		} else {
 			logger.Append("分解を中断した")
 		}

--- a/internal/activity/disassemble.go
+++ b/internal/activity/disassemble.go
@@ -23,6 +23,8 @@ import (
 // エンティティ参照を持ち越さないのでセーブ互換の考慮が不要になり、
 // 途中で工具を失った場合も次のターン検査で自然に中断へ落ちる
 type DisassembleBehavior struct {
+	// Target は着手時のパラメータで BuildActivity だけが読み、gc.Activity.Target へ書き写す。
+	// 継続処理は behaviors マップのゼロ値シングルトンで回るので、着手後は comp.Target を読む。
 	Target ecs.Entity
 }
 

--- a/internal/activity/disassemble.go
+++ b/internal/activity/disassemble.go
@@ -56,16 +56,8 @@ func (db *DisassembleBehavior) BuildActivity(actor ecs.Entity, world w.World) (*
 	}
 
 	requiredAP := RequiredDisassemblyAP(int(def.BaseAP), mechanicSkillValue(actor, world), grade)
-	characterAP, err := getEntityMaxAP(actor, world)
-	if err != nil {
-		return nil, err
-	}
-	duration := consts.Turn(1)
-	if characterAP > 0 {
-		duration = consts.Turn((requiredAP + characterAP - 1) / characterAP)
-	}
 
-	comp, err := NewActivity(db, duration)
+	comp, err := NewActivity(db, requiredAP)
 	if err != nil {
 		return nil, err
 	}
@@ -138,8 +130,9 @@ func (db *DisassembleBehavior) DoTurn(comp *gc.Activity, actor ecs.Entity, world
 		return nil
 	}
 
-	comp.TurnsLeft--
-	if comp.TurnsLeft <= 0 {
+	// 今ターンのAPを注ぐ。APが高いほど速く分解が進む
+	comp.Accumulated += perTurnAP(actor, world)
+	if comp.Accumulated >= comp.Required {
 		Complete(comp)
 	}
 	return nil

--- a/internal/activity/disassemble.go
+++ b/internal/activity/disassemble.go
@@ -22,11 +22,7 @@ import (
 // 工具は開始時に固定せず、毎回actorの所持品から分類に適合する最良の1つを解決する。
 // エンティティ参照を持ち越さないのでセーブ互換の考慮が不要になり、
 // 途中で工具を失った場合も次のターン検査で自然に中断へ落ちる
-type DisassembleBehavior struct {
-	// Target は着手時のパラメータで BuildActivity だけが読み、gc.Activity.Target へ書き写す。
-	// 継続処理は GetBehavior が毎回作るゼロ値インスタンスで回るので、着手後は comp.Target を読む。
-	Target ecs.Entity
-}
+type DisassembleBehavior struct{}
 
 // Info はBehaviorの実装
 func (db *DisassembleBehavior) Info() Info {
@@ -44,11 +40,10 @@ func (db *DisassembleBehavior) Name() gc.BehaviorName {
 	return gc.BehaviorDisassemble
 }
 
-// BuildActivity はBehaviorの実装。
-// 必要ターン数は固定値でなく、対象のbaseAPへ機械スキルと工具グレードの短縮を
-// 掛けた総APから毎回計算する
-func (db *DisassembleBehavior) BuildActivity(actor ecs.Entity, world w.World) (*gc.Activity, error) {
-	def, ok := findDisassemblyDef(db.Target, world)
+// NewDisassembleActivity は分解対象を指定して分解アクティビティを組む。
+// 必要APは対象のbaseAPに機械スキルと工具グレードの短縮を掛けて求める。
+func NewDisassembleActivity(target, actor ecs.Entity, world w.World) (*gc.Activity, error) {
+	def, ok := findDisassemblyDef(target, world)
 	if !ok {
 		return nil, fmt.Errorf("対象は分解定義を持っていません")
 	}
@@ -58,12 +53,8 @@ func (db *DisassembleBehavior) BuildActivity(actor ecs.Entity, world w.World) (*
 	}
 
 	requiredAP := RequiredDisassemblyAP(int(def.BaseAP), mechanicSkillValue(actor, world), grade)
-
-	comp, err := NewActivity(db, requiredAP)
-	if err != nil {
-		return nil, err
-	}
-	comp.Target = &db.Target
+	comp := newActivity(gc.BehaviorDisassemble, requiredAP)
+	comp.Target = &target
 	return comp, nil
 }
 

--- a/internal/activity/disassemble.go
+++ b/internal/activity/disassemble.go
@@ -133,8 +133,8 @@ func (db *DisassembleBehavior) DoTurn(comp *gc.Activity, actor ecs.Entity, world
 	}
 
 	// 今ターンのAPを注ぐ。APが高いほど速く分解が進む
-	comp.Accumulated += perTurnAP(actor, world)
-	if comp.Accumulated >= comp.Required {
+	comp.Progress.Current += perTurnAP(actor, world)
+	if comp.Progress.Current >= comp.Progress.Max {
 		Complete(comp)
 	}
 	return nil

--- a/internal/activity/disassemble.go
+++ b/internal/activity/disassemble.go
@@ -24,7 +24,7 @@ import (
 // 途中で工具を失った場合も次のターン検査で自然に中断へ落ちる
 type DisassembleBehavior struct {
 	// Target は着手時のパラメータで BuildActivity だけが読み、gc.Activity.Target へ書き写す。
-	// 継続処理は behaviors マップのゼロ値シングルトンで回るので、着手後は comp.Target を読む。
+	// 継続処理は GetBehavior が毎回作るゼロ値インスタンスで回るので、着手後は comp.Target を読む。
 	Target ecs.Entity
 }
 

--- a/internal/activity/disassemble.go
+++ b/internal/activity/disassemble.go
@@ -54,13 +54,13 @@ func NewDisassembleActivity(target, actor ecs.Entity, world w.World) (*gc.Activi
 
 	requiredAP := RequiredDisassemblyAP(int(def.BaseAP), mechanicSkillValue(actor, world), grade)
 	comp := NewActivity(gc.BehaviorDisassemble, requiredAP)
-	comp.Params = &gc.TargetParams{Target: target}
+	comp.Params = &gc.DisassembleParams{Target: target}
 	return comp, nil
 }
 
 // Validate は分解アクティビティの検証を行う
 func (db *DisassembleBehavior) Validate(comp *gc.Activity, actor ecs.Entity, world w.World) error {
-	p, ok := comp.Params.(*gc.TargetParams)
+	p, ok := comp.Params.(*gc.DisassembleParams)
 	if !ok {
 		return fmt.Errorf("分解対象が指定されていません")
 	}
@@ -82,7 +82,7 @@ func (db *DisassembleBehavior) Validate(comp *gc.Activity, actor ecs.Entity, wor
 
 // Start は分解開始時の処理を実行する
 func (db *DisassembleBehavior) Start(comp *gc.Activity, actor ecs.Entity, world w.World) error {
-	p, ok := comp.Params.(*gc.TargetParams)
+	p, ok := comp.Params.(*gc.DisassembleParams)
 	if !ok {
 		return fmt.Errorf("分解対象が指定されていません")
 	}
@@ -110,7 +110,7 @@ func (db *DisassembleBehavior) Start(comp *gc.Activity, actor ecs.Entity, world 
 // DoTurn は分解アクティビティの1ターン分の処理を実行する。
 // 対象が消えている可能性があるため、毎ターン先頭で生存を確認する
 func (db *DisassembleBehavior) DoTurn(comp *gc.Activity, actor ecs.Entity, world w.World) error {
-	p, ok := comp.Params.(*gc.TargetParams)
+	p, ok := comp.Params.(*gc.DisassembleParams)
 	if !ok {
 		Cancel(comp, "分解対象が指定されていません")
 		return nil
@@ -144,7 +144,7 @@ func (db *DisassembleBehavior) DoTurn(comp *gc.Activity, actor ecs.Entity, world
 // Finish は分解完了時の処理を実行する。産出を抽選し、propは足元へ落として
 // エンティティを除去、アイテムは1個消費して所持品へ加える
 func (db *DisassembleBehavior) Finish(comp *gc.Activity, actor ecs.Entity, world w.World) error {
-	p, ok := comp.Params.(*gc.TargetParams)
+	p, ok := comp.Params.(*gc.DisassembleParams)
 	if !ok {
 		return nil
 	}
@@ -205,7 +205,7 @@ func (db *DisassembleBehavior) Finish(comp *gc.Activity, actor ecs.Entity, world
 func (db *DisassembleBehavior) Canceled(comp *gc.Activity, actor ecs.Entity, world w.World) error {
 	if world.Components.Player.Has(actor) {
 		logger := gamelog.New(query.GetGameLog(world))
-		if p, ok := comp.Params.(*gc.TargetParams); ok && world.ECS.Alive(p.Target) {
+		if p, ok := comp.Params.(*gc.DisassembleParams); ok && world.ECS.Alive(p.Target) {
 			logger.ItemName(query.GetEntityName(p.Target, world)).Append("の分解を中断した")
 		} else {
 			logger.Append("分解を中断した")

--- a/internal/activity/disassemble.go
+++ b/internal/activity/disassemble.go
@@ -53,7 +53,7 @@ func NewDisassembleActivity(target, actor ecs.Entity, world w.World) (*gc.Activi
 	}
 
 	requiredAP := RequiredDisassemblyAP(int(def.BaseAP), mechanicSkillValue(actor, world), grade)
-	comp := newActivity(gc.BehaviorDisassemble, requiredAP)
+	comp := NewActivity(gc.BehaviorDisassemble, requiredAP)
 	comp.Target = &target
 	return comp, nil
 }

--- a/internal/activity/disassemble_test.go
+++ b/internal/activity/disassemble_test.go
@@ -146,8 +146,8 @@ func TestDisassembleBehavior_propを分解すると素材が足元に落ちる(t
 	da := &DisassembleBehavior{Target: crate}
 	comp, err := da.BuildActivity(player, world)
 	require.NoError(t, err)
-	// baseAP2000 スキル0 グレード1 で必要AP2000、AP100につき20ターン
-	assert.Equal(t, consts.Turn(20), comp.TurnsTotal)
+	// baseAP2000 スキル0 グレード1 で必要AP2000
+	assert.Equal(t, 2000, comp.Required)
 
 	require.NoError(t, da.Validate(comp, player, world))
 	require.NoError(t, da.Start(comp, player, world))
@@ -187,8 +187,8 @@ func TestDisassembleBehavior_アイテムを分解すると消費して素材が
 	da := &DisassembleBehavior{Target: hdd}
 	comp, err := da.BuildActivity(player, world)
 	require.NoError(t, err)
-	// baseAP1000 グレード2 で必要AP800、AP100につき8ターン
-	assert.Equal(t, consts.Turn(8), comp.TurnsTotal)
+	// baseAP1000 グレード2 で必要AP800
+	assert.Equal(t, 800, comp.Required)
 
 	require.NoError(t, da.Start(comp, player, world))
 	for comp.State == gc.ActivityStateRunning {

--- a/internal/activity/disassemble_test.go
+++ b/internal/activity/disassemble_test.go
@@ -107,7 +107,7 @@ func TestDisassembleBehavior_Validate_工具がないとエラー(t *testing.T) 
 	require.NoError(t, err)
 
 	da := &DisassembleBehavior{}
-	comp := &gc.Activity{Target: &crate}
+	comp := &gc.Activity{Params: &gc.TargetParams{Target: crate}}
 	err = da.Validate(comp, player, world)
 	require.Error(t, err)
 	assert.ErrorContains(t, err, "工具")
@@ -334,7 +334,7 @@ func TestDisassembleBehavior_Validate_敵が隣接していると開始できな
 	spawnHostileAt(world, 9, 10)
 
 	da := &DisassembleBehavior{}
-	comp := &gc.Activity{Target: &crate}
+	comp := &gc.Activity{Params: &gc.TargetParams{Target: crate}}
 	err = da.Validate(comp, player, world)
 	require.Error(t, err)
 	assert.ErrorContains(t, err, "敵")

--- a/internal/activity/disassemble_test.go
+++ b/internal/activity/disassemble_test.go
@@ -106,7 +106,7 @@ func TestDisassembleBehavior_Validate_工具がないとエラー(t *testing.T) 
 	crate, err := lifecycle.SpawnProp(world, "crate", 11, 10)
 	require.NoError(t, err)
 
-	da := &DisassembleBehavior{Target: crate}
+	da := &DisassembleBehavior{}
 	comp := &gc.Activity{Target: &crate}
 	err = da.Validate(comp, player, world)
 	require.Error(t, err)
@@ -122,8 +122,7 @@ func TestDisassembleBehavior_BuildActivity_分解定義のない対象はエラ�
 	desk, err := lifecycle.SpawnProp(world, "desk", 11, 10)
 	require.NoError(t, err)
 
-	da := &DisassembleBehavior{Target: desk}
-	_, err = da.BuildActivity(player, world)
+	_, err = NewDisassembleActivity(desk, player, world)
 	require.Error(t, err)
 	assert.ErrorContains(t, err, "分解定義")
 }
@@ -143,8 +142,8 @@ func TestDisassembleBehavior_propを分解すると素材が足元に落ちる(t
 	assert.Contains(t, world.Components.Interactable.Get(crate).Interactions, gc.InteractionDisassemble,
 		"分解定義を持つpropはInteractionDisassembleを持つべき")
 
-	da := &DisassembleBehavior{Target: crate}
-	comp, err := da.BuildActivity(player, world)
+	da := &DisassembleBehavior{}
+	comp, err := NewDisassembleActivity(crate, player, world)
 	require.NoError(t, err)
 	// baseAP2000 スキル0 グレード1 で必要AP2000
 	assert.Equal(t, 2000, comp.Progress.Max)
@@ -184,8 +183,8 @@ func TestDisassembleBehavior_アイテムを分解すると消費して素材が
 	hdd, err := lifecycle.SpawnBackpackItem(world, "ハードディスク", 1)
 	require.NoError(t, err)
 
-	da := &DisassembleBehavior{Target: hdd}
-	comp, err := da.BuildActivity(player, world)
+	da := &DisassembleBehavior{}
+	comp, err := NewDisassembleActivity(hdd, player, world)
 	require.NoError(t, err)
 	// baseAP1000 グレード2 で必要AP800
 	assert.Equal(t, 800, comp.Progress.Max)
@@ -223,8 +222,8 @@ func TestDisassembleBehavior_収納propを分解すると中身が足元に出�
 	require.NoError(t, err)
 	require.NoError(t, lifecycle.MoveToStorage(world, loot, crate))
 
-	da := &DisassembleBehavior{Target: crate}
-	comp, err := da.BuildActivity(player, world)
+	da := &DisassembleBehavior{}
+	comp, err := NewDisassembleActivity(crate, player, world)
 	require.NoError(t, err)
 	require.NoError(t, da.Start(comp, player, world))
 	for comp.State == gc.ActivityStateRunning {
@@ -250,8 +249,8 @@ func TestDisassembleBehavior_Finish_対象が既に消えていれば何もし�
 	crate, err := lifecycle.SpawnProp(world, "crate", 11, 10)
 	require.NoError(t, err)
 
-	da := &DisassembleBehavior{Target: crate}
-	comp, err := da.BuildActivity(player, world)
+	da := &DisassembleBehavior{}
+	comp, err := NewDisassembleActivity(crate, player, world)
 	require.NoError(t, err)
 	require.NoError(t, da.Start(comp, player, world))
 
@@ -279,8 +278,8 @@ func TestDisassembleBehavior_スタックのあるアイテムは1個だけ消�
 	hdd, err := lifecycle.SpawnBackpackItem(world, "ハードディスク", 2)
 	require.NoError(t, err)
 
-	da := &DisassembleBehavior{Target: hdd}
-	comp, err := da.BuildActivity(player, world)
+	da := &DisassembleBehavior{}
+	comp, err := NewDisassembleActivity(hdd, player, world)
 	require.NoError(t, err)
 	require.NoError(t, da.Start(comp, player, world))
 	for comp.State == gc.ActivityStateRunning {
@@ -308,8 +307,8 @@ func TestDisassembleBehavior_Finish_レベルアップでStatsChangedが付く(t
 	crate, err := lifecycle.SpawnProp(world, "crate", 11, 10)
 	require.NoError(t, err)
 
-	da := &DisassembleBehavior{Target: crate}
-	comp, err := da.BuildActivity(player, world)
+	da := &DisassembleBehavior{}
+	comp, err := NewDisassembleActivity(crate, player, world)
 	require.NoError(t, err)
 	require.NoError(t, da.Start(comp, player, world))
 	for comp.State == gc.ActivityStateRunning {
@@ -334,7 +333,7 @@ func TestDisassembleBehavior_Validate_敵が隣接していると開始できな
 	require.NoError(t, err)
 	spawnHostileAt(world, 9, 10)
 
-	da := &DisassembleBehavior{Target: crate}
+	da := &DisassembleBehavior{}
 	comp := &gc.Activity{Target: &crate}
 	err = da.Validate(comp, player, world)
 	require.Error(t, err)
@@ -352,8 +351,8 @@ func TestDisassembleBehavior_DoTurn_敵が接近すると中断する(t *testing
 	crate, err := lifecycle.SpawnProp(world, "crate", 11, 10)
 	require.NoError(t, err)
 
-	da := &DisassembleBehavior{Target: crate}
-	comp, err := da.BuildActivity(player, world)
+	da := &DisassembleBehavior{}
+	comp, err := NewDisassembleActivity(crate, player, world)
 	require.NoError(t, err)
 	require.NoError(t, da.Validate(comp, player, world))
 	require.NoError(t, da.Start(comp, player, world))
@@ -407,8 +406,8 @@ func TestDisassembleBehavior_DoTurn_対象が消えると中断する(t *testing
 	crate, err := lifecycle.SpawnProp(world, "crate", 11, 10)
 	require.NoError(t, err)
 
-	da := &DisassembleBehavior{Target: crate}
-	comp, err := da.BuildActivity(player, world)
+	da := &DisassembleBehavior{}
+	comp, err := NewDisassembleActivity(crate, player, world)
 	require.NoError(t, err)
 	require.NoError(t, da.Start(comp, player, world))
 
@@ -433,8 +432,8 @@ func TestDisassembleBehavior_DoTurn_工具を失うと中断する(t *testing.T)
 	crate, err := lifecycle.SpawnProp(world, "crate", 11, 10)
 	require.NoError(t, err)
 
-	da := &DisassembleBehavior{Target: crate}
-	comp, err := da.BuildActivity(player, world)
+	da := &DisassembleBehavior{}
+	comp, err := NewDisassembleActivity(crate, player, world)
 	require.NoError(t, err)
 	require.NoError(t, da.Start(comp, player, world))
 

--- a/internal/activity/disassemble_test.go
+++ b/internal/activity/disassemble_test.go
@@ -107,7 +107,7 @@ func TestDisassembleBehavior_Validate_工具がないとエラー(t *testing.T) 
 	require.NoError(t, err)
 
 	da := &DisassembleBehavior{}
-	comp := &gc.Activity{Params: &gc.TargetParams{Target: crate}}
+	comp := &gc.Activity{Params: &gc.DisassembleParams{Target: crate}}
 	err = da.Validate(comp, player, world)
 	require.Error(t, err)
 	assert.ErrorContains(t, err, "工具")
@@ -334,7 +334,7 @@ func TestDisassembleBehavior_Validate_敵が隣接していると開始できな
 	spawnHostileAt(world, 9, 10)
 
 	da := &DisassembleBehavior{}
-	comp := &gc.Activity{Params: &gc.TargetParams{Target: crate}}
+	comp := &gc.Activity{Params: &gc.DisassembleParams{Target: crate}}
 	err = da.Validate(comp, player, world)
 	require.Error(t, err)
 	assert.ErrorContains(t, err, "敵")

--- a/internal/activity/disassemble_test.go
+++ b/internal/activity/disassemble_test.go
@@ -147,7 +147,7 @@ func TestDisassembleBehavior_propを分解すると素材が足元に落ちる(t
 	comp, err := da.BuildActivity(player, world)
 	require.NoError(t, err)
 	// baseAP2000 スキル0 グレード1 で必要AP2000
-	assert.Equal(t, 2000, comp.Required)
+	assert.Equal(t, 2000, comp.Progress.Max)
 
 	require.NoError(t, da.Validate(comp, player, world))
 	require.NoError(t, da.Start(comp, player, world))
@@ -188,7 +188,7 @@ func TestDisassembleBehavior_アイテムを分解すると消費して素材が
 	comp, err := da.BuildActivity(player, world)
 	require.NoError(t, err)
 	// baseAP1000 グレード2 で必要AP800
-	assert.Equal(t, 800, comp.Required)
+	assert.Equal(t, 800, comp.Progress.Max)
 
 	require.NoError(t, da.Start(comp, player, world))
 	for comp.State == gc.ActivityStateRunning {

--- a/internal/activity/doc.go
+++ b/internal/activity/doc.go
@@ -106,8 +106,7 @@
 //	type Activity struct {
 //		BehaviorName gc.BehaviorName  // アクション種別
 //		State        gc.ActivityState // 実行状態
-//		Required     int              // 完了に必要な総量。即時は0
-//		Accumulated  int              // 注ぎ込んだ総量。Requiredに達したら完了
+//		Progress     IntPool          // Max=完了に必要な総量、Current=注ぎ込んだ総量。Current>=Maxで完了
 //		// ...
 //	}
 //

--- a/internal/activity/doc.go
+++ b/internal/activity/doc.go
@@ -90,23 +90,24 @@
 //
 // ### 1. 即座実行アクション（短期間で完了）
 // - 移動、攻撃、アイテム拾得など
-// - `TurnsTotal = 1`で残りAP1でも1ターンで完了
+// - `Required = 0`で初回ステップに完結する
 // - シンプルな実行ロジック
 //
 // ### 2. 継続実行アクション（複数ターンにわたる）
 // - 休息、読書、クラフトなど
-// - `TurnsTotal > 1`で段階的に実行
+// - `Required > 0`の総量に対し、毎ターン注ぐ量を累積して段階的に実行
 // - 中断・再開機能あり
 //
-// ## 統一インターフェース
+// ## 進捗モデル
 //
-// 全てのアクションは`Activity`構造体を通じて統一的に管理される：
+// 継続アクションは残りターン数を凍結せず、必要総量に対する累積で進捗を表す。
+// 毎ターンの注入量はBehaviorごとに再計算するため、APや能力の変動へ追従する。
 //
 //	type Activity struct {
-//		BehaviorName gc.BehaviorName // アクション種別
+//		BehaviorName gc.BehaviorName  // アクション種別
 //		State        gc.ActivityState // 実行状態
-//		TurnsTotal   int              // 必要ターン数
-//		TurnsLeft    int              // 残りターン数
+//		Required     int              // 完了に必要な総量。即時は0
+//		Accumulated  int              // 注ぎ込んだ総量。Requiredに達したら完了
 //		// ...
 //	}
 //
@@ -126,7 +127,7 @@
 //	result, err := activity.Execute(&activity.MoveBehavior{Destination: dest}, player, world)
 //
 //	// 継続実行アクション（休息）
-//	result, err := activity.Execute(&activity.RestBehavior{Duration: 10}, player, world)
+//	result, err := activity.Execute(&activity.RestBehavior{}, player, world)
 //
 //	// アクティビティの管理
 //	activity.InterruptActivity(player, "戦闘開始", world)

--- a/internal/activity/doc.go
+++ b/internal/activity/doc.go
@@ -155,5 +155,5 @@
 //
 // 1. gc.BehaviorNameに新しい定数を追加
 // 2. Behaviorインターフェースを実装した構造体を作成
-// 3. behaviorsマップに登録
+// 3. GetBehaviorのswitchに対応を追加
 package activity

--- a/internal/activity/door.go
+++ b/internal/activity/door.go
@@ -37,7 +37,7 @@ func (odb *OpenDoorBehavior) Name() gc.BehaviorName {
 
 // BuildActivity はBehaviorの実装
 func (odb *OpenDoorBehavior) BuildActivity(_ ecs.Entity, _ w.World) (*gc.Activity, error) {
-	comp, err := NewActivity(odb, 1)
+	comp, err := NewActivity(odb, 0)
 	if err != nil {
 		return nil, err
 	}
@@ -152,7 +152,7 @@ func (cdb *CloseDoorBehavior) Name() gc.BehaviorName {
 
 // BuildActivity はBehaviorの実装
 func (cdb *CloseDoorBehavior) BuildActivity(_ ecs.Entity, _ w.World) (*gc.Activity, error) {
-	comp, err := NewActivity(cdb, 1)
+	comp, err := NewActivity(cdb, 0)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/activity/door.go
+++ b/internal/activity/door.go
@@ -36,13 +36,13 @@ func (odb *OpenDoorBehavior) Name() gc.BehaviorName {
 // NewOpenDoorActivity は対象扉を指定して開扉アクティビティを組む。
 func NewOpenDoorActivity(target ecs.Entity) *gc.Activity {
 	comp := NewActivity(gc.BehaviorOpenDoor, 0)
-	comp.Params = &gc.TargetParams{Target: target}
+	comp.Params = &gc.OpenDoorParams{Target: target}
 	return comp
 }
 
 // Validate は扉開閉アクティビティの検証を行う
 func (odb *OpenDoorBehavior) Validate(comp *gc.Activity, _ ecs.Entity, world w.World) error {
-	p, ok := comp.Params.(*gc.TargetParams)
+	p, ok := comp.Params.(*gc.OpenDoorParams)
 	if !ok {
 		return fmt.Errorf("扉エンティティが指定されていません")
 	}
@@ -70,7 +70,7 @@ func (odb *OpenDoorBehavior) Start(_ *gc.Activity, actor ecs.Entity, _ w.World) 
 
 // DoTurn は扉開閉アクティビティの1ターン分の処理を実行する
 func (odb *OpenDoorBehavior) DoTurn(comp *gc.Activity, _ ecs.Entity, world w.World) error {
-	p, ok := comp.Params.(*gc.TargetParams)
+	p, ok := comp.Params.(*gc.OpenDoorParams)
 	if !ok {
 		Cancel(comp, "扉エンティティが指定されていません")
 		return fmt.Errorf("扉エンティティが指定されていません")
@@ -152,13 +152,13 @@ func (cdb *CloseDoorBehavior) Name() gc.BehaviorName {
 // NewCloseDoorActivity は対象扉を指定して閉扉アクティビティを組む。
 func NewCloseDoorActivity(target ecs.Entity) *gc.Activity {
 	comp := NewActivity(gc.BehaviorCloseDoor, 0)
-	comp.Params = &gc.TargetParams{Target: target}
+	comp.Params = &gc.CloseDoorParams{Target: target}
 	return comp
 }
 
 // Validate は扉閉鎖アクティビティの検証を行う
 func (cdb *CloseDoorBehavior) Validate(comp *gc.Activity, _ ecs.Entity, world w.World) error {
-	p, ok := comp.Params.(*gc.TargetParams)
+	p, ok := comp.Params.(*gc.CloseDoorParams)
 	if !ok {
 		return fmt.Errorf("扉エンティティが指定されていません")
 	}
@@ -186,7 +186,7 @@ func (cdb *CloseDoorBehavior) Start(_ *gc.Activity, actor ecs.Entity, _ w.World)
 
 // DoTurn は扉閉鎖アクティビティの1ターン分の処理を実行する
 func (cdb *CloseDoorBehavior) DoTurn(comp *gc.Activity, _ ecs.Entity, world w.World) error {
-	p, ok := comp.Params.(*gc.TargetParams)
+	p, ok := comp.Params.(*gc.CloseDoorParams)
 	if !ok {
 		Cancel(comp, "扉エンティティが指定されていません")
 		return fmt.Errorf("扉エンティティが指定されていません")

--- a/internal/activity/door.go
+++ b/internal/activity/door.go
@@ -35,7 +35,7 @@ func (odb *OpenDoorBehavior) Name() gc.BehaviorName {
 
 // NewOpenDoorActivity は対象扉を指定して開扉アクティビティを組む。
 func NewOpenDoorActivity(target ecs.Entity) *gc.Activity {
-	comp := newActivity(gc.BehaviorOpenDoor, 0)
+	comp := NewActivity(gc.BehaviorOpenDoor, 0)
 	comp.Target = &target
 	return comp
 }
@@ -145,7 +145,7 @@ func (cdb *CloseDoorBehavior) Name() gc.BehaviorName {
 
 // NewCloseDoorActivity は対象扉を指定して閉扉アクティビティを組む。
 func NewCloseDoorActivity(target ecs.Entity) *gc.Activity {
-	comp := newActivity(gc.BehaviorCloseDoor, 0)
+	comp := NewActivity(gc.BehaviorCloseDoor, 0)
 	comp.Target = &target
 	return comp
 }

--- a/internal/activity/door.go
+++ b/internal/activity/door.go
@@ -14,9 +14,7 @@ import (
 )
 
 // OpenDoorBehavior はBehaviorの実装
-type OpenDoorBehavior struct {
-	Target ecs.Entity
-}
+type OpenDoorBehavior struct{}
 
 // Info はBehaviorの実装
 func (odb *OpenDoorBehavior) Info() Info {
@@ -35,14 +33,11 @@ func (odb *OpenDoorBehavior) Name() gc.BehaviorName {
 	return gc.BehaviorOpenDoor
 }
 
-// BuildActivity はBehaviorの実装
-func (odb *OpenDoorBehavior) BuildActivity(_ ecs.Entity, _ w.World) (*gc.Activity, error) {
-	comp, err := NewActivity(odb, 0)
-	if err != nil {
-		return nil, err
-	}
-	comp.Target = &odb.Target
-	return comp, nil
+// NewOpenDoorActivity は対象扉を指定して開扉アクティビティを組む。
+func NewOpenDoorActivity(target ecs.Entity) *gc.Activity {
+	comp := newActivity(gc.BehaviorOpenDoor, 0)
+	comp.Target = &target
+	return comp
 }
 
 // Validate は扉開閉アクティビティの検証を行う
@@ -129,9 +124,7 @@ func (odb *OpenDoorBehavior) Canceled(comp *gc.Activity, actor ecs.Entity, _ w.W
 }
 
 // CloseDoorBehavior はBehaviorの実装
-type CloseDoorBehavior struct {
-	Target ecs.Entity
-}
+type CloseDoorBehavior struct{}
 
 // Info はBehaviorの実装
 func (cdb *CloseDoorBehavior) Info() Info {
@@ -150,14 +143,11 @@ func (cdb *CloseDoorBehavior) Name() gc.BehaviorName {
 	return gc.BehaviorCloseDoor
 }
 
-// BuildActivity はBehaviorの実装
-func (cdb *CloseDoorBehavior) BuildActivity(_ ecs.Entity, _ w.World) (*gc.Activity, error) {
-	comp, err := NewActivity(cdb, 0)
-	if err != nil {
-		return nil, err
-	}
-	comp.Target = &cdb.Target
-	return comp, nil
+// NewCloseDoorActivity は対象扉を指定して閉扉アクティビティを組む。
+func NewCloseDoorActivity(target ecs.Entity) *gc.Activity {
+	comp := newActivity(gc.BehaviorCloseDoor, 0)
+	comp.Target = &target
+	return comp
 }
 
 // Validate は扉閉鎖アクティビティの検証を行う

--- a/internal/activity/door.go
+++ b/internal/activity/door.go
@@ -36,17 +36,18 @@ func (odb *OpenDoorBehavior) Name() gc.BehaviorName {
 // NewOpenDoorActivity は対象扉を指定して開扉アクティビティを組む。
 func NewOpenDoorActivity(target ecs.Entity) *gc.Activity {
 	comp := NewActivity(gc.BehaviorOpenDoor, 0)
-	comp.Target = &target
+	comp.Params = &gc.TargetParams{Target: target}
 	return comp
 }
 
 // Validate は扉開閉アクティビティの検証を行う
 func (odb *OpenDoorBehavior) Validate(comp *gc.Activity, _ ecs.Entity, world w.World) error {
-	if comp.Target == nil {
+	p, ok := comp.Params.(*gc.TargetParams)
+	if !ok {
 		return fmt.Errorf("扉エンティティが指定されていません")
 	}
 
-	targetEntity := *comp.Target
+	targetEntity := p.Target
 
 	// ゼロ値・死亡エンティティはArkのHasでパニックするため先に弾く
 	if !world.ECS.Alive(targetEntity) {
@@ -69,7 +70,12 @@ func (odb *OpenDoorBehavior) Start(_ *gc.Activity, actor ecs.Entity, _ w.World) 
 
 // DoTurn は扉開閉アクティビティの1ターン分の処理を実行する
 func (odb *OpenDoorBehavior) DoTurn(comp *gc.Activity, _ ecs.Entity, world w.World) error {
-	targetEntity := *comp.Target
+	p, ok := comp.Params.(*gc.TargetParams)
+	if !ok {
+		Cancel(comp, "扉エンティティが指定されていません")
+		return fmt.Errorf("扉エンティティが指定されていません")
+	}
+	targetEntity := p.Target
 
 	if !world.Components.Door.Has(targetEntity) {
 		Cancel(comp, "扉コンポーネントが取得できません")
@@ -146,17 +152,18 @@ func (cdb *CloseDoorBehavior) Name() gc.BehaviorName {
 // NewCloseDoorActivity は対象扉を指定して閉扉アクティビティを組む。
 func NewCloseDoorActivity(target ecs.Entity) *gc.Activity {
 	comp := NewActivity(gc.BehaviorCloseDoor, 0)
-	comp.Target = &target
+	comp.Params = &gc.TargetParams{Target: target}
 	return comp
 }
 
 // Validate は扉閉鎖アクティビティの検証を行う
 func (cdb *CloseDoorBehavior) Validate(comp *gc.Activity, _ ecs.Entity, world w.World) error {
-	if comp.Target == nil {
+	p, ok := comp.Params.(*gc.TargetParams)
+	if !ok {
 		return fmt.Errorf("扉エンティティが指定されていません")
 	}
 
-	targetEntity := *comp.Target
+	targetEntity := p.Target
 
 	// ゼロ値・死亡エンティティはArkのHasでパニックするため先に弾く
 	if !world.ECS.Alive(targetEntity) {
@@ -179,7 +186,12 @@ func (cdb *CloseDoorBehavior) Start(_ *gc.Activity, actor ecs.Entity, _ w.World)
 
 // DoTurn は扉閉鎖アクティビティの1ターン分の処理を実行する
 func (cdb *CloseDoorBehavior) DoTurn(comp *gc.Activity, _ ecs.Entity, world w.World) error {
-	targetEntity := *comp.Target
+	p, ok := comp.Params.(*gc.TargetParams)
+	if !ok {
+		Cancel(comp, "扉エンティティが指定されていません")
+		return fmt.Errorf("扉エンティティが指定されていません")
+	}
+	targetEntity := p.Target
 
 	if !world.Components.Door.Has(targetEntity) {
 		Cancel(comp, "扉コンポーネントが取得できません")

--- a/internal/activity/door_test.go
+++ b/internal/activity/door_test.go
@@ -33,7 +33,7 @@ func TestOpenDoorBehavior(t *testing.T) {
 		world.Components.BlockView.Add(door, &gc.BlockView{})
 
 		// OpenDoorBehaviorを実行
-		result, err := Execute(&OpenDoorBehavior{Target: door}, player, world)
+		result, err := Execute(NewOpenDoorActivity(door), player, world)
 
 		require.NoError(t, err)
 		require.NotNil(t, result)
@@ -66,7 +66,7 @@ func TestOpenDoorBehavior(t *testing.T) {
 		world.Components.BlockPass.Add(wall, &gc.BlockPass{})
 
 		// OpenDoorBehaviorを実行
-		result, err := Execute(&OpenDoorBehavior{Target: wall}, player, world)
+		result, err := Execute(NewOpenDoorActivity(wall), player, world)
 
 		require.Error(t, err)
 		require.NotNil(t, result)
@@ -92,7 +92,7 @@ func TestOpenDoorBehavior(t *testing.T) {
 		world.Components.BlockPass.Add(door, &gc.BlockPass{})
 		world.Components.BlockView.Add(door, &gc.BlockView{})
 
-		result, err := Execute(&OpenDoorBehavior{Target: door}, player, world)
+		result, err := Execute(NewOpenDoorActivity(door), player, world)
 
 		require.NoError(t, err, "ロック済み扉のキャンセルは致命的エラーではない")
 		require.NotNil(t, result)
@@ -123,8 +123,8 @@ func TestOpenDoorBehavior(t *testing.T) {
 		world.Components.Player.Add(player, &gc.Player{})
 		world.Components.TurnBased.Add(player, &gc.TurnBased{})
 
-		// OpenDoorBehaviorを実行（Targetなし → ゼロ値Entityは扉ではない）
-		result, err := Execute(&OpenDoorBehavior{}, player, world)
+		// OpenDoorを実行（ゼロ値Entityは扉ではない）
+		result, err := Execute(NewOpenDoorActivity(gc.InvalidEntity), player, world)
 
 		require.Error(t, err)
 		require.NotNil(t, result)

--- a/internal/activity/drop.go
+++ b/internal/activity/drop.go
@@ -14,10 +14,7 @@ import (
 )
 
 // DropBehavior はBehaviorの実装
-type DropBehavior struct {
-	Target      ecs.Entity
-	Destination gc.GridElement
-}
+type DropBehavior struct{}
 
 // Info はBehaviorの実装
 func (db *DropBehavior) Info() Info {
@@ -36,15 +33,12 @@ func (db *DropBehavior) Name() gc.BehaviorName {
 	return gc.BehaviorDrop
 }
 
-// BuildActivity はBehaviorの実装
-func (db *DropBehavior) BuildActivity(_ ecs.Entity, _ w.World) (*gc.Activity, error) {
-	comp, err := NewActivity(db, 0)
-	if err != nil {
-		return nil, err
-	}
-	comp.Target = &db.Target
-	comp.Destination = &db.Destination
-	return comp, nil
+// NewDropActivity は対象アイテムと落とす先を指定してドロップアクティビティを組む。
+func NewDropActivity(target ecs.Entity, destination gc.GridElement) *gc.Activity {
+	comp := newActivity(gc.BehaviorDrop, 0)
+	comp.Target = &target
+	comp.Destination = &destination
+	return comp
 }
 
 // Validate はアイテムドロップアクティビティの検証を行う

--- a/internal/activity/drop.go
+++ b/internal/activity/drop.go
@@ -35,7 +35,7 @@ func (db *DropBehavior) Name() gc.BehaviorName {
 
 // NewDropActivity は対象アイテムと落とす先を指定してドロップアクティビティを組む。
 func NewDropActivity(target ecs.Entity, destination gc.GridElement) *gc.Activity {
-	comp := newActivity(gc.BehaviorDrop, 0)
+	comp := NewActivity(gc.BehaviorDrop, 0)
 	comp.Target = &target
 	comp.Destination = &destination
 	return comp

--- a/internal/activity/drop.go
+++ b/internal/activity/drop.go
@@ -38,7 +38,7 @@ func (db *DropBehavior) Name() gc.BehaviorName {
 
 // BuildActivity はBehaviorの実装
 func (db *DropBehavior) BuildActivity(_ ecs.Entity, _ w.World) (*gc.Activity, error) {
-	comp, err := NewActivity(db, 1)
+	comp, err := NewActivity(db, 0)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/activity/drop.go
+++ b/internal/activity/drop.go
@@ -36,18 +36,18 @@ func (db *DropBehavior) Name() gc.BehaviorName {
 // NewDropActivity は対象アイテムと落とす先を指定してドロップアクティビティを組む。
 func NewDropActivity(target ecs.Entity, destination gc.GridElement) *gc.Activity {
 	comp := NewActivity(gc.BehaviorDrop, 0)
-	comp.Target = &target
-	comp.Destination = &destination
+	comp.Params = &gc.PlaceParams{Target: target, Destination: destination}
 	return comp
 }
 
 // Validate はアイテムドロップアクティビティの検証を行う
 func (db *DropBehavior) Validate(comp *gc.Activity, _ ecs.Entity, world w.World) error {
-	if comp.Target == nil {
+	p, ok := comp.Params.(*gc.PlaceParams)
+	if !ok {
 		return fmt.Errorf("ドロップ対象が指定されていません")
 	}
 
-	target := *comp.Target
+	target := p.Target
 
 	// Targetがバックパック内にあることを確認する
 	if !world.Components.LocationInBackpack.Has(target) {
@@ -64,7 +64,9 @@ func (db *DropBehavior) Validate(comp *gc.Activity, _ ecs.Entity, world w.World)
 
 // Start はアイテムドロップ開始時の処理を実行する
 func (db *DropBehavior) Start(comp *gc.Activity, actor ecs.Entity, _ w.World) error {
-	log.Debug("アイテムドロップ開始", "actor", actor, "target", *comp.Target)
+	if p, ok := comp.Params.(*gc.PlaceParams); ok {
+		log.Debug("アイテムドロップ開始", "actor", actor, "target", p.Target)
+	}
 	return nil
 }
 
@@ -95,12 +97,16 @@ func (db *DropBehavior) Canceled(comp *gc.Activity, actor ecs.Entity, _ w.World)
 
 // performDrop は実際のアイテムドロップ処理を実行する
 func (db *DropBehavior) performDrop(comp *gc.Activity, actor ecs.Entity, world w.World) error {
+	p, ok := comp.Params.(*gc.PlaceParams)
+	if !ok {
+		return fmt.Errorf("ドロップ対象が指定されていません")
+	}
 	targetTile, err := requireDestination(comp)
 	if err != nil {
 		return err
 	}
 
-	target := *comp.Target
+	target := p.Target
 	formattedName := query.FormatItemName(world, target)
 
 	lifecycle.MoveToField(world, target, &actor)

--- a/internal/activity/drop_test.go
+++ b/internal/activity/drop_test.go
@@ -324,12 +324,8 @@ func TestPickupAndDropRoundTrip(t *testing.T) {
 		item, err := lifecycle.SpawnFieldItem(world, "木刀", 10, 10, 1)
 		require.NoError(t, err)
 
-		// 拾う
-		pickupComp := &gc.Activity{
-			BehaviorName: gc.BehaviorPickup,
-			State:        gc.ActivityStateRunning,
-			Params:       &gc.PlaceParams{Destination: gc.GridElement{Coord: consts.Coord[consts.Tile]{X: 10, Y: 10}}},
-		}
+		// 拾う。拾得対象は構築時にタイルから解決する
+		pickupComp := NewPickupTileActivity(world, consts.Coord[consts.Tile]{X: 10, Y: 10})
 
 		pa := &PickupBehavior{}
 		err = pa.DoTurn(pickupComp, player, world)

--- a/internal/activity/drop_test.go
+++ b/internal/activity/drop_test.go
@@ -28,8 +28,7 @@ func TestDropBehavior_Validate(t *testing.T) {
 
 		comp := &gc.Activity{
 			BehaviorName: gc.BehaviorDrop,
-			Target:       &item,
-			Destination:  &gc.GridElement{Coord: consts.Coord[consts.Tile]{X: 10, Y: 10}},
+			Params:       &gc.PlaceParams{Target: item, Destination: gc.GridElement{Coord: consts.Coord[consts.Tile]{X: 10, Y: 10}}},
 		}
 
 		da := &DropBehavior{}
@@ -46,7 +45,6 @@ func TestDropBehavior_Validate(t *testing.T) {
 
 		comp := &gc.Activity{
 			BehaviorName: gc.BehaviorDrop,
-			Target:       nil,
 		}
 
 		da := &DropBehavior{}
@@ -66,8 +64,7 @@ func TestDropBehavior_Validate(t *testing.T) {
 		item := world.ECS.NewEntity()
 		comp := &gc.Activity{
 			BehaviorName: gc.BehaviorDrop,
-			Target:       &item,
-			Destination:  &gc.GridElement{Coord: consts.Coord[consts.Tile]{X: 10, Y: 10}},
+			Params:       &gc.PlaceParams{Target: item, Destination: gc.GridElement{Coord: consts.Coord[consts.Tile]{X: 10, Y: 10}}},
 		}
 
 		da := &DropBehavior{}
@@ -76,25 +73,23 @@ func TestDropBehavior_Validate(t *testing.T) {
 		assert.Contains(t, err.Error(), "バックパック内にありません")
 	})
 
-	t.Run("Destinationがない場合はエラー", func(t *testing.T) {
+	t.Run("パラメータがない場合はエラー", func(t *testing.T) {
 		t.Parallel()
 		world := testutil.InitTestWorld(t)
 
 		player, err := lifecycle.SpawnPlayer(world, consts.Coord[consts.Tile]{X: 10, Y: 10}, "Ash")
 		require.NoError(t, err)
 
-		item, err := lifecycle.SpawnBackpackItem(world, "木刀", 1)
-		require.NoError(t, err)
-
+		// 値型パラメータでは目的地未指定を表せない。ドロップ対象と目的地は構築関数が必ずまとめて渡す。
+		// PlaceParams が付かない不正なアクティビティは弾かれる
 		comp := &gc.Activity{
 			BehaviorName: gc.BehaviorDrop,
-			Target:       &item,
 		}
 
 		da := &DropBehavior{}
 		err = da.Validate(comp, player, world)
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "目的地が指定されていません")
+		assert.Contains(t, err.Error(), "ドロップ対象が指定されていません")
 	})
 }
 
@@ -131,8 +126,7 @@ func TestDropBehavior_performDrop(t *testing.T) {
 
 		comp := &gc.Activity{
 			BehaviorName: gc.BehaviorDrop,
-			Target:       &item,
-			Destination:  &gc.GridElement{Coord: consts.Coord[consts.Tile]{X: 10, Y: 10}},
+			Params:       &gc.PlaceParams{Target: item, Destination: gc.GridElement{Coord: consts.Coord[consts.Tile]{X: 10, Y: 10}}},
 		}
 
 		da := &DropBehavior{}
@@ -155,25 +149,22 @@ func TestDropBehavior_performDrop(t *testing.T) {
 		assert.Contains(t, recent[0], "を置いた")
 	})
 
-	t.Run("Destinationがない場合はエラー", func(t *testing.T) {
+	t.Run("パラメータがない場合はエラー", func(t *testing.T) {
 		t.Parallel()
 		world := testutil.InitTestWorld(t)
 
 		player, err := lifecycle.SpawnPlayer(world, consts.Coord[consts.Tile]{X: 10, Y: 10}, "Ash")
 		require.NoError(t, err)
 
-		item, err := lifecycle.SpawnBackpackItem(world, "木刀", 1)
-		require.NoError(t, err)
-
+		// PlaceParams が付かない不正なアクティビティは performDrop でも弾かれる
 		comp := &gc.Activity{
 			BehaviorName: gc.BehaviorDrop,
-			Target:       &item,
 		}
 
 		da := &DropBehavior{}
 		err = da.performDrop(comp, player, world)
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "目的地が指定されていません")
+		assert.Contains(t, err.Error(), "ドロップ対象が指定されていません")
 	})
 }
 
@@ -193,8 +184,7 @@ func TestDropBehavior_DoTurn(t *testing.T) {
 		comp := &gc.Activity{
 			BehaviorName: gc.BehaviorDrop,
 			State:        gc.ActivityStateRunning,
-			Target:       &item,
-			Destination:  &gc.GridElement{Coord: consts.Coord[consts.Tile]{X: 10, Y: 10}},
+			Params:       &gc.PlaceParams{Target: item, Destination: gc.GridElement{Coord: consts.Coord[consts.Tile]{X: 10, Y: 10}}},
 		}
 
 		da := &DropBehavior{}
@@ -204,20 +194,17 @@ func TestDropBehavior_DoTurn(t *testing.T) {
 		assert.Equal(t, gc.ActivityStateCompleted, comp.State)
 	})
 
-	t.Run("Destinationがない場合はキャンセルされる", func(t *testing.T) {
+	t.Run("パラメータがない場合はキャンセルされる", func(t *testing.T) {
 		t.Parallel()
 		world := testutil.InitTestWorld(t)
 
 		player, err := lifecycle.SpawnPlayer(world, consts.Coord[consts.Tile]{X: 10, Y: 10}, "Ash")
 		require.NoError(t, err)
 
-		item, err := lifecycle.SpawnBackpackItem(world, "木刀", 1)
-		require.NoError(t, err)
-
+		// PlaceParams が付かない不正なアクティビティは DoTurn でキャンセルへ落ちる
 		comp := &gc.Activity{
 			BehaviorName: gc.BehaviorDrop,
 			State:        gc.ActivityStateRunning,
-			Target:       &item,
 		}
 
 		da := &DropBehavior{}
@@ -244,8 +231,7 @@ func TestDropBehavior_performDrop_AdjacentTile(t *testing.T) {
 		// プレイヤーの右隣にドロップ
 		comp := &gc.Activity{
 			BehaviorName: gc.BehaviorDrop,
-			Target:       &item,
-			Destination:  &gc.GridElement{Coord: consts.Coord[consts.Tile]{X: 11, Y: 10}},
+			Params:       &gc.PlaceParams{Target: item, Destination: gc.GridElement{Coord: consts.Coord[consts.Tile]{X: 11, Y: 10}}},
 		}
 
 		da := &DropBehavior{}
@@ -272,8 +258,7 @@ func TestDropBehavior_performDrop_AdjacentTile(t *testing.T) {
 		// 右下斜めにドロップ
 		comp := &gc.Activity{
 			BehaviorName: gc.BehaviorDrop,
-			Target:       &item,
-			Destination:  &gc.GridElement{Coord: consts.Coord[consts.Tile]{X: 11, Y: 11}},
+			Params:       &gc.PlaceParams{Target: item, Destination: gc.GridElement{Coord: consts.Coord[consts.Tile]{X: 11, Y: 11}}},
 		}
 
 		da := &DropBehavior{}
@@ -306,8 +291,7 @@ func TestDropBehavior_FixtureDerivedItem(t *testing.T) {
 		// ドロップ実行
 		comp := &gc.Activity{
 			BehaviorName: gc.BehaviorDrop,
-			Target:       &prop,
-			Destination:  &gc.GridElement{Coord: consts.Coord[consts.Tile]{X: 11, Y: 10}},
+			Params:       &gc.PlaceParams{Target: prop, Destination: gc.GridElement{Coord: consts.Coord[consts.Tile]{X: 11, Y: 10}}},
 		}
 
 		da := &DropBehavior{}
@@ -344,7 +328,7 @@ func TestPickupAndDropRoundTrip(t *testing.T) {
 		pickupComp := &gc.Activity{
 			BehaviorName: gc.BehaviorPickup,
 			State:        gc.ActivityStateRunning,
-			Destination:  &gc.GridElement{Coord: consts.Coord[consts.Tile]{X: 10, Y: 10}},
+			Params:       &gc.PlaceParams{Destination: gc.GridElement{Coord: consts.Coord[consts.Tile]{X: 10, Y: 10}}},
 		}
 
 		pa := &PickupBehavior{}
@@ -358,8 +342,7 @@ func TestPickupAndDropRoundTrip(t *testing.T) {
 		dropComp := &gc.Activity{
 			BehaviorName: gc.BehaviorDrop,
 			State:        gc.ActivityStateRunning,
-			Target:       &item,
-			Destination:  &gc.GridElement{Coord: consts.Coord[consts.Tile]{X: 9, Y: 9}},
+			Params:       &gc.PlaceParams{Target: item, Destination: gc.GridElement{Coord: consts.Coord[consts.Tile]{X: 9, Y: 9}}},
 		}
 
 		da := &DropBehavior{}

--- a/internal/activity/errors.go
+++ b/internal/activity/errors.go
@@ -8,7 +8,7 @@ var (
 	ErrActivityNil           = errors.New("アクティビティがnilです")
 	ErrActorNotSet           = errors.New("アクターが設定されていません")
 	ErrActivityNotFound      = errors.New("アクティビティが見つかりません")
-	ErrInvalidDuration       = errors.New("duration は1以上である必要があります")
+	ErrInvalidRequired       = errors.New("required は0以上である必要があります")
 	ErrActivityActorNotFound = errors.New("アクティビティアクターが見つかりません")
 	ErrActivityCannotPause   = errors.New("アクティビティは中断できません")
 	ErrActivityCannotResume  = errors.New("アクティビティは再開できません")

--- a/internal/activity/errors.go
+++ b/internal/activity/errors.go
@@ -8,7 +8,6 @@ var (
 	ErrActivityNil           = errors.New("アクティビティがnilです")
 	ErrActorNotSet           = errors.New("アクターが設定されていません")
 	ErrActivityNotFound      = errors.New("アクティビティが見つかりません")
-	ErrInvalidRequired       = errors.New("required は0以上である必要があります")
 	ErrActivityActorNotFound = errors.New("アクティビティアクターが見つかりません")
 	ErrActivityCannotPause   = errors.New("アクティビティは中断できません")
 	ErrActivityCannotResume  = errors.New("アクティビティは再開できません")

--- a/internal/activity/execute_interaction.go
+++ b/internal/activity/execute_interaction.go
@@ -94,7 +94,11 @@ func executePullCube(actor ecs.Entity, cube ecs.Entity, world w.World) (*ActionR
 		gamelog.New(query.GetGameLog(world)).Append("引くスペースがない。").Log()
 		return &ActionResult{Success: false, ActivityName: gc.BehaviorPull, Message: "引けない"}, nil
 	}
-	return Execute(NewPullBehavior(cube), actor, world)
+	comp, err := NewPullActivity(cube, actor, world)
+	if err != nil {
+		return nil, err
+	}
+	return Execute(comp, actor, world)
 }
 
 func executeDoor(actor ecs.Entity, doorEntity ecs.Entity, world w.World) (*ActionResult, error) {
@@ -105,9 +109,9 @@ func executeDoor(actor ecs.Entity, doorEntity ecs.Entity, world w.World) (*Actio
 	door := world.Components.Door.Get(doorEntity)
 
 	if door.IsOpen {
-		return Execute(&CloseDoorBehavior{Target: doorEntity}, actor, world)
+		return Execute(NewCloseDoorActivity(doorEntity), actor, world)
 	}
-	return Execute(&OpenDoorBehavior{Target: doorEntity}, actor, world)
+	return Execute(NewOpenDoorActivity(doorEntity), actor, world)
 }
 
 func executeDoorLock(world w.World) (*ActionResult, error) {
@@ -124,7 +128,7 @@ func executeTalk(actor ecs.Entity, npcEntity ecs.Entity, world w.World) (*Action
 		return nil, fmt.Errorf("TalkInteractionですがDialogコンポーネントがありません")
 	}
 
-	result, err := Execute(&TalkBehavior{Target: npcEntity}, actor, world)
+	result, err := Execute(NewTalkActivity(npcEntity), actor, world)
 	if err != nil {
 		return nil, fmt.Errorf("会話アクション失敗: %w", err)
 	}
@@ -133,7 +137,7 @@ func executeTalk(actor ecs.Entity, npcEntity ecs.Entity, world w.World) (*Action
 }
 
 func executeItem(actor ecs.Entity, target ecs.Entity, world w.World) (*ActionResult, error) {
-	return Execute(&PickupBehavior{Target: &target}, actor, world)
+	return Execute(NewPickupActivity(&target, nil), actor, world)
 }
 
 func executeItemAll(actor ecs.Entity, world w.World) (*ActionResult, error) {
@@ -141,7 +145,7 @@ func executeItemAll(actor ecs.Entity, world w.World) (*ActionResult, error) {
 		return nil, fmt.Errorf("位置情報が見つかりません")
 	}
 	gridElement := world.Components.GridElement.Get(actor)
-	return Execute(&PickupBehavior{Destination: &gc.GridElement{Coord: gridElement.Coord}}, actor, world)
+	return Execute(NewPickupActivity(nil, &gc.GridElement{Coord: gridElement.Coord}), actor, world)
 }
 
 func executeStorage(storageEntity ecs.Entity, world w.World) (*ActionResult, error) {
@@ -152,7 +156,7 @@ func executeStorage(storageEntity ecs.Entity, world w.World) (*ActionResult, err
 }
 
 func executeMelee(actor ecs.Entity, target ecs.Entity, world w.World) (*ActionResult, error) {
-	return Execute(&AttackBehavior{Target: target}, actor, world)
+	return Execute(NewAttackActivity(target), actor, world)
 }
 
 // executeDisassemble は工具の有無を先に確かめ、無ければエラーでなくログで知らせる。
@@ -170,5 +174,9 @@ func executeDisassemble(actor ecs.Entity, target ecs.Entity, world w.World) (*Ac
 			Log()
 		return &ActionResult{Success: false, ActivityName: gc.BehaviorDisassemble, Message: "工具がない"}, nil
 	}
-	return Execute(&DisassembleBehavior{Target: target}, actor, world)
+	comp, err := NewDisassembleActivity(target, actor, world)
+	if err != nil {
+		return nil, err
+	}
+	return Execute(comp, actor, world)
 }

--- a/internal/activity/execute_interaction.go
+++ b/internal/activity/execute_interaction.go
@@ -137,7 +137,7 @@ func executeTalk(actor ecs.Entity, npcEntity ecs.Entity, world w.World) (*Action
 }
 
 func executeItem(actor ecs.Entity, target ecs.Entity, world w.World) (*ActionResult, error) {
-	return Execute(NewPickupActivity(&target, nil), actor, world)
+	return Execute(NewPickupActivity(target), actor, world)
 }
 
 func executeItemAll(actor ecs.Entity, world w.World) (*ActionResult, error) {
@@ -145,7 +145,7 @@ func executeItemAll(actor ecs.Entity, world w.World) (*ActionResult, error) {
 		return nil, fmt.Errorf("位置情報が見つかりません")
 	}
 	gridElement := world.Components.GridElement.Get(actor)
-	return Execute(NewPickupActivity(nil, &gc.GridElement{Coord: gridElement.Coord}), actor, world)
+	return Execute(NewPickupTileActivity(world, gridElement.Coord), actor, world)
 }
 
 func executeStorage(storageEntity ecs.Entity, world w.World) (*ActionResult, error) {

--- a/internal/activity/move.go
+++ b/internal/activity/move.go
@@ -103,17 +103,18 @@ func (mb *MoveBehavior) Name() gc.BehaviorName {
 // NewMoveActivity は移動先を指定して移動アクティビティを組む。
 func NewMoveActivity(destination gc.GridElement) *gc.Activity {
 	comp := NewActivity(gc.BehaviorMove, 0)
-	comp.Destination = &destination
+	comp.Params = &gc.MoveParams{Destination: destination}
 	return comp
 }
 
 // Validate はBehaviorの実装
 func (mb *MoveBehavior) Validate(comp *gc.Activity, actor ecs.Entity, world w.World) error {
-	if comp.Destination == nil {
+	p, ok := comp.Params.(*gc.MoveParams)
+	if !ok {
 		return ErrMoveTargetNotSet
 	}
 
-	if comp.Destination.X < 0 || comp.Destination.Y < 0 {
+	if p.Destination.X < 0 || p.Destination.Y < 0 {
 		return ErrMoveTargetCoordInvalid
 	}
 
@@ -121,7 +122,7 @@ func (mb *MoveBehavior) Validate(comp *gc.Activity, actor ecs.Entity, world w.Wo
 		return ErrMoveNoGridElement
 	}
 	gridElement := world.Components.GridElement.Get(actor)
-	if !CanMoveTo(world, comp.Destination.Coord, gridElement.Coord, actor) {
+	if !CanMoveTo(world, p.Destination.Coord, gridElement.Coord, actor) {
 		return ErrMoveTargetInvalid
 	}
 
@@ -144,13 +145,16 @@ func (mb *MoveBehavior) Validate(comp *gc.Activity, actor ecs.Entity, world w.Wo
 
 // Start はBehaviorの実装
 func (mb *MoveBehavior) Start(comp *gc.Activity, actor ecs.Entity, _ w.World) error {
-	log.Debug("移動開始", "actor", actor, "destination", *comp.Destination)
+	if p, ok := comp.Params.(*gc.MoveParams); ok {
+		log.Debug("移動開始", "actor", actor, "destination", p.Destination)
+	}
 	return nil
 }
 
 // DoTurn はBehaviorの実装
 func (mb *MoveBehavior) DoTurn(comp *gc.Activity, actor ecs.Entity, world w.World) error {
-	if comp.Destination == nil {
+	p, ok := comp.Params.(*gc.MoveParams)
+	if !ok {
 		Cancel(comp, "移動先が設定されていません")
 		return ErrMoveTargetNotSet
 	}
@@ -164,7 +168,7 @@ func (mb *MoveBehavior) DoTurn(comp *gc.Activity, actor ecs.Entity, world w.Worl
 
 	// 移動可能かチェック
 	grid := gridElement
-	to := comp.Destination.Coord
+	to := p.Destination.Coord
 	from := grid.Coord
 	if !CanMoveTo(world, to, from, actor) {
 		Cancel(comp, "移動できません")
@@ -185,8 +189,8 @@ func (mb *MoveBehavior) Finish(comp *gc.Activity, actor ecs.Entity, world w.Worl
 	log.Debug("移動アクティビティ完了", "actor", actor)
 
 	// プレイヤーの場合のみ移動先のタイルイベントをチェック
-	if comp.Destination != nil && world.Components.Player.Has(actor) {
-		showTileInteractionMessage(world, comp.Destination)
+	if p, ok := comp.Params.(*gc.MoveParams); ok && world.Components.Player.Has(actor) {
+		showTileInteractionMessage(world, &p.Destination)
 	}
 
 	return nil
@@ -199,12 +203,16 @@ func (mb *MoveBehavior) Canceled(comp *gc.Activity, actor ecs.Entity, _ w.World)
 }
 
 func (mb *MoveBehavior) performMove(comp *gc.Activity, actor ecs.Entity, world w.World) error {
+	p, ok := comp.Params.(*gc.MoveParams)
+	if !ok {
+		return ErrMoveTargetNotSet
+	}
 	if !world.Components.GridElement.Has(actor) {
 		return ErrGridElementNotFound
 	}
 	grid := world.Components.GridElement.Get(actor)
 	old := grid.Coord
-	dest := comp.Destination.Coord
+	dest := p.Destination.Coord
 
 	// 味方キャラクターのいるタイルに移動する場合、位置を入れ替える
 	swapped, didSwap := swapAllyIfNeeded(world, actor, old, dest)

--- a/internal/activity/move.go
+++ b/internal/activity/move.go
@@ -81,9 +81,7 @@ func CanSwapPosition(world w.World, mover, target ecs.Entity) bool {
 }
 
 // MoveBehavior はBehaviorの実装
-type MoveBehavior struct {
-	Destination gc.GridElement
-}
+type MoveBehavior struct{}
 
 // Info はBehaviorの実装
 func (mb *MoveBehavior) Info() Info {
@@ -102,14 +100,11 @@ func (mb *MoveBehavior) Name() gc.BehaviorName {
 	return gc.BehaviorMove
 }
 
-// BuildActivity はBehaviorの実装
-func (mb *MoveBehavior) BuildActivity(_ ecs.Entity, _ w.World) (*gc.Activity, error) {
-	comp, err := NewActivity(mb, 0)
-	if err != nil {
-		return nil, err
-	}
-	comp.Destination = &mb.Destination
-	return comp, nil
+// NewMoveActivity は移動先を指定して移動アクティビティを組む。
+func NewMoveActivity(destination gc.GridElement) *gc.Activity {
+	comp := newActivity(gc.BehaviorMove, 0)
+	comp.Destination = &destination
+	return comp
 }
 
 // Validate はBehaviorの実装

--- a/internal/activity/move.go
+++ b/internal/activity/move.go
@@ -104,7 +104,7 @@ func (mb *MoveBehavior) Name() gc.BehaviorName {
 
 // BuildActivity はBehaviorの実装
 func (mb *MoveBehavior) BuildActivity(_ ecs.Entity, _ w.World) (*gc.Activity, error) {
-	comp, err := NewActivity(mb, 1)
+	comp, err := NewActivity(mb, 0)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/activity/move.go
+++ b/internal/activity/move.go
@@ -102,7 +102,7 @@ func (mb *MoveBehavior) Name() gc.BehaviorName {
 
 // NewMoveActivity は移動先を指定して移動アクティビティを組む。
 func NewMoveActivity(destination gc.GridElement) *gc.Activity {
-	comp := newActivity(gc.BehaviorMove, 0)
+	comp := NewActivity(gc.BehaviorMove, 0)
 	comp.Destination = &destination
 	return comp
 }

--- a/internal/activity/move_test.go
+++ b/internal/activity/move_test.go
@@ -24,7 +24,7 @@ func TestMoveBehavior_Validate(t *testing.T) {
 
 		comp := &gc.Activity{
 			BehaviorName: gc.BehaviorMove,
-			Destination:  &gc.GridElement{Coord: consts.Coord[consts.Tile]{X: 11, Y: 10}},
+			Params:       &gc.MoveParams{Destination: gc.GridElement{Coord: consts.Coord[consts.Tile]{X: 11, Y: 10}}},
 		}
 
 		ma := &MoveBehavior{}
@@ -41,7 +41,6 @@ func TestMoveBehavior_Validate(t *testing.T) {
 
 		comp := &gc.Activity{
 			BehaviorName: gc.BehaviorMove,
-			Destination:  nil,
 		}
 
 		ma := &MoveBehavior{}
@@ -60,7 +59,7 @@ func TestMoveBehavior_Validate(t *testing.T) {
 
 		comp := &gc.Activity{
 			BehaviorName: gc.BehaviorMove,
-			Destination:  &gc.GridElement{Coord: consts.Coord[consts.Tile]{X: 11, Y: 10}},
+			Params:       &gc.MoveParams{Destination: gc.GridElement{Coord: consts.Coord[consts.Tile]{X: 11, Y: 10}}},
 		}
 
 		ma := &MoveBehavior{}
@@ -101,7 +100,7 @@ func TestMoveBehavior_DoTurn(t *testing.T) {
 		comp := &gc.Activity{
 			BehaviorName: gc.BehaviorMove,
 			State:        gc.ActivityStateRunning,
-			Destination:  &gc.GridElement{Coord: consts.Coord[consts.Tile]{X: 11, Y: 10}},
+			Params:       &gc.MoveParams{Destination: gc.GridElement{Coord: consts.Coord[consts.Tile]{X: 11, Y: 10}}},
 		}
 
 		ma := &MoveBehavior{}
@@ -126,7 +125,6 @@ func TestMoveBehavior_DoTurn(t *testing.T) {
 		comp := &gc.Activity{
 			BehaviorName: gc.BehaviorMove,
 			State:        gc.ActivityStateRunning,
-			Destination:  nil,
 		}
 
 		ma := &MoveBehavior{}
@@ -147,7 +145,7 @@ func TestMoveBehavior_DoTurn(t *testing.T) {
 		comp := &gc.Activity{
 			BehaviorName: gc.BehaviorMove,
 			State:        gc.ActivityStateRunning,
-			Destination:  &gc.GridElement{Coord: consts.Coord[consts.Tile]{X: 11, Y: 10}},
+			Params:       &gc.MoveParams{Destination: gc.GridElement{Coord: consts.Coord[consts.Tile]{X: 11, Y: 10}}},
 		}
 
 		ma := &MoveBehavior{}
@@ -179,7 +177,7 @@ func TestMoveBehavior_DoTurn(t *testing.T) {
 		comp := &gc.Activity{
 			BehaviorName: gc.BehaviorMove,
 			State:        gc.ActivityStateRunning,
-			Destination:  &gc.GridElement{Coord: memberGrid.Coord},
+			Params:       &gc.MoveParams{Destination: gc.GridElement{Coord: memberGrid.Coord}},
 		}
 
 		ma := &MoveBehavior{}

--- a/internal/activity/pickup.go
+++ b/internal/activity/pickup.go
@@ -37,7 +37,7 @@ func (pb *PickupBehavior) Name() gc.BehaviorName {
 // NewPickupActivity は拾得対象または拾得先を指定して拾得アクティビティを組む。
 // target が nil なら足元や指定座標から拾う。
 func NewPickupActivity(target *ecs.Entity, destination *gc.GridElement) *gc.Activity {
-	comp := newActivity(gc.BehaviorPickup, 0)
+	comp := NewActivity(gc.BehaviorPickup, 0)
 	comp.Target = target
 	comp.Destination = destination
 	return comp

--- a/internal/activity/pickup.go
+++ b/internal/activity/pickup.go
@@ -38,16 +38,28 @@ func (pb *PickupBehavior) Name() gc.BehaviorName {
 // target が nil なら足元や指定座標から拾う。
 func NewPickupActivity(target *ecs.Entity, destination *gc.GridElement) *gc.Activity {
 	comp := NewActivity(gc.BehaviorPickup, 0)
-	comp.Target = target
-	comp.Destination = destination
+	// Target 未指定は足元拾得を表すので、無効エンティティを標識に置く
+	p := &gc.PlaceParams{Target: gc.InvalidEntity}
+	if target != nil {
+		p.Target = *target
+	}
+	if destination != nil {
+		p.Destination = *destination
+	}
+	comp.Params = p
 	return comp
 }
 
 // Validate はアイテム拾得アクティビティの検証を行う
 func (pb *PickupBehavior) Validate(comp *gc.Activity, _ ecs.Entity, world w.World) error {
+	p, ok := comp.Params.(*gc.PlaceParams)
+	if !ok {
+		return fmt.Errorf("拾得対象が指定されていません")
+	}
+
 	// Targetが指定されている場合は、そのエンティティが拾得可能かだけを確認する
-	if comp.Target != nil {
-		if !query.IsPickable(*comp.Target, world) {
+	if p.Target != gc.InvalidEntity {
+		if !query.IsPickable(p.Target, world) {
 			return fmt.Errorf("拾えるものがありません")
 		}
 		return nil
@@ -117,12 +129,17 @@ func (pb *PickupBehavior) Canceled(comp *gc.Activity, actor ecs.Entity, _ w.Worl
 // Targetが指定されている場合はそのエンティティだけを拾い、
 // 未指定の場合はDestinationタイル上の全拾得可能エンティティを拾う
 func (pb *PickupBehavior) performPickup(comp *gc.Activity, actor ecs.Entity, world w.World) error {
+	p, ok := comp.Params.(*gc.PlaceParams)
+	if !ok {
+		return fmt.Errorf("拾得対象が指定されていません")
+	}
+
 	// Targetが指定されている場合は、そのエンティティだけを拾う
-	if comp.Target != nil {
-		if !query.IsPickable(*comp.Target, world) {
+	if p.Target != gc.InvalidEntity {
+		if !query.IsPickable(p.Target, world) {
 			return fmt.Errorf("拾えるものがありません")
 		}
-		return pb.collect(actor, world, *comp.Target)
+		return pb.collect(actor, world, p.Target)
 	}
 
 	target, err := requireDestination(comp)

--- a/internal/activity/pickup.go
+++ b/internal/activity/pickup.go
@@ -34,63 +34,33 @@ func (pb *PickupBehavior) Name() gc.BehaviorName {
 	return gc.BehaviorPickup
 }
 
-// NewPickupActivity は拾得対象または拾得先を指定して拾得アクティビティを組む。
-// target が nil なら足元や指定座標から拾う。
-func NewPickupActivity(target *ecs.Entity, destination *gc.GridElement) *gc.Activity {
+// NewPickupActivity は特定のエンティティ1つを拾う拾得アクティビティを組む。
+func NewPickupActivity(target ecs.Entity) *gc.Activity {
 	comp := NewActivity(gc.BehaviorPickup, 0)
-	// Target 未指定は足元拾得を表すので、無効エンティティを標識に置く
-	p := &gc.PlaceParams{Target: gc.InvalidEntity}
-	if target != nil {
-		p.Target = *target
-	}
-	if destination != nil {
-		p.Destination = *destination
-	}
-	comp.Params = p
+	comp.Params = &gc.PickupParams{Targets: []ecs.Entity{target}}
 	return comp
 }
 
-// Validate はアイテム拾得アクティビティの検証を行う
+// NewPickupTileActivity は指定タイル上の拾得可能なエンティティを全部拾う拾得アクティビティを組む。
+// 何を拾うかはここで解決して Targets に確定させる。behavior はタイル走査を持たない。
+func NewPickupTileActivity(world w.World, tile consts.Coord[consts.Tile]) *gc.Activity {
+	comp := NewActivity(gc.BehaviorPickup, 0)
+	comp.Params = &gc.PickupParams{Targets: query.PickablesAt(world, tile)}
+	return comp
+}
+
+// Validate はアイテム拾得アクティビティの検証を行う。1つでも拾えるものがあれば有効。
 func (pb *PickupBehavior) Validate(comp *gc.Activity, _ ecs.Entity, world w.World) error {
-	p, ok := comp.Params.(*gc.PlaceParams)
+	p, ok := comp.Params.(*gc.PickupParams)
 	if !ok {
 		return fmt.Errorf("拾得対象が指定されていません")
 	}
-
-	// Targetが指定されている場合は、そのエンティティが拾得可能かだけを確認する
-	if p.Target != gc.InvalidEntity {
-		if !query.IsPickable(p.Target, world) {
-			return fmt.Errorf("拾えるものがありません")
-		}
-		return nil
-	}
-
-	target, err := requireDestination(comp)
-	if err != nil {
-		return err
-	}
-
-	hasPickable := false
-	pickableQuery := query.ActiveFilter1[gc.GridElement](world).Query()
-	for pickableQuery.Next() {
-		entity := pickableQuery.Entity()
-		if hasPickable {
-			continue
-		}
-		grid := world.Components.GridElement.Get(entity)
-		if grid.X != target.X || grid.Y != target.Y {
-			continue
-		}
+	for _, entity := range p.Targets {
 		if query.IsPickable(entity, world) {
-			hasPickable = true
+			return nil
 		}
 	}
-
-	if !hasPickable {
-		return fmt.Errorf("拾えるものがありません")
-	}
-
-	return nil
+	return fmt.Errorf("拾えるものがありません")
 }
 
 // Start はアイテム拾得開始時の処理を実行する
@@ -125,49 +95,20 @@ func (pb *PickupBehavior) Canceled(comp *gc.Activity, actor ecs.Entity, _ w.Worl
 	return nil
 }
 
-// performPickup は実際のアイテム拾得処理を実行する。
-// Targetが指定されている場合はそのエンティティだけを拾い、
-// 未指定の場合はDestinationタイル上の全拾得可能エンティティを拾う
+// performPickup は Params に確定済みの Targets を順に拾う。拾得不能になったものは飛ばす。
 func (pb *PickupBehavior) performPickup(comp *gc.Activity, actor ecs.Entity, world w.World) error {
-	p, ok := comp.Params.(*gc.PlaceParams)
+	p, ok := comp.Params.(*gc.PickupParams)
 	if !ok {
 		return fmt.Errorf("拾得対象が指定されていません")
 	}
 
-	// Targetが指定されている場合は、そのエンティティだけを拾う
-	if p.Target != gc.InvalidEntity {
-		if !query.IsPickable(p.Target, world) {
-			return fmt.Errorf("拾えるものがありません")
-		}
-		return pb.collect(actor, world, p.Target)
-	}
-
-	target, err := requireDestination(comp)
-	if err != nil {
-		return err
-	}
-
-	// 対象タイルの拾得可能なエンティティを検索
-	var toCollect []ecs.Entity
-	collectQuery := query.ActiveFilter1[gc.GridElement](world).Query()
-	for collectQuery.Next() {
-		entity := collectQuery.Entity()
-		grid := world.Components.GridElement.Get(entity)
-		if grid.X != target.X || grid.Y != target.Y {
-			continue
-		}
-		if query.IsPickable(entity, world) {
-			toCollect = append(toCollect, entity)
-		}
-	}
-
-	if len(toCollect) == 0 {
-		return fmt.Errorf("拾えるものがありません")
-	}
-
 	collectedCount := 0
 	var errs []error
-	for _, entity := range toCollect {
+	for _, entity := range p.Targets {
+		// 構築後に拾えなくなったものは飛ばす。着手時に他の拾得や消滅で状態が変わりうる
+		if !query.IsPickable(entity, world) {
+			continue
+		}
 		if err := pb.collect(actor, world, entity); err != nil {
 			errs = append(errs, err)
 			continue
@@ -176,7 +117,10 @@ func (pb *PickupBehavior) performPickup(comp *gc.Activity, actor ecs.Entity, wor
 	}
 
 	if collectedCount == 0 {
-		return fmt.Errorf("拾得に失敗しました")
+		if len(errs) > 0 {
+			return fmt.Errorf("一部の拾得に失敗: %w", errors.Join(errs...))
+		}
+		return fmt.Errorf("拾えるものがありません")
 	}
 
 	log.Debug("拾得完了", "count", collectedCount)

--- a/internal/activity/pickup.go
+++ b/internal/activity/pickup.go
@@ -15,10 +15,7 @@ import (
 )
 
 // PickupBehavior はBehaviorの実装
-type PickupBehavior struct {
-	Target      *ecs.Entity
-	Destination *gc.GridElement
-}
+type PickupBehavior struct{}
 
 // Info はBehaviorの実装
 func (pb *PickupBehavior) Info() Info {
@@ -37,19 +34,13 @@ func (pb *PickupBehavior) Name() gc.BehaviorName {
 	return gc.BehaviorPickup
 }
 
-// BuildActivity はBehaviorの実装
-func (pb *PickupBehavior) BuildActivity(_ ecs.Entity, _ w.World) (*gc.Activity, error) {
-	comp, err := NewActivity(pb, 0)
-	if err != nil {
-		return nil, err
-	}
-	if pb.Target != nil {
-		comp.Target = pb.Target
-	}
-	if pb.Destination != nil {
-		comp.Destination = pb.Destination
-	}
-	return comp, nil
+// NewPickupActivity は拾得対象または拾得先を指定して拾得アクティビティを組む。
+// target が nil なら足元や指定座標から拾う。
+func NewPickupActivity(target *ecs.Entity, destination *gc.GridElement) *gc.Activity {
+	comp := newActivity(gc.BehaviorPickup, 0)
+	comp.Target = target
+	comp.Destination = destination
+	return comp
 }
 
 // Validate はアイテム拾得アクティビティの検証を行う

--- a/internal/activity/pickup.go
+++ b/internal/activity/pickup.go
@@ -39,7 +39,7 @@ func (pb *PickupBehavior) Name() gc.BehaviorName {
 
 // BuildActivity はBehaviorの実装
 func (pb *PickupBehavior) BuildActivity(_ ecs.Entity, _ w.World) (*gc.Activity, error) {
-	comp, err := NewActivity(pb, 1)
+	comp, err := NewActivity(pb, 0)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/activity/pickup_test.go
+++ b/internal/activity/pickup_test.go
@@ -25,10 +25,7 @@ func TestPickupBehavior_Validate(t *testing.T) {
 		_, err = lifecycle.SpawnFieldItem(world, "木刀", 10, 10, 1)
 		require.NoError(t, err)
 
-		comp := &gc.Activity{
-			BehaviorName: gc.BehaviorPickup,
-			Params:       &gc.PlaceParams{Destination: gc.GridElement{Coord: consts.Coord[consts.Tile]{X: 10, Y: 10}}},
-		}
+		comp := NewPickupTileActivity(world, consts.Coord[consts.Tile]{X: 10, Y: 10})
 
 		pa := &PickupBehavior{}
 		err = pa.Validate(comp, player, world)
@@ -46,10 +43,8 @@ func TestPickupBehavior_Validate(t *testing.T) {
 		_, err = lifecycle.SpawnFieldItem(world, "木刀", 20, 20, 1)
 		require.NoError(t, err)
 
-		comp := &gc.Activity{
-			BehaviorName: gc.BehaviorPickup,
-			Params:       &gc.PlaceParams{Destination: gc.GridElement{Coord: consts.Coord[consts.Tile]{X: 10, Y: 10}}},
-		}
+		// 対象タイルには拾えるものがないので Targets が空になる
+		comp := NewPickupTileActivity(world, consts.Coord[consts.Tile]{X: 10, Y: 10})
 
 		pa := &PickupBehavior{}
 		err = pa.Validate(comp, player, world)
@@ -64,8 +59,7 @@ func TestPickupBehavior_Validate(t *testing.T) {
 		player, err := lifecycle.SpawnPlayer(world, consts.Coord[consts.Tile]{X: 10, Y: 10}, "Ash")
 		require.NoError(t, err)
 
-		// 値型パラメータでは目的地未指定を表せない。拾得対象も拾得先も無い不正なアクティビティは
-		// PlaceParams が付いていないため弾かれる
+		// PickupParams が付かない不正なアクティビティは型アサートで弾かれる
 		comp := &gc.Activity{
 			BehaviorName: gc.BehaviorPickup,
 		}
@@ -108,11 +102,7 @@ func TestPickupBehavior_DoTurn(t *testing.T) {
 		item, err := lifecycle.SpawnFieldItem(world, "木刀", 10, 10, 1)
 		require.NoError(t, err)
 
-		comp := &gc.Activity{
-			BehaviorName: gc.BehaviorPickup,
-			State:        gc.ActivityStateRunning,
-			Params:       &gc.PlaceParams{Destination: gc.GridElement{Coord: consts.Coord[consts.Tile]{X: 10, Y: 10}}},
-		}
+		comp := NewPickupTileActivity(world, consts.Coord[consts.Tile]{X: 10, Y: 10})
 
 		pa := &PickupBehavior{}
 		err = pa.DoTurn(comp, player, world)
@@ -137,11 +127,7 @@ func TestPickupBehavior_DoTurn(t *testing.T) {
 		_, err = lifecycle.SpawnFieldItem(world, "木刀", 20, 20, 1)
 		require.NoError(t, err)
 
-		comp := &gc.Activity{
-			BehaviorName: gc.BehaviorPickup,
-			State:        gc.ActivityStateRunning,
-			Params:       &gc.PlaceParams{Destination: gc.GridElement{Coord: consts.Coord[consts.Tile]{X: 10, Y: 10}}},
-		}
+		comp := NewPickupTileActivity(world, consts.Coord[consts.Tile]{X: 10, Y: 10})
 
 		pa := &PickupBehavior{}
 		err = pa.DoTurn(comp, player, world)
@@ -150,13 +136,14 @@ func TestPickupBehavior_DoTurn(t *testing.T) {
 		assert.Equal(t, gc.ActivityStateCanceled, comp.State)
 	})
 
-	t.Run("Destinationがない場合はキャンセルされる", func(t *testing.T) {
+	t.Run("パラメータがない場合はキャンセルされる", func(t *testing.T) {
 		t.Parallel()
 		world := testutil.InitTestWorld(t)
 
 		player, err := lifecycle.SpawnPlayer(world, consts.Coord[consts.Tile]{X: 10, Y: 10}, "Ash")
 		require.NoError(t, err)
 
+		// PickupParams が付かない不正なアクティビティは DoTurn でキャンセルへ落ちる
 		comp := &gc.Activity{
 			BehaviorName: gc.BehaviorPickup,
 			State:        gc.ActivityStateRunning,
@@ -186,11 +173,8 @@ func TestPickupBehavior_DoTurn_Target(t *testing.T) {
 		item2, err := lifecycle.SpawnFieldItem(world, "回復薬", 10, 10, 1)
 		require.NoError(t, err)
 
-		comp := &gc.Activity{
-			BehaviorName: gc.BehaviorPickup,
-			State:        gc.ActivityStateRunning,
-			Params:       &gc.PlaceParams{Target: item1},
-		}
+		// 特定のアイテム1つだけを対象にする
+		comp := NewPickupActivity(item1)
 
 		pa := &PickupBehavior{}
 		err = pa.DoTurn(comp, player, world)
@@ -221,10 +205,7 @@ func TestPickupBehavior_Validate_Target(t *testing.T) {
 		item, err := lifecycle.SpawnFieldItem(world, "木刀", 10, 10, 1)
 		require.NoError(t, err)
 
-		comp := &gc.Activity{
-			BehaviorName: gc.BehaviorPickup,
-			Params:       &gc.PlaceParams{Target: item},
-		}
+		comp := NewPickupActivity(item)
 
 		pa := &PickupBehavior{}
 		err = pa.Validate(comp, player, world)
@@ -244,10 +225,7 @@ func TestPickupBehavior_Validate_Target(t *testing.T) {
 		world.Components.GridElement.Add(prop, &gc.GridElement{Coord: consts.Coord[consts.Tile]{X: 10, Y: 10}})
 		world.Components.LocationOnField.Add(prop, &gc.LocationOnField{})
 
-		comp := &gc.Activity{
-			BehaviorName: gc.BehaviorPickup,
-			Params:       &gc.PlaceParams{Target: prop},
-		}
+		comp := NewPickupActivity(prop)
 
 		pa := &PickupBehavior{}
 		err = pa.Validate(comp, player, world)
@@ -272,10 +250,8 @@ func TestPickupBehavior_Validate_Fixed(t *testing.T) {
 		world.Components.GridElement.Add(prop, &gc.GridElement{Coord: consts.Coord[consts.Tile]{X: 10, Y: 10}})
 		world.Components.LocationOnField.Add(prop, &gc.LocationOnField{})
 
-		comp := &gc.Activity{
-			BehaviorName: gc.BehaviorPickup,
-			Params:       &gc.PlaceParams{Destination: gc.GridElement{Coord: consts.Coord[consts.Tile]{X: 10, Y: 10}}},
-		}
+		// 固定物は PickablesAt で除かれ Targets が空になる
+		comp := NewPickupTileActivity(world, consts.Coord[consts.Tile]{X: 10, Y: 10})
 
 		pa := &PickupBehavior{}
 		err = pa.Validate(comp, player, world)
@@ -299,10 +275,7 @@ func TestPickupBehavior_Validate_Fixed(t *testing.T) {
 		world.Components.GridElement.Add(prop, &gc.GridElement{Coord: consts.Coord[consts.Tile]{X: 5, Y: 5}})
 		world.Components.Interactable.Add(prop, &gc.Interactable{Interactions: []gc.InteractionKind{gc.InteractionMelee}})
 
-		comp := &gc.Activity{
-			BehaviorName: gc.BehaviorPickup,
-			Params:       &gc.PlaceParams{Destination: gc.GridElement{Coord: consts.Coord[consts.Tile]{X: 5, Y: 5}}},
-		}
+		comp := NewPickupTileActivity(world, consts.Coord[consts.Tile]{X: 5, Y: 5})
 
 		pa := &PickupBehavior{}
 		err = pa.Validate(comp, player, world)
@@ -327,11 +300,7 @@ func TestPickupBehavior_DoTurn_Fixed(t *testing.T) {
 		world.Components.GridElement.Add(prop, &gc.GridElement{Coord: consts.Coord[consts.Tile]{X: 8, Y: 6}})
 		world.Components.LocationOnField.Add(prop, &gc.LocationOnField{})
 
-		comp := &gc.Activity{
-			BehaviorName: gc.BehaviorPickup,
-			State:        gc.ActivityStateRunning,
-			Params:       &gc.PlaceParams{Destination: gc.GridElement{Coord: consts.Coord[consts.Tile]{X: 8, Y: 6}}},
-		}
+		comp := NewPickupTileActivity(world, consts.Coord[consts.Tile]{X: 8, Y: 6})
 
 		pa := &PickupBehavior{}
 		err = pa.DoTurn(comp, player, world)

--- a/internal/activity/pickup_test.go
+++ b/internal/activity/pickup_test.go
@@ -27,7 +27,7 @@ func TestPickupBehavior_Validate(t *testing.T) {
 
 		comp := &gc.Activity{
 			BehaviorName: gc.BehaviorPickup,
-			Destination:  &gc.GridElement{Coord: consts.Coord[consts.Tile]{X: 10, Y: 10}},
+			Params:       &gc.PlaceParams{Destination: gc.GridElement{Coord: consts.Coord[consts.Tile]{X: 10, Y: 10}}},
 		}
 
 		pa := &PickupBehavior{}
@@ -48,7 +48,7 @@ func TestPickupBehavior_Validate(t *testing.T) {
 
 		comp := &gc.Activity{
 			BehaviorName: gc.BehaviorPickup,
-			Destination:  &gc.GridElement{Coord: consts.Coord[consts.Tile]{X: 10, Y: 10}},
+			Params:       &gc.PlaceParams{Destination: gc.GridElement{Coord: consts.Coord[consts.Tile]{X: 10, Y: 10}}},
 		}
 
 		pa := &PickupBehavior{}
@@ -57,13 +57,15 @@ func TestPickupBehavior_Validate(t *testing.T) {
 		assert.Contains(t, err.Error(), "拾えるものがありません")
 	})
 
-	t.Run("Destinationがない場合はエラー", func(t *testing.T) {
+	t.Run("パラメータがない場合はエラー", func(t *testing.T) {
 		t.Parallel()
 		world := testutil.InitTestWorld(t)
 
 		player, err := lifecycle.SpawnPlayer(world, consts.Coord[consts.Tile]{X: 10, Y: 10}, "Ash")
 		require.NoError(t, err)
 
+		// 値型パラメータでは目的地未指定を表せない。拾得対象も拾得先も無い不正なアクティビティは
+		// PlaceParams が付いていないため弾かれる
 		comp := &gc.Activity{
 			BehaviorName: gc.BehaviorPickup,
 		}
@@ -71,7 +73,7 @@ func TestPickupBehavior_Validate(t *testing.T) {
 		pa := &PickupBehavior{}
 		err = pa.Validate(comp, player, world)
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "目的地が指定されていません")
+		assert.Contains(t, err.Error(), "拾得対象が指定されていません")
 	})
 }
 
@@ -109,7 +111,7 @@ func TestPickupBehavior_DoTurn(t *testing.T) {
 		comp := &gc.Activity{
 			BehaviorName: gc.BehaviorPickup,
 			State:        gc.ActivityStateRunning,
-			Destination:  &gc.GridElement{Coord: consts.Coord[consts.Tile]{X: 10, Y: 10}},
+			Params:       &gc.PlaceParams{Destination: gc.GridElement{Coord: consts.Coord[consts.Tile]{X: 10, Y: 10}}},
 		}
 
 		pa := &PickupBehavior{}
@@ -138,7 +140,7 @@ func TestPickupBehavior_DoTurn(t *testing.T) {
 		comp := &gc.Activity{
 			BehaviorName: gc.BehaviorPickup,
 			State:        gc.ActivityStateRunning,
-			Destination:  &gc.GridElement{Coord: consts.Coord[consts.Tile]{X: 10, Y: 10}},
+			Params:       &gc.PlaceParams{Destination: gc.GridElement{Coord: consts.Coord[consts.Tile]{X: 10, Y: 10}}},
 		}
 
 		pa := &PickupBehavior{}
@@ -187,7 +189,7 @@ func TestPickupBehavior_DoTurn_Target(t *testing.T) {
 		comp := &gc.Activity{
 			BehaviorName: gc.BehaviorPickup,
 			State:        gc.ActivityStateRunning,
-			Target:       &item1,
+			Params:       &gc.PlaceParams{Target: item1},
 		}
 
 		pa := &PickupBehavior{}
@@ -221,7 +223,7 @@ func TestPickupBehavior_Validate_Target(t *testing.T) {
 
 		comp := &gc.Activity{
 			BehaviorName: gc.BehaviorPickup,
-			Target:       &item,
+			Params:       &gc.PlaceParams{Target: item},
 		}
 
 		pa := &PickupBehavior{}
@@ -244,7 +246,7 @@ func TestPickupBehavior_Validate_Target(t *testing.T) {
 
 		comp := &gc.Activity{
 			BehaviorName: gc.BehaviorPickup,
-			Target:       &prop,
+			Params:       &gc.PlaceParams{Target: prop},
 		}
 
 		pa := &PickupBehavior{}
@@ -272,7 +274,7 @@ func TestPickupBehavior_Validate_Fixed(t *testing.T) {
 
 		comp := &gc.Activity{
 			BehaviorName: gc.BehaviorPickup,
-			Destination:  &gc.GridElement{Coord: consts.Coord[consts.Tile]{X: 10, Y: 10}},
+			Params:       &gc.PlaceParams{Destination: gc.GridElement{Coord: consts.Coord[consts.Tile]{X: 10, Y: 10}}},
 		}
 
 		pa := &PickupBehavior{}
@@ -299,7 +301,7 @@ func TestPickupBehavior_Validate_Fixed(t *testing.T) {
 
 		comp := &gc.Activity{
 			BehaviorName: gc.BehaviorPickup,
-			Destination:  &gc.GridElement{Coord: consts.Coord[consts.Tile]{X: 5, Y: 5}},
+			Params:       &gc.PlaceParams{Destination: gc.GridElement{Coord: consts.Coord[consts.Tile]{X: 5, Y: 5}}},
 		}
 
 		pa := &PickupBehavior{}
@@ -328,7 +330,7 @@ func TestPickupBehavior_DoTurn_Fixed(t *testing.T) {
 		comp := &gc.Activity{
 			BehaviorName: gc.BehaviorPickup,
 			State:        gc.ActivityStateRunning,
-			Destination:  &gc.GridElement{Coord: consts.Coord[consts.Tile]{X: 8, Y: 6}},
+			Params:       &gc.PlaceParams{Destination: gc.GridElement{Coord: consts.Coord[consts.Tile]{X: 8, Y: 6}}},
 		}
 
 		pa := &PickupBehavior{}

--- a/internal/activity/player_actions.go
+++ b/internal/activity/player_actions.go
@@ -77,14 +77,18 @@ func ExecuteMoveAction(world w.World, direction gc.Direction) error {
 		if !CanMoveTo(world, cubeCoord.Add(direction.GetDelta()), cubeCoord, cube) {
 			return nil
 		}
-		_, err := Execute(NewPushBehavior(cube, direction), entity, world)
+		comp, err := NewPushActivity(cube, direction, world)
+		if err != nil {
+			return err
+		}
+		_, err = Execute(comp, entity, world)
 		return err
 	}
 
 	canMove := CanMoveTo(world, next, current, entity)
 	if canMove {
 		destination := gc.GridElement{Coord: next}
-		_, err := Execute(&MoveBehavior{Destination: destination}, entity, world)
+		_, err := Execute(NewMoveActivity(destination), entity, world)
 		return err
 	}
 
@@ -108,7 +112,7 @@ func ExecuteWaitAction(world w.World) error {
 		return err
 	}
 
-	_, err = Execute(&WaitBehavior{Duration: 1, Reason: "プレイヤー待機"}, entity, world)
+	_, err = Execute(NewWaitActivity(1), entity, world)
 	return err
 }
 

--- a/internal/activity/push.go
+++ b/internal/activity/push.go
@@ -28,6 +28,7 @@ func (pb *PushBehavior) Info() Info {
 		Interruptible:   true,
 		Resumable:       false,
 		ActionPointCost: consts.StandardActionCost,
+		// 必要総APはキューブの総重量に応じて buildCubeMove が算出するため、Info では持たず 0 とする
 		TotalRequiredAP: 0,
 	}
 }
@@ -173,6 +174,7 @@ func (pb *PullBehavior) Info() Info {
 		Interruptible:   true,
 		Resumable:       false,
 		ActionPointCost: consts.StandardActionCost,
+		// 必要総APはキューブの総重量に応じて buildCubeMove が算出するため、Info では持たず 0 とする
 		TotalRequiredAP: 0,
 	}
 }

--- a/internal/activity/push.go
+++ b/internal/activity/push.go
@@ -108,8 +108,9 @@ func (pb *PushBehavior) DoTurn(comp *gc.Activity, _ ecs.Entity, world w.World) e
 		return nil
 	}
 
-	comp.TurnsLeft--
-	if comp.TurnsLeft <= 0 {
+	// パーティの押し力を注ぐ。強いパーティほど速く動かす
+	comp.Accumulated += query.PartyPushPower(world)
+	if comp.Accumulated >= comp.Required {
 		Complete(comp)
 	}
 	return nil
@@ -138,29 +139,28 @@ func (pb *PushBehavior) Canceled(comp *gc.Activity, actor ecs.Entity, _ w.World)
 	return nil
 }
 
-// cubePushTurns はキューブを1タイル動かすのに要するターン数を返す。総重量が重いほど、
-// パーティAPが少ないほど増える。押しと引きで共通。APが無ければエラー。
+// cubePushCost はキューブを1タイル動かすのに要する総コストを返す。総重量が重いほど増える。
+// 押しと引きで共通。APが無ければエラー。毎ターン注ぐAPは DoTurn でパーティの押し力から
+// 再計算するため、着手時に凍結するのは総コストだけにする。
 //
 // 総重量は内部ステージに置いた物の総和。内部はオーバーワールドと同じく単一の永続ステージなので、
 // 固定キー NewCubeInteriorStage で直接引く。どのキューブを押しても同じ内部の総重量が押しの重さに
 // なる。内部をキューブごとに分ける拡張へ進むときは、キューブから内部へのリンクをここで解決し直す。
-func cubePushTurns(world w.World) (consts.Turn, error) {
-	power := query.PartyPushPower(world)
-	if power <= 0 {
+func cubePushCost(world w.World) (int, error) {
+	if query.PartyPushPower(world) <= 0 {
 		return 0, fmt.Errorf("APが足りず動かせません")
 	}
-	cost := query.PushCost(query.CubeWeight(world, gc.NewCubeInteriorStage()))
-	return consts.Turn((cost + power - 1) / power), nil
+	return query.PushCost(query.CubeWeight(world, gc.NewCubeInteriorStage())), nil
 }
 
-// buildCubeMove は押しと引きで共通の gc.Activity を組む。所要ターンは総重量とパーティAPで決まり、
+// buildCubeMove は押しと引きで共通の gc.Activity を組む。総コストは総重量で決まり、
 // 押し引きで違うのは対象キューブと移動先だけなので、それを引数で受ける。
 func buildCubeMove(behavior Behavior, cube *ecs.Entity, dest consts.Coord[consts.Tile], world w.World) (*gc.Activity, error) {
-	duration, err := cubePushTurns(world)
+	required, err := cubePushCost(world)
 	if err != nil {
 		return nil, err
 	}
-	comp, err := NewActivity(behavior, duration)
+	comp, err := NewActivity(behavior, required)
 	if err != nil {
 		return nil, err
 	}
@@ -276,8 +276,9 @@ func (pb *PullBehavior) DoTurn(comp *gc.Activity, actor ecs.Entity, world w.Worl
 		return nil
 	}
 
-	comp.TurnsLeft--
-	if comp.TurnsLeft <= 0 {
+	// パーティの押し力を注ぐ。強いパーティほど速く動かす
+	comp.Accumulated += query.PartyPushPower(world)
+	if comp.Accumulated >= comp.Required {
 		Complete(comp)
 	}
 	return nil

--- a/internal/activity/push.go
+++ b/internal/activity/push.go
@@ -16,8 +16,8 @@ import (
 // 必要な総コストが増え、パーティAPが多いほど速く満ちる。
 //
 // 着手時のパラメータである押す対象キューブと押し向きは NewPushActivity が受け取り、
-// 押し先を求めて gc.Activity の Target と Destination へ書き込む。継続処理は状態を持たない
-// ゼロ値インスタンスで回るので、着手後は gc.Activity の Target と Destination だけを読む。
+// 押し先を求めて gc.Activity の PlaceParams へ書き込む。継続処理は状態を持たない
+// ゼロ値インスタンスで回るので、着手後は gc.Activity の PlaceParams だけを読む。
 type PushBehavior struct{}
 
 // Info はBehaviorの実装
@@ -49,28 +49,26 @@ func NewPushActivity(cube ecs.Entity, dir gc.Direction, world w.World) (*gc.Acti
 
 // Validate はBehaviorの実装
 func (pb *PushBehavior) Validate(comp *gc.Activity, actor ecs.Entity, world w.World) error {
-	if comp.Target == nil {
+	p, ok := comp.Params.(*gc.PlaceParams)
+	if !ok {
 		return fmt.Errorf("押す対象が指定されていません")
 	}
-	if !world.ECS.Alive(*comp.Target) {
+	if !world.ECS.Alive(p.Target) {
 		return fmt.Errorf("押す対象が存在しません")
 	}
-	if !world.Components.Pushable.Has(*comp.Target) {
+	if !world.Components.Pushable.Has(p.Target) {
 		return fmt.Errorf("対象は押せません")
 	}
-	if !world.Components.GridElement.Has(*comp.Target) {
+	if !world.Components.GridElement.Has(p.Target) {
 		return fmt.Errorf("押す対象に位置がありません")
-	}
-	if comp.Destination == nil {
-		return fmt.Errorf("押し先が指定されていません")
 	}
 	if !world.Components.GridElement.Has(actor) {
 		return fmt.Errorf("押し手に位置がありません")
 	}
 	// 押せる先はプレイヤーが行ける先に一致させる。CanMoveTo が寒波前線の破棄域や
 	// 壁を弾くので、押し専用の前線チェックは持たない
-	cubeCoord := world.Components.GridElement.Get(*comp.Target).Coord
-	if !CanMoveTo(world, comp.Destination.Coord, cubeCoord, *comp.Target) {
+	cubeCoord := world.Components.GridElement.Get(p.Target).Coord
+	if !CanMoveTo(world, p.Destination.Coord, cubeCoord, p.Target) {
 		return fmt.Errorf("その方向へは押せません")
 	}
 	return nil
@@ -84,16 +82,17 @@ func (pb *PushBehavior) Start(_ *gc.Activity, actor ecs.Entity, _ w.World) error
 
 // DoTurn はBehaviorの実装。毎ターン対象の生存と押し先の通行可否を確かめ、ターンを1つ消費する。
 func (pb *PushBehavior) DoTurn(comp *gc.Activity, _ ecs.Entity, world w.World) error {
-	if comp.Target == nil || !world.ECS.Alive(*comp.Target) {
+	p, ok := comp.Params.(*gc.PlaceParams)
+	if !ok || !world.ECS.Alive(p.Target) {
 		Cancel(comp, "押す対象が消えたため中断")
 		return nil
 	}
-	if comp.Destination == nil || !world.Components.GridElement.Has(*comp.Target) {
+	if !world.Components.GridElement.Has(p.Target) {
 		Cancel(comp, "押せなくなったため中断")
 		return nil
 	}
-	cubeCoord := world.Components.GridElement.Get(*comp.Target).Coord
-	if !CanMoveTo(world, comp.Destination.Coord, cubeCoord, *comp.Target) {
+	cubeCoord := world.Components.GridElement.Get(p.Target).Coord
+	if !CanMoveTo(world, p.Destination.Coord, cubeCoord, p.Target) {
 		Cancel(comp, "その方向へは押せなくなった")
 		return nil
 	}
@@ -110,16 +109,20 @@ func (pb *PushBehavior) DoTurn(comp *gc.Activity, _ ecs.Entity, world w.World) e
 // プレイヤーは次の移動入力で空いたタイルへ普通に一歩進む。押しと移動を別アクティビティに分け、
 // それぞれが自然な通貨、押しはターン、移動はAPで課金される。
 func (pb *PushBehavior) Finish(comp *gc.Activity, actor ecs.Entity, world w.World) error {
-	cube := *comp.Target
+	p, ok := comp.Params.(*gc.PlaceParams)
+	if !ok {
+		return nil
+	}
+	cube := p.Target
 	if !world.ECS.Alive(cube) || !world.Components.GridElement.Has(cube) {
 		return nil
 	}
-	world.Components.GridElement.Get(cube).Coord = comp.Destination.Coord
+	world.Components.GridElement.Get(cube).Coord = p.Destination.Coord
 
 	// キューブは BlockPass なので通行索引が変わる。全再構築で確実に反映する
 	query.InvalidateSpatialIndex(world)
 
-	log.Debug("押し完了", "actor", actor, "cube", cube, "to", comp.Destination.String())
+	log.Debug("押し完了", "actor", actor, "cube", cube, "to", p.Destination.String())
 	return nil
 }
 
@@ -151,16 +154,14 @@ func buildCubeMove(name gc.BehaviorName, cube ecs.Entity, dest consts.Coord[cons
 		return nil, err
 	}
 	comp := NewActivity(name, required)
-	c := cube
-	comp.Target = &c
-	comp.Destination = &gc.GridElement{Coord: dest}
+	comp.Params = &gc.PlaceParams{Target: cube, Destination: gc.GridElement{Coord: dest}}
 	return comp, nil
 }
 
 // PullBehavior は BehaviorPull の実装。プレイヤーが隣接する Pushable キューブを自分の側へ引き、
 // 自分は1タイル後退する。押しでは動かせない壁際・角のキューブを引き出して詰みを解く。
 // 総コストは押しと同じく総重量で決まる。着手時のパラメータである引く対象キューブは
-// NewPullActivity が受け取り、gc.Activity の Target と Destination へ書き込む。継続処理は
+// NewPullActivity が受け取り、gc.Activity の PlaceParams へ書き込む。継続処理は
 // 状態を持たないゼロ値インスタンスで回るので、着手後は gc.Activity 側だけを読む。
 type PullBehavior struct{}
 
@@ -213,22 +214,23 @@ func NewPullActivity(cube, actor ecs.Entity, world w.World) (*gc.Activity, error
 
 // Validate はBehaviorの実装。後退先が通行可能であることを確かめる。
 func (pb *PullBehavior) Validate(comp *gc.Activity, actor ecs.Entity, world w.World) error {
-	if comp.Target == nil || !world.ECS.Alive(*comp.Target) {
+	p, ok := comp.Params.(*gc.PlaceParams)
+	if !ok || !world.ECS.Alive(p.Target) {
 		return fmt.Errorf("引く対象が存在しません")
 	}
-	if !world.Components.Pushable.Has(*comp.Target) {
+	if !world.Components.Pushable.Has(p.Target) {
 		return fmt.Errorf("対象は引けません")
 	}
-	if !world.Components.GridElement.Has(*comp.Target) || comp.Destination == nil {
+	if !world.Components.GridElement.Has(p.Target) {
 		return fmt.Errorf("引く対象に位置がありません")
 	}
 	if !world.Components.GridElement.Has(actor) {
 		return fmt.Errorf("引き手に位置がありません")
 	}
-	cubeCoord := world.Components.GridElement.Get(*comp.Target).Coord
-	retreat := pullRetreat(cubeCoord, comp.Destination.Coord)
+	cubeCoord := world.Components.GridElement.Get(p.Target).Coord
+	retreat := pullRetreat(cubeCoord, p.Destination.Coord)
 	// 後退先がプレイヤーの行ける先であること。キューブの入る先はプレイヤーが退いて空く
-	if !CanMoveTo(world, retreat, comp.Destination.Coord, actor) {
+	if !CanMoveTo(world, retreat, p.Destination.Coord, actor) {
 		return fmt.Errorf("引くスペースがありません")
 	}
 	return nil
@@ -242,17 +244,18 @@ func (pb *PullBehavior) Start(_ *gc.Activity, actor ecs.Entity, _ w.World) error
 
 // DoTurn はBehaviorの実装。毎ターン対象の生存と後退先の通行可否を確かめ、ターンを1つ消費する。
 func (pb *PullBehavior) DoTurn(comp *gc.Activity, actor ecs.Entity, world w.World) error {
-	if comp.Target == nil || !world.ECS.Alive(*comp.Target) {
+	p, ok := comp.Params.(*gc.PlaceParams)
+	if !ok || !world.ECS.Alive(p.Target) {
 		Cancel(comp, "引く対象が消えたため中断")
 		return nil
 	}
-	if comp.Destination == nil || !world.Components.GridElement.Has(*comp.Target) || !world.Components.GridElement.Has(actor) {
+	if !world.Components.GridElement.Has(p.Target) || !world.Components.GridElement.Has(actor) {
 		Cancel(comp, "引けなくなったため中断")
 		return nil
 	}
-	cubeCoord := world.Components.GridElement.Get(*comp.Target).Coord
-	retreat := pullRetreat(cubeCoord, comp.Destination.Coord)
-	if !CanMoveTo(world, retreat, comp.Destination.Coord, actor) {
+	cubeCoord := world.Components.GridElement.Get(p.Target).Coord
+	retreat := pullRetreat(cubeCoord, p.Destination.Coord)
+	if !CanMoveTo(world, retreat, p.Destination.Coord, actor) {
 		Cancel(comp, "引くスペースがなくなった")
 		return nil
 	}
@@ -267,22 +270,26 @@ func (pb *PullBehavior) DoTurn(comp *gc.Activity, actor ecs.Entity, world w.Worl
 
 // Finish はBehaviorの実装。キューブをプレイヤーの元タイルへ引き入れ、プレイヤーは1タイル後退する。
 func (pb *PullBehavior) Finish(comp *gc.Activity, actor ecs.Entity, world w.World) error {
-	cube := *comp.Target
+	p, ok := comp.Params.(*gc.PlaceParams)
+	if !ok {
+		return nil
+	}
+	cube := p.Target
 	if !world.ECS.Alive(cube) || !world.Components.GridElement.Has(cube) || !world.Components.GridElement.Has(actor) {
 		return nil
 	}
 	cubeGrid := world.Components.GridElement.Get(cube)
 	cubeOld := cubeGrid.Coord
-	retreat := pullRetreat(cubeOld, comp.Destination.Coord)
+	retreat := pullRetreat(cubeOld, p.Destination.Coord)
 
 	// 先にプレイヤーを後退させてタイルを空け、そこへキューブを引き入れる
 	world.Components.GridElement.Get(actor).Coord = retreat
-	cubeGrid.Coord = comp.Destination.Coord
+	cubeGrid.Coord = p.Destination.Coord
 
 	// キューブは BlockPass なので通行索引が変わる。全再構築で確実に反映する
 	query.InvalidateSpatialIndex(world)
 
-	log.Debug("引き完了", "actor", actor, "cube", cube, "to", comp.Destination.String())
+	log.Debug("引き完了", "actor", actor, "cube", cube, "to", p.Destination.String())
 	return nil
 }
 

--- a/internal/activity/push.go
+++ b/internal/activity/push.go
@@ -109,8 +109,8 @@ func (pb *PushBehavior) DoTurn(comp *gc.Activity, _ ecs.Entity, world w.World) e
 	}
 
 	// パーティの押し力を注ぐ。強いパーティほど速く動かす
-	comp.Accumulated += query.PartyPushPower(world)
-	if comp.Accumulated >= comp.Required {
+	comp.Progress.Current += query.PartyPushPower(world)
+	if comp.Progress.Current >= comp.Progress.Max {
 		Complete(comp)
 	}
 	return nil
@@ -277,8 +277,8 @@ func (pb *PullBehavior) DoTurn(comp *gc.Activity, actor ecs.Entity, world w.Worl
 	}
 
 	// パーティの押し力を注ぐ。強いパーティほど速く動かす
-	comp.Accumulated += query.PartyPushPower(world)
-	if comp.Accumulated >= comp.Required {
+	comp.Progress.Current += query.PartyPushPower(world)
+	if comp.Progress.Current >= comp.Progress.Max {
 		Complete(comp)
 	}
 	return nil

--- a/internal/activity/push.go
+++ b/internal/activity/push.go
@@ -15,20 +15,10 @@ import (
 // gc.Activity の Progress にパーティの押し力を累積して進捗を表す。重いキューブほど
 // 必要な総コストが増え、パーティAPが多いほど速く満ちる。
 //
-// Cube と Dir は着手時のパラメータで、BuildActivity だけが読む。BuildActivity はこの2つから
-// 押す対象と押し先を求め、gc.Activity の Target と Destination へ書き写す。
-// 継続処理は GetBehavior が毎回作る Cube も Dir もゼロ値のインスタンスで Validate・DoTurn・Finish を
-// 呼ぶ。すなわち NewPushBehavior で作った物ではない。だから着手後はフィールドを当てにせず、
-// gc.Activity の Target と Destination だけを読む。
-type PushBehavior struct {
-	Cube ecs.Entity
-	Dir  gc.Direction
-}
-
-// NewPushBehavior は押す対象キューブと押し向きを指定して押しアクティビティを作る。
-func NewPushBehavior(cube ecs.Entity, dir gc.Direction) *PushBehavior {
-	return &PushBehavior{Cube: cube, Dir: dir}
-}
+// 着手時のパラメータである押す対象キューブと押し向きは NewPushActivity が受け取り、
+// 押し先を求めて gc.Activity の Target と Destination へ書き込む。継続処理は状態を持たない
+// ゼロ値インスタンスで回るので、着手後は gc.Activity の Target と Destination だけを読む。
+type PushBehavior struct{}
 
 // Info はBehaviorの実装
 func (pb *PushBehavior) Info() Info {
@@ -47,14 +37,14 @@ func (pb *PushBehavior) Name() gc.BehaviorName {
 	return gc.BehaviorPush
 }
 
-// BuildActivity はBehaviorの実装。押し先タイルを求め、総重量とパーティAPから所要ターンを決める。
-func (pb *PushBehavior) BuildActivity(_ ecs.Entity, world w.World) (*gc.Activity, error) {
-	if !world.Components.GridElement.Has(pb.Cube) {
+// NewPushActivity は押すキューブと向きを指定して押しアクティビティを組む。
+func NewPushActivity(cube ecs.Entity, dir gc.Direction, world w.World) (*gc.Activity, error) {
+	if !world.Components.GridElement.Has(cube) {
 		return nil, fmt.Errorf("押す対象に位置がありません")
 	}
-	cubeCoord := world.Components.GridElement.Get(pb.Cube).Coord
-	dest := cubeCoord.Add(pb.Dir.GetDelta())
-	return buildCubeMove(pb, &pb.Cube, dest, world)
+	cubeCoord := world.Components.GridElement.Get(cube).Coord
+	dest := cubeCoord.Add(dir.GetDelta())
+	return buildCubeMove(gc.BehaviorPush, cube, dest, world)
 }
 
 // Validate はBehaviorの実装
@@ -155,33 +145,24 @@ func cubePushCost(world w.World) (int, error) {
 
 // buildCubeMove は押しと引きで共通の gc.Activity を組む。総コストは総重量で決まり、
 // 押し引きで違うのは対象キューブと移動先だけなので、それを引数で受ける。
-func buildCubeMove(behavior Behavior, cube *ecs.Entity, dest consts.Coord[consts.Tile], world w.World) (*gc.Activity, error) {
+func buildCubeMove(name gc.BehaviorName, cube ecs.Entity, dest consts.Coord[consts.Tile], world w.World) (*gc.Activity, error) {
 	required, err := cubePushCost(world)
 	if err != nil {
 		return nil, err
 	}
-	comp, err := NewActivity(behavior, required)
-	if err != nil {
-		return nil, err
-	}
-	comp.Target = cube
+	comp := newActivity(name, required)
+	c := cube
+	comp.Target = &c
 	comp.Destination = &gc.GridElement{Coord: dest}
 	return comp, nil
 }
 
 // PullBehavior は BehaviorPull の実装。プレイヤーが隣接する Pushable キューブを自分の側へ引き、
 // 自分は1タイル後退する。押しでは動かせない壁際・角のキューブを引き出して詰みを解く。
-// 所要ターンは押しと同じく総重量とパーティAPで決まる。Cube は着手時のパラメータで BuildActivity
-// だけが読み、gc.Activity の Target と Destination へ書き写す。継続処理は GetBehavior が毎回作る
-// Cube ゼロ値のインスタンスで呼ばれるので、着手後は gc.Activity 側だけを読む。
-type PullBehavior struct {
-	Cube ecs.Entity
-}
-
-// NewPullBehavior は引く対象キューブを指定して引きアクティビティを作る。
-func NewPullBehavior(cube ecs.Entity) *PullBehavior {
-	return &PullBehavior{Cube: cube}
-}
+// 総コストは押しと同じく総重量で決まる。着手時のパラメータである引く対象キューブは
+// NewPullActivity が受け取り、gc.Activity の Target と Destination へ書き込む。継続処理は
+// 状態を持たないゼロ値インスタンスで回るので、着手後は gc.Activity 側だけを読む。
+type PullBehavior struct{}
 
 // Info はBehaviorの実装
 func (pb *PullBehavior) Info() Info {
@@ -217,9 +198,9 @@ func canPullCube(world w.World, actor, cube ecs.Entity) bool {
 	return CanMoveTo(world, retreat, playerCoord, actor)
 }
 
-// BuildActivity はBehaviorの実装。キューブの移動先はプレイヤーの現在タイル、所要ターンは重量で決まる。
-func (pb *PullBehavior) BuildActivity(actor ecs.Entity, world w.World) (*gc.Activity, error) {
-	if !world.Components.GridElement.Has(pb.Cube) {
+// NewPullActivity は引くキューブと引き手を指定して引きアクティビティを組む。
+func NewPullActivity(cube, actor ecs.Entity, world w.World) (*gc.Activity, error) {
+	if !world.Components.GridElement.Has(cube) {
 		return nil, fmt.Errorf("引く対象に位置がありません")
 	}
 	if !world.Components.GridElement.Has(actor) {
@@ -227,7 +208,7 @@ func (pb *PullBehavior) BuildActivity(actor ecs.Entity, world w.World) (*gc.Acti
 	}
 	// キューブはプレイヤーの立っているタイルへ入る。プレイヤーはそのぶん後退する
 	dest := world.Components.GridElement.Get(actor).Coord
-	return buildCubeMove(pb, &pb.Cube, dest, world)
+	return buildCubeMove(gc.BehaviorPull, cube, dest, world)
 }
 
 // Validate はBehaviorの実装。後退先が通行可能であることを確かめる。

--- a/internal/activity/push.go
+++ b/internal/activity/push.go
@@ -12,14 +12,14 @@ import (
 
 // PushBehavior は BehaviorPush の実装。プレイヤーが隣接する Pushable キューブを押し方向へ
 // 1タイル動かす。分解などと同じ多ターン行動で、専用の進捗コンポーネントを持たず
-// gc.Activity のカウントダウンで進捗を表す。重いキューブほど所要ターンが増え、
-// パーティAPが多いほど減る。
+// gc.Activity の Progress にパーティの押し力を累積して進捗を表す。重いキューブほど
+// 必要な総コストが増え、パーティAPが多いほど速く満ちる。
 //
 // Cube と Dir は着手時のパラメータで、BuildActivity だけが読む。BuildActivity はこの2つから
 // 押す対象と押し先を求め、gc.Activity の Target と Destination へ書き写す。
-// 多ターンの継続処理は behaviors マップの共有インスタンス、すなわち NewPushBehavior で作った物では
-// なく Cube も Dir もゼロ値の1個で Validate・DoTurn・Finish を呼ぶ。だから着手後はフィールドを
-// 当てにせず、gc.Activity の Target と Destination だけを読む。
+// 継続処理は GetBehavior が毎回作る Cube も Dir もゼロ値のインスタンスで Validate・DoTurn・Finish を
+// 呼ぶ。すなわち NewPushBehavior で作った物ではない。だから着手後はフィールドを当てにせず、
+// gc.Activity の Target と Destination だけを読む。
 type PushBehavior struct {
 	Cube ecs.Entity
 	Dir  gc.Direction
@@ -172,8 +172,8 @@ func buildCubeMove(behavior Behavior, cube *ecs.Entity, dest consts.Coord[consts
 // PullBehavior は BehaviorPull の実装。プレイヤーが隣接する Pushable キューブを自分の側へ引き、
 // 自分は1タイル後退する。押しでは動かせない壁際・角のキューブを引き出して詰みを解く。
 // 所要ターンは押しと同じく総重量とパーティAPで決まる。Cube は着手時のパラメータで BuildActivity
-// だけが読み、gc.Activity の Target と Destination へ書き写す。継続処理は behaviors マップの
-// 共有インスタンス、Cube がゼロ値の1個で呼ばれるので、着手後は gc.Activity 側だけを読む。
+// だけが読み、gc.Activity の Target と Destination へ書き写す。継続処理は GetBehavior が毎回作る
+// Cube ゼロ値のインスタンスで呼ばれるので、着手後は gc.Activity 側だけを読む。
 type PullBehavior struct {
 	Cube ecs.Entity
 }

--- a/internal/activity/push.go
+++ b/internal/activity/push.go
@@ -150,7 +150,7 @@ func buildCubeMove(name gc.BehaviorName, cube ecs.Entity, dest consts.Coord[cons
 	if err != nil {
 		return nil, err
 	}
-	comp := newActivity(name, required)
+	comp := NewActivity(name, required)
 	c := cube
 	comp.Target = &c
 	comp.Destination = &gc.GridElement{Coord: dest}

--- a/internal/activity/push_test.go
+++ b/internal/activity/push_test.go
@@ -147,13 +147,11 @@ func TestExecuteMoveAction_キューブへの移動は押しになる(t *testing
 	cube := addCube(t, world, consts.Coord[consts.Tile]{X: 5, Y: 5})
 	player := addPusher(t, world, consts.Coord[consts.Tile]{X: 4, Y: 5}, consts.PushCostBase)
 
-	// 右へ移動入力すると、歩行でなく押しアクティビティが始まる
+	// 右へ移動入力すると、歩行でなく押しアクティビティが始まる。
+	// AP がちょうど足りるので初回ステップで押し切り、Execute 内で即時完了する
 	require.NoError(t, activity.ExecuteMoveAction(world, gc.DirectionRight))
 
-	// 押しは継続アクション。1ターン処理で押し切る
-	activity.ProcessContinuousActivities(world)
-
-	// AP がちょうど足りるので1ターンで押し切れる。キューブだけが前進し、押し手は追随しない
+	// キューブだけが前進し、押し手は追随しない
 	assert.Equal(t, consts.Coord[consts.Tile]{X: 6, Y: 5}, world.Components.GridElement.Get(cube).Coord)
 	assert.Equal(t, consts.Coord[consts.Tile]{X: 4, Y: 5}, world.Components.GridElement.Get(player).Coord, "押し手は追随せず元位置に留まる")
 }
@@ -167,9 +165,8 @@ func TestExecuteMoveAction_押しの次の入力で空いたタイルへ進む(t
 	cube := addCube(t, world, consts.Coord[consts.Tile]{X: 5, Y: 5})
 	player := addPusher(t, world, consts.Coord[consts.Tile]{X: 4, Y: 5}, consts.PushCostBase*2)
 
-	// 1回目: 押し。継続アクションを1ターン処理でキューブが {6,5} へ抜け、プレイヤーは {4,5} のまま
+	// 1回目: 押し。AP がちょうど足りるので初回ステップで完了し、キューブが {6,5} へ抜け、プレイヤーは {4,5} のまま
 	require.NoError(t, activity.ExecuteMoveAction(world, gc.DirectionRight))
-	activity.ProcessContinuousActivities(world)
 	require.Equal(t, consts.Coord[consts.Tile]{X: 6, Y: 5}, world.Components.GridElement.Get(cube).Coord)
 	require.Equal(t, consts.Coord[consts.Tile]{X: 4, Y: 5}, world.Components.GridElement.Get(player).Coord)
 
@@ -187,11 +184,9 @@ func TestPullBehavior_壁際のキューブを引き出せる(t *testing.T) {
 	addWall(t, world, consts.Coord[consts.Tile]{X: 4, Y: 5})
 	player := addPusher(t, world, consts.Coord[consts.Tile]{X: 6, Y: 5}, consts.PushCostBase)
 
+	// AP がちょうど足りるので初回ステップで引き切り、Execute 内で即時完了する
 	_, err := activity.Execute(activity.NewPullBehavior(cube), player, world)
 	require.NoError(t, err)
-
-	// 引きは継続アクション。1ターン処理で引き切る
-	activity.ProcessContinuousActivities(world)
 
 	assert.Equal(t, consts.Coord[consts.Tile]{X: 6, Y: 5}, world.Components.GridElement.Get(cube).Coord, "キューブはプレイヤーの元タイルへ引かれる")
 	assert.Equal(t, consts.Coord[consts.Tile]{X: 7, Y: 5}, world.Components.GridElement.Get(player).Coord, "プレイヤーは1タイル後退する")

--- a/internal/activity/push_test.go
+++ b/internal/activity/push_test.go
@@ -158,7 +158,7 @@ func TestExecuteMoveAction_キューブへの移動は押しになる(t *testing
 
 // TestExecuteMoveAction_押しの次の入力で空いたタイルへ進む は、押しでキューブが抜けた後、同じ方向を
 // もう一度入力するとプレイヤーが空いたタイルへ普通に一歩進むことを検証する。方向を押し続けると
-// 押しと移動が交互に起きてキューブが進む、案Aの体感を固定する。
+// 押しと移動が交互に起きてキューブが進む、という操作感を固定する。
 func TestExecuteMoveAction_押しの次の入力で空いたタイルへ進む(t *testing.T) {
 	t.Parallel()
 	world := testutil.InitTestWorld(t)

--- a/internal/activity/push_test.go
+++ b/internal/activity/push_test.go
@@ -75,7 +75,9 @@ func TestPushBehavior_総重量とパーティAPで決まる複数ターンを�
 	cube := addCube(t, world, consts.Coord[consts.Tile]{X: 5, Y: 5})
 	player := addPusher(t, world, consts.Coord[consts.Tile]{X: 4, Y: 5}, consts.PushCostBase/2)
 
-	result, err := activity.Execute(activity.NewPushBehavior(cube, gc.DirectionRight), player, world)
+	pushComp, perr := activity.NewPushActivity(cube, gc.DirectionRight, world)
+	require.NoError(t, perr)
+	result, err := activity.Execute(pushComp, player, world)
 	require.NoError(t, err)
 	assert.Equal(t, gc.ActivityStateRunning, result.State, "重いので初回では完了せず継続する")
 	assert.Equal(t, consts.Coord[consts.Tile]{X: 5, Y: 5}, world.Components.GridElement.Get(cube).Coord, "開始だけではまだ動かない")
@@ -111,7 +113,9 @@ func TestPushBehavior_内部に置いた物の重量が押しターンに乗る(
 	// 内部に 8kg を据えると PushCost が基準を超え、同じAPでは1ターンで足りなくなる
 	addInteriorWeight(t, world, 8*consts.MilligramPerKg)
 
-	result, err := activity.Execute(activity.NewPushBehavior(cube, gc.DirectionRight), player, world)
+	pushComp, perr := activity.NewPushActivity(cube, gc.DirectionRight, world)
+	require.NoError(t, perr)
+	result, err := activity.Execute(pushComp, player, world)
 	require.NoError(t, err)
 	assert.Equal(t, gc.ActivityStateRunning, result.State, "内部の重量ぶん所要ターンが増え、初回では完了しない")
 	assert.Equal(t, consts.Coord[consts.Tile]{X: 5, Y: 5}, world.Components.GridElement.Get(cube).Coord, "重くて1ターンでは動かない")
@@ -124,7 +128,9 @@ func TestPushBehavior_プレイヤーが行けない先へは押せない(t *tes
 	player := addPusher(t, world, consts.Coord[consts.Tile]{X: 4, Y: 5}, consts.PushCostBase)
 	addWall(t, world, consts.Coord[consts.Tile]{X: 6, Y: 5})
 
-	_, err := activity.Execute(activity.NewPushBehavior(cube, gc.DirectionRight), player, world)
+	pushComp, perr := activity.NewPushActivity(cube, gc.DirectionRight, world)
+	require.NoError(t, perr)
+	_, err := activity.Execute(pushComp, player, world)
 	require.Error(t, err, "押し先が壁なら押せない")
 	assert.Equal(t, consts.Coord[consts.Tile]{X: 5, Y: 5}, world.Components.GridElement.Get(cube).Coord, "押せなければキューブは動かない")
 }
@@ -133,10 +139,11 @@ func TestPushBehavior_APが無ければ押せない(t *testing.T) {
 	t.Parallel()
 	world := testutil.InitTestWorld(t)
 	cube := addCube(t, world, consts.Coord[consts.Tile]{X: 5, Y: 5})
-	player := addPusher(t, world, consts.Coord[consts.Tile]{X: 4, Y: 5}, 0)
+	addPusher(t, world, consts.Coord[consts.Tile]{X: 4, Y: 5}, 0)
 
-	_, err := activity.Execute(activity.NewPushBehavior(cube, gc.DirectionRight), player, world)
-	require.Error(t, err, "APが無ければ押せない")
+	// APが無ければ押しアクティビティの構築時点でエラーになる
+	_, perr := activity.NewPushActivity(cube, gc.DirectionRight, world)
+	require.Error(t, perr, "APが無ければ押せない")
 	assert.Equal(t, consts.Coord[consts.Tile]{X: 5, Y: 5}, world.Components.GridElement.Get(cube).Coord)
 }
 
@@ -185,7 +192,9 @@ func TestPullBehavior_壁際のキューブを引き出せる(t *testing.T) {
 	player := addPusher(t, world, consts.Coord[consts.Tile]{X: 6, Y: 5}, consts.PushCostBase)
 
 	// AP がちょうど足りるので初回ステップで引き切り、Execute 内で即時完了する
-	_, err := activity.Execute(activity.NewPullBehavior(cube), player, world)
+	pullComp, perr := activity.NewPullActivity(cube, player, world)
+	require.NoError(t, perr)
+	_, err := activity.Execute(pullComp, player, world)
 	require.NoError(t, err)
 
 	assert.Equal(t, consts.Coord[consts.Tile]{X: 6, Y: 5}, world.Components.GridElement.Get(cube).Coord, "キューブはプレイヤーの元タイルへ引かれる")
@@ -199,7 +208,9 @@ func TestPullBehavior_後退スペースが無ければ引けない(t *testing.T
 	player := addPusher(t, world, consts.Coord[consts.Tile]{X: 6, Y: 5}, consts.PushCostBase)
 	addWall(t, world, consts.Coord[consts.Tile]{X: 7, Y: 5}) // 後退先を塞ぐ
 
-	_, err := activity.Execute(activity.NewPullBehavior(cube), player, world)
+	pullComp, perr := activity.NewPullActivity(cube, player, world)
+	require.NoError(t, perr)
+	_, err := activity.Execute(pullComp, player, world)
 	require.Error(t, err, "後退スペースが無ければ引けない")
 	assert.Equal(t, consts.Coord[consts.Tile]{X: 5, Y: 5}, world.Components.GridElement.Get(cube).Coord, "引けないのでキューブは動かない")
 }

--- a/internal/activity/push_test.go
+++ b/internal/activity/push_test.go
@@ -150,6 +150,9 @@ func TestExecuteMoveAction_キューブへの移動は押しになる(t *testing
 	// 右へ移動入力すると、歩行でなく押しアクティビティが始まる
 	require.NoError(t, activity.ExecuteMoveAction(world, gc.DirectionRight))
 
+	// 押しは継続アクション。1ターン処理で押し切る
+	activity.ProcessContinuousActivities(world)
+
 	// AP がちょうど足りるので1ターンで押し切れる。キューブだけが前進し、押し手は追随しない
 	assert.Equal(t, consts.Coord[consts.Tile]{X: 6, Y: 5}, world.Components.GridElement.Get(cube).Coord)
 	assert.Equal(t, consts.Coord[consts.Tile]{X: 4, Y: 5}, world.Components.GridElement.Get(player).Coord, "押し手は追随せず元位置に留まる")
@@ -164,8 +167,9 @@ func TestExecuteMoveAction_押しの次の入力で空いたタイルへ進む(t
 	cube := addCube(t, world, consts.Coord[consts.Tile]{X: 5, Y: 5})
 	player := addPusher(t, world, consts.Coord[consts.Tile]{X: 4, Y: 5}, consts.PushCostBase*2)
 
-	// 1回目: 押し。キューブが {6,5} へ抜け、プレイヤーは {4,5} のまま
+	// 1回目: 押し。継続アクションを1ターン処理でキューブが {6,5} へ抜け、プレイヤーは {4,5} のまま
 	require.NoError(t, activity.ExecuteMoveAction(world, gc.DirectionRight))
+	activity.ProcessContinuousActivities(world)
 	require.Equal(t, consts.Coord[consts.Tile]{X: 6, Y: 5}, world.Components.GridElement.Get(cube).Coord)
 	require.Equal(t, consts.Coord[consts.Tile]{X: 4, Y: 5}, world.Components.GridElement.Get(player).Coord)
 
@@ -185,6 +189,9 @@ func TestPullBehavior_壁際のキューブを引き出せる(t *testing.T) {
 
 	_, err := activity.Execute(activity.NewPullBehavior(cube), player, world)
 	require.NoError(t, err)
+
+	// 引きは継続アクション。1ターン処理で引き切る
+	activity.ProcessContinuousActivities(world)
 
 	assert.Equal(t, consts.Coord[consts.Tile]{X: 6, Y: 5}, world.Components.GridElement.Get(cube).Coord, "キューブはプレイヤーの元タイルへ引かれる")
 	assert.Equal(t, consts.Coord[consts.Tile]{X: 7, Y: 5}, world.Components.GridElement.Get(player).Coord, "プレイヤーは1タイル後退する")

--- a/internal/activity/read.go
+++ b/internal/activity/read.go
@@ -127,7 +127,7 @@ func (rb *ReadBehavior) DoTurn(comp *gc.Activity, actor ecs.Entity, world w.Worl
 	rb.applyPerTurnEffect(book, actor, world, abilityValue)
 
 	// 進捗を activity 側にも反映して表示を揃える
-	comp.Accumulated = book.Effort.Current
+	comp.Progress.Current = book.Effort.Current
 
 	// 読了チェック
 	if book.IsCompleted() {

--- a/internal/activity/read.go
+++ b/internal/activity/read.go
@@ -15,9 +15,7 @@ import (
 )
 
 // ReadBehavior は読書アクティビティの実装
-type ReadBehavior struct {
-	Target ecs.Entity
-}
+type ReadBehavior struct{}
 
 // Info はBehaviorの実装
 func (rb *ReadBehavior) Info() Info {
@@ -35,18 +33,15 @@ func (rb *ReadBehavior) Name() gc.BehaviorName {
 	return gc.BehaviorRead
 }
 
-// BuildActivity はBehaviorの実装。読書の進捗は再開できるよう本エンティティの
-// Effort に保持する。Required には本の総工数を据え、進捗表示を Accumulated と揃える。
-func (rb *ReadBehavior) BuildActivity(_ ecs.Entity, world w.World) (*gc.Activity, error) {
-	book := rb.getBook(rb.Target, world)
+// NewReadActivity は読む本を指定して読書アクティビティを組む。進捗は本の Effort に
+// 永続するので、Progress.Max も本の総工数に据えて表示を揃える。
+func NewReadActivity(target ecs.Entity, world w.World) (*gc.Activity, error) {
+	book := getBook(target, world)
 	if book == nil {
 		return nil, fmt.Errorf("対象はBookコンポーネントを持っていません")
 	}
-	comp, err := NewActivity(rb, book.Effort.Max)
-	if err != nil {
-		return nil, err
-	}
-	comp.Target = &rb.Target
+	comp := newActivity(gc.BehaviorRead, book.Effort.Max)
+	comp.Target = &target
 	return comp, nil
 }
 
@@ -56,7 +51,7 @@ func (rb *ReadBehavior) Validate(comp *gc.Activity, actor ecs.Entity, world w.Wo
 		return fmt.Errorf("本が指定されていません")
 	}
 
-	book := rb.getBook(*comp.Target, world)
+	book := getBook(*comp.Target, world)
 	if book == nil {
 		return fmt.Errorf("対象はBookコンポーネントを持っていません")
 	}
@@ -83,7 +78,7 @@ func (rb *ReadBehavior) Start(comp *gc.Activity, actor ecs.Entity, world w.World
 		return ErrReadTargetNotSet
 	}
 
-	book := rb.getBook(*comp.Target, world)
+	book := getBook(*comp.Target, world)
 	if book == nil {
 		return fmt.Errorf("Bookコンポーネントが見つかりません")
 	}
@@ -111,7 +106,7 @@ func (rb *ReadBehavior) DoTurn(comp *gc.Activity, actor ecs.Entity, world w.Worl
 		return nil
 	}
 
-	book := rb.getBook(*comp.Target, world)
+	book := getBook(*comp.Target, world)
 	if book == nil {
 		Cancel(comp, "本が見つかりません")
 		return nil
@@ -143,7 +138,7 @@ func (rb *ReadBehavior) Finish(comp *gc.Activity, actor ecs.Entity, world w.Worl
 		return nil
 	}
 
-	book := rb.getBook(*comp.Target, world)
+	book := getBook(*comp.Target, world)
 	name := query.GetEntityName(*comp.Target, world)
 
 	if book != nil && book.IsCompleted() {
@@ -239,7 +234,7 @@ func (rb *ReadBehavior) getSkillAbilityValue(book *gc.Book, actor ecs.Entity, wo
 }
 
 // getBook は対象エンティティのBookコンポーネントを取得する
-func (rb *ReadBehavior) getBook(entity ecs.Entity, world w.World) *gc.Book {
+func getBook(entity ecs.Entity, world w.World) *gc.Book {
 	if !world.Components.Book.Has(entity) {
 		return nil
 	}

--- a/internal/activity/read.go
+++ b/internal/activity/read.go
@@ -41,17 +41,18 @@ func NewReadActivity(target ecs.Entity, world w.World) (*gc.Activity, error) {
 		return nil, fmt.Errorf("対象はBookコンポーネントを持っていません")
 	}
 	comp := NewActivity(gc.BehaviorRead, book.Effort.Max)
-	comp.Target = &target
+	comp.Params = &gc.TargetParams{Target: target}
 	return comp, nil
 }
 
 // Validate は読書アクティビティの検証を行う
 func (rb *ReadBehavior) Validate(comp *gc.Activity, actor ecs.Entity, world w.World) error {
-	if comp.Target == nil {
+	p, ok := comp.Params.(*gc.TargetParams)
+	if !ok {
 		return fmt.Errorf("本が指定されていません")
 	}
 
-	book := getBook(*comp.Target, world)
+	book := getBook(p.Target, world)
 	if book == nil {
 		return fmt.Errorf("対象はBookコンポーネントを持っていません")
 	}
@@ -74,16 +75,17 @@ func (rb *ReadBehavior) Validate(comp *gc.Activity, actor ecs.Entity, world w.Wo
 
 // Start は読書開始時の処理を実行する
 func (rb *ReadBehavior) Start(comp *gc.Activity, actor ecs.Entity, world w.World) error {
-	if comp.Target == nil {
+	p, ok := comp.Params.(*gc.TargetParams)
+	if !ok {
 		return ErrReadTargetNotSet
 	}
 
-	book := getBook(*comp.Target, world)
+	book := getBook(p.Target, world)
 	if book == nil {
 		return fmt.Errorf("Bookコンポーネントが見つかりません")
 	}
 
-	name := query.GetEntityName(*comp.Target, world)
+	name := query.GetEntityName(p.Target, world)
 	gamelog.New(query.GetGameLog(world)).
 		Append(fmt.Sprintf("「%s」を読み始めた", name)).
 		Log()
@@ -95,7 +97,12 @@ func (rb *ReadBehavior) Start(comp *gc.Activity, actor ecs.Entity, world w.World
 // DoTurn は読書アクティビティの1ターン分の処理を実行する。
 // スタック統合などで本エンティティが消えている可能性があるため、毎ターン先頭で生存を確認する
 func (rb *ReadBehavior) DoTurn(comp *gc.Activity, actor ecs.Entity, world w.World) error {
-	if !world.ECS.Alive(*comp.Target) {
+	p, ok := comp.Params.(*gc.TargetParams)
+	if !ok {
+		Cancel(comp, "本が指定されていません")
+		return nil
+	}
+	if !world.ECS.Alive(p.Target) {
 		Cancel(comp, "本が消えたため中断")
 		return nil
 	}
@@ -106,7 +113,7 @@ func (rb *ReadBehavior) DoTurn(comp *gc.Activity, actor ecs.Entity, world w.Worl
 		return nil
 	}
 
-	book := getBook(*comp.Target, world)
+	book := getBook(p.Target, world)
 	if book == nil {
 		Cancel(comp, "本が見つかりません")
 		return nil
@@ -134,12 +141,16 @@ func (rb *ReadBehavior) DoTurn(comp *gc.Activity, actor ecs.Entity, world w.Worl
 
 // Finish は読書完了時の処理を実行する
 func (rb *ReadBehavior) Finish(comp *gc.Activity, actor ecs.Entity, world w.World) error {
-	if !world.ECS.Alive(*comp.Target) {
+	p, ok := comp.Params.(*gc.TargetParams)
+	if !ok {
+		return nil
+	}
+	if !world.ECS.Alive(p.Target) {
 		return nil
 	}
 
-	book := getBook(*comp.Target, world)
-	name := query.GetEntityName(*comp.Target, world)
+	book := getBook(p.Target, world)
+	name := query.GetEntityName(p.Target, world)
 
 	if book != nil && book.IsCompleted() {
 		gamelog.New(query.GetGameLog(world)).
@@ -147,7 +158,7 @@ func (rb *ReadBehavior) Finish(comp *gc.Activity, actor ecs.Entity, world w.Worl
 			Log()
 
 		// 読了した本を消費する
-		if err := lifecycle.ChangeItemCount(world, *comp.Target, -1); err != nil {
+		if err := lifecycle.ChangeItemCount(world, p.Target, -1); err != nil {
 			return fmt.Errorf("本の消費に失敗: %w", err)
 		}
 	}
@@ -161,8 +172,8 @@ func (rb *ReadBehavior) Finish(comp *gc.Activity, actor ecs.Entity, world w.Worl
 func (rb *ReadBehavior) Canceled(comp *gc.Activity, actor ecs.Entity, world w.World) error {
 	if world.Components.Player.Has(actor) {
 		message := "読書を中断した"
-		if comp.Target != nil && world.ECS.Alive(*comp.Target) {
-			message = fmt.Sprintf("「%s」の読書を中断した", query.GetEntityName(*comp.Target, world))
+		if p, ok := comp.Params.(*gc.TargetParams); ok && world.ECS.Alive(p.Target) {
+			message = fmt.Sprintf("「%s」の読書を中断した", query.GetEntityName(p.Target, world))
 		}
 		gamelog.New(query.GetGameLog(world)).
 			Append(message).

--- a/internal/activity/read.go
+++ b/internal/activity/read.go
@@ -40,7 +40,7 @@ func NewReadActivity(target ecs.Entity, world w.World) (*gc.Activity, error) {
 	if book == nil {
 		return nil, fmt.Errorf("対象はBookコンポーネントを持っていません")
 	}
-	comp := newActivity(gc.BehaviorRead, book.Effort.Max)
+	comp := NewActivity(gc.BehaviorRead, book.Effort.Max)
 	comp.Target = &target
 	return comp, nil
 }

--- a/internal/activity/read.go
+++ b/internal/activity/read.go
@@ -16,8 +16,7 @@ import (
 
 // ReadBehavior は読書アクティビティの実装
 type ReadBehavior struct {
-	Target   ecs.Entity
-	Duration consts.Turn
+	Target ecs.Entity
 }
 
 // Info はBehaviorの実装
@@ -36,17 +35,14 @@ func (rb *ReadBehavior) Name() gc.BehaviorName {
 	return gc.BehaviorRead
 }
 
-// BuildActivity はBehaviorの実装
-func (rb *ReadBehavior) BuildActivity(actor ecs.Entity, world w.World) (*gc.Activity, error) {
-	duration := rb.Duration
-	if duration <= 0 {
-		characterAP, err := getEntityMaxAP(actor, world)
-		if err != nil {
-			return nil, err
-		}
-		duration = CalculateRequiredTurns(rb, characterAP)
+// BuildActivity はBehaviorの実装。読書の進捗は再開できるよう本エンティティの
+// Effort に保持する。Required には本の総工数を据え、進捗表示を Accumulated と揃える。
+func (rb *ReadBehavior) BuildActivity(_ ecs.Entity, world w.World) (*gc.Activity, error) {
+	book := rb.getBook(rb.Target, world)
+	if book == nil {
+		return nil, fmt.Errorf("対象はBookコンポーネントを持っていません")
 	}
-	comp, err := NewActivity(rb, duration)
+	comp, err := NewActivity(rb, book.Effort.Max)
 	if err != nil {
 		return nil, err
 	}
@@ -130,16 +126,11 @@ func (rb *ReadBehavior) DoTurn(comp *gc.Activity, actor ecs.Entity, world w.Worl
 	// 効果の適用（毎ターン）
 	rb.applyPerTurnEffect(book, actor, world, abilityValue)
 
-	// ターン進行
-	comp.TurnsLeft--
+	// 進捗を activity 側にも反映して表示を揃える
+	comp.Accumulated = book.Effort.Current
 
 	// 読了チェック
 	if book.IsCompleted() {
-		Complete(comp)
-		return nil
-	}
-
-	if comp.TurnsLeft <= 0 {
 		Complete(comp)
 	}
 

--- a/internal/activity/read.go
+++ b/internal/activity/read.go
@@ -41,13 +41,13 @@ func NewReadActivity(target ecs.Entity, world w.World) (*gc.Activity, error) {
 		return nil, fmt.Errorf("対象はBookコンポーネントを持っていません")
 	}
 	comp := NewActivity(gc.BehaviorRead, book.Effort.Max)
-	comp.Params = &gc.TargetParams{Target: target}
+	comp.Params = &gc.ReadParams{Target: target}
 	return comp, nil
 }
 
 // Validate は読書アクティビティの検証を行う
 func (rb *ReadBehavior) Validate(comp *gc.Activity, actor ecs.Entity, world w.World) error {
-	p, ok := comp.Params.(*gc.TargetParams)
+	p, ok := comp.Params.(*gc.ReadParams)
 	if !ok {
 		return fmt.Errorf("本が指定されていません")
 	}
@@ -75,7 +75,7 @@ func (rb *ReadBehavior) Validate(comp *gc.Activity, actor ecs.Entity, world w.Wo
 
 // Start は読書開始時の処理を実行する
 func (rb *ReadBehavior) Start(comp *gc.Activity, actor ecs.Entity, world w.World) error {
-	p, ok := comp.Params.(*gc.TargetParams)
+	p, ok := comp.Params.(*gc.ReadParams)
 	if !ok {
 		return ErrReadTargetNotSet
 	}
@@ -97,7 +97,7 @@ func (rb *ReadBehavior) Start(comp *gc.Activity, actor ecs.Entity, world w.World
 // DoTurn は読書アクティビティの1ターン分の処理を実行する。
 // スタック統合などで本エンティティが消えている可能性があるため、毎ターン先頭で生存を確認する
 func (rb *ReadBehavior) DoTurn(comp *gc.Activity, actor ecs.Entity, world w.World) error {
-	p, ok := comp.Params.(*gc.TargetParams)
+	p, ok := comp.Params.(*gc.ReadParams)
 	if !ok {
 		Cancel(comp, "本が指定されていません")
 		return nil
@@ -141,7 +141,7 @@ func (rb *ReadBehavior) DoTurn(comp *gc.Activity, actor ecs.Entity, world w.Worl
 
 // Finish は読書完了時の処理を実行する
 func (rb *ReadBehavior) Finish(comp *gc.Activity, actor ecs.Entity, world w.World) error {
-	p, ok := comp.Params.(*gc.TargetParams)
+	p, ok := comp.Params.(*gc.ReadParams)
 	if !ok {
 		return nil
 	}
@@ -172,7 +172,7 @@ func (rb *ReadBehavior) Finish(comp *gc.Activity, actor ecs.Entity, world w.Worl
 func (rb *ReadBehavior) Canceled(comp *gc.Activity, actor ecs.Entity, world w.World) error {
 	if world.Components.Player.Has(actor) {
 		message := "読書を中断した"
-		if p, ok := comp.Params.(*gc.TargetParams); ok && world.ECS.Alive(p.Target) {
+		if p, ok := comp.Params.(*gc.ReadParams); ok && world.ECS.Alive(p.Target) {
 			message = fmt.Sprintf("「%s」の読書を中断した", query.GetEntityName(p.Target, world))
 		}
 		gamelog.New(query.GetGameLog(world)).

--- a/internal/activity/read_test.go
+++ b/internal/activity/read_test.go
@@ -17,7 +17,7 @@ func TestReadBehavior_Validate_NoTarget(t *testing.T) {
 	actor := world.ECS.NewEntity()
 
 	ra := &ReadBehavior{}
-	comp := &gc.Activity{Target: nil}
+	comp := &gc.Activity{}
 	assert.Error(t, ra.Validate(comp, actor, world))
 }
 
@@ -29,7 +29,7 @@ func TestReadBehavior_Validate_NotABook(t *testing.T) {
 	item := world.ECS.NewEntity()
 
 	ra := &ReadBehavior{}
-	comp := &gc.Activity{Target: &item}
+	comp := &gc.Activity{Params: &gc.TargetParams{Target: item}}
 	assert.Error(t, ra.Validate(comp, actor, world))
 }
 
@@ -47,7 +47,7 @@ func TestReadBehavior_Validate_AlreadyCompleted(t *testing.T) {
 	world.Components.Book.Add(bookEntity, book)
 
 	ra := &ReadBehavior{}
-	comp := &gc.Activity{Target: &bookEntity}
+	comp := &gc.Activity{Params: &gc.TargetParams{Target: bookEntity}}
 	err := ra.Validate(comp, actor, world)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "読了済み")
@@ -69,7 +69,7 @@ func TestReadBehavior_Validate_RequiredLevelNotMet(t *testing.T) {
 	world.Components.Book.Add(bookEntity, book)
 
 	ra := &ReadBehavior{}
-	comp := &gc.Activity{Target: &bookEntity}
+	comp := &gc.Activity{Params: &gc.TargetParams{Target: bookEntity}}
 	err := ra.Validate(comp, actor, world)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "レベル3以上必要")
@@ -94,7 +94,7 @@ func TestReadBehavior_Validate_RequiredLevelMet(t *testing.T) {
 	world.Components.Book.Add(bookEntity, book)
 
 	ra := &ReadBehavior{}
-	comp := &gc.Activity{Target: &bookEntity}
+	comp := &gc.Activity{Params: &gc.TargetParams{Target: bookEntity}}
 	assert.NoError(t, ra.Validate(comp, actor, world))
 }
 
@@ -113,7 +113,7 @@ func TestReadBehavior_Validate_Success(t *testing.T) {
 	world.Components.Book.Add(bookEntity, book)
 
 	ra := &ReadBehavior{}
-	comp := &gc.Activity{Target: &bookEntity}
+	comp := &gc.Activity{Params: &gc.TargetParams{Target: bookEntity}}
 	assert.NoError(t, ra.Validate(comp, actor, world))
 }
 
@@ -139,7 +139,7 @@ func TestReadBehavior_DoTurn_AdvancesProgress(t *testing.T) {
 		BehaviorName: gc.BehaviorRead,
 		State:        gc.ActivityStateRunning,
 		Progress:     gc.IntPool{Max: 100},
-		Target:       &bookEntity,
+		Params:       &gc.TargetParams{Target: bookEntity},
 	}
 
 	err := ra.DoTurn(comp, actor, world)
@@ -172,7 +172,7 @@ func TestReadBehavior_DoTurn_GainsSkillExp(t *testing.T) {
 		BehaviorName: gc.BehaviorRead,
 		State:        gc.ActivityStateRunning,
 		Progress:     gc.IntPool{Max: 10},
-		Target:       &bookEntity,
+		Params:       &gc.TargetParams{Target: bookEntity},
 	}
 
 	before := skills.Get(gc.SkillSword).Exp.Current
@@ -205,7 +205,7 @@ func TestReadBehavior_DoTurn_NoExpWhenTooHard(t *testing.T) {
 		BehaviorName: gc.BehaviorRead,
 		State:        gc.ActivityStateRunning,
 		Progress:     gc.IntPool{Max: 10},
-		Target:       &bookEntity,
+		Params:       &gc.TargetParams{Target: bookEntity},
 	}
 
 	err := ra.DoTurn(comp, actor, world)
@@ -236,7 +236,7 @@ func TestReadBehavior_DoTurn_CompletesWhenEffortReached(t *testing.T) {
 		BehaviorName: gc.BehaviorRead,
 		State:        gc.ActivityStateRunning,
 		Progress:     gc.IntPool{Max: 15},
-		Target:       &bookEntity,
+		Params:       &gc.TargetParams{Target: bookEntity},
 	}
 
 	err := ra.DoTurn(comp, actor, world)
@@ -272,7 +272,7 @@ func TestReadBehavior_DoTurn_CanceledByEnemy(t *testing.T) {
 		BehaviorName: gc.BehaviorRead,
 		State:        gc.ActivityStateRunning,
 		Progress:     gc.IntPool{Max: 10},
-		Target:       &bookEntity,
+		Params:       &gc.TargetParams{Target: bookEntity},
 	}
 
 	err := ra.DoTurn(comp, actor, world)
@@ -309,7 +309,7 @@ func TestReadBehavior_DoTurn_SkillLevelUp(t *testing.T) {
 		BehaviorName: gc.BehaviorRead,
 		State:        gc.ActivityStateRunning,
 		Progress:     gc.IntPool{Max: 10},
-		Target:       &bookEntity,
+		Params:       &gc.TargetParams{Target: bookEntity},
 	}
 
 	err := ra.DoTurn(comp, actor, world)
@@ -342,7 +342,7 @@ func TestReadBehavior_NoSkillsComponent(t *testing.T) {
 		BehaviorName: gc.BehaviorRead,
 		State:        gc.ActivityStateRunning,
 		Progress:     gc.IntPool{Max: 10},
-		Target:       &bookEntity,
+		Params:       &gc.TargetParams{Target: bookEntity},
 	}
 
 	err := ra.DoTurn(comp, actor, world)
@@ -361,7 +361,7 @@ func TestReadBehavior_DoTurn_本が消えると中断する(t *testing.T) {
 	})
 
 	ra := &ReadBehavior{}
-	comp := &gc.Activity{Target: &bookEntity, State: gc.ActivityStateRunning, Progress: gc.IntPool{Max: 10}}
+	comp := &gc.Activity{Params: &gc.TargetParams{Target: bookEntity}, State: gc.ActivityStateRunning, Progress: gc.IntPool{Max: 10}}
 
 	world.ECS.RemoveEntity(bookEntity)
 
@@ -384,7 +384,7 @@ func TestReadBehavior_Finish_本が消えていれば何もしない(t *testing.
 	})
 
 	ra := &ReadBehavior{}
-	comp := &gc.Activity{Target: &bookEntity, State: gc.ActivityStateCompleted}
+	comp := &gc.Activity{Params: &gc.TargetParams{Target: bookEntity}, State: gc.ActivityStateCompleted}
 
 	world.ECS.RemoveEntity(bookEntity)
 

--- a/internal/activity/read_test.go
+++ b/internal/activity/read_test.go
@@ -29,7 +29,7 @@ func TestReadBehavior_Validate_NotABook(t *testing.T) {
 	item := world.ECS.NewEntity()
 
 	ra := &ReadBehavior{}
-	comp := &gc.Activity{Params: &gc.TargetParams{Target: item}}
+	comp := &gc.Activity{Params: &gc.ReadParams{Target: item}}
 	assert.Error(t, ra.Validate(comp, actor, world))
 }
 
@@ -47,7 +47,7 @@ func TestReadBehavior_Validate_AlreadyCompleted(t *testing.T) {
 	world.Components.Book.Add(bookEntity, book)
 
 	ra := &ReadBehavior{}
-	comp := &gc.Activity{Params: &gc.TargetParams{Target: bookEntity}}
+	comp := &gc.Activity{Params: &gc.ReadParams{Target: bookEntity}}
 	err := ra.Validate(comp, actor, world)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "読了済み")
@@ -69,7 +69,7 @@ func TestReadBehavior_Validate_RequiredLevelNotMet(t *testing.T) {
 	world.Components.Book.Add(bookEntity, book)
 
 	ra := &ReadBehavior{}
-	comp := &gc.Activity{Params: &gc.TargetParams{Target: bookEntity}}
+	comp := &gc.Activity{Params: &gc.ReadParams{Target: bookEntity}}
 	err := ra.Validate(comp, actor, world)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "レベル3以上必要")
@@ -94,7 +94,7 @@ func TestReadBehavior_Validate_RequiredLevelMet(t *testing.T) {
 	world.Components.Book.Add(bookEntity, book)
 
 	ra := &ReadBehavior{}
-	comp := &gc.Activity{Params: &gc.TargetParams{Target: bookEntity}}
+	comp := &gc.Activity{Params: &gc.ReadParams{Target: bookEntity}}
 	assert.NoError(t, ra.Validate(comp, actor, world))
 }
 
@@ -113,7 +113,7 @@ func TestReadBehavior_Validate_Success(t *testing.T) {
 	world.Components.Book.Add(bookEntity, book)
 
 	ra := &ReadBehavior{}
-	comp := &gc.Activity{Params: &gc.TargetParams{Target: bookEntity}}
+	comp := &gc.Activity{Params: &gc.ReadParams{Target: bookEntity}}
 	assert.NoError(t, ra.Validate(comp, actor, world))
 }
 
@@ -139,7 +139,7 @@ func TestReadBehavior_DoTurn_AdvancesProgress(t *testing.T) {
 		BehaviorName: gc.BehaviorRead,
 		State:        gc.ActivityStateRunning,
 		Progress:     gc.IntPool{Max: 100},
-		Params:       &gc.TargetParams{Target: bookEntity},
+		Params:       &gc.ReadParams{Target: bookEntity},
 	}
 
 	err := ra.DoTurn(comp, actor, world)
@@ -172,7 +172,7 @@ func TestReadBehavior_DoTurn_GainsSkillExp(t *testing.T) {
 		BehaviorName: gc.BehaviorRead,
 		State:        gc.ActivityStateRunning,
 		Progress:     gc.IntPool{Max: 10},
-		Params:       &gc.TargetParams{Target: bookEntity},
+		Params:       &gc.ReadParams{Target: bookEntity},
 	}
 
 	before := skills.Get(gc.SkillSword).Exp.Current
@@ -205,7 +205,7 @@ func TestReadBehavior_DoTurn_NoExpWhenTooHard(t *testing.T) {
 		BehaviorName: gc.BehaviorRead,
 		State:        gc.ActivityStateRunning,
 		Progress:     gc.IntPool{Max: 10},
-		Params:       &gc.TargetParams{Target: bookEntity},
+		Params:       &gc.ReadParams{Target: bookEntity},
 	}
 
 	err := ra.DoTurn(comp, actor, world)
@@ -236,7 +236,7 @@ func TestReadBehavior_DoTurn_CompletesWhenEffortReached(t *testing.T) {
 		BehaviorName: gc.BehaviorRead,
 		State:        gc.ActivityStateRunning,
 		Progress:     gc.IntPool{Max: 15},
-		Params:       &gc.TargetParams{Target: bookEntity},
+		Params:       &gc.ReadParams{Target: bookEntity},
 	}
 
 	err := ra.DoTurn(comp, actor, world)
@@ -272,7 +272,7 @@ func TestReadBehavior_DoTurn_CanceledByEnemy(t *testing.T) {
 		BehaviorName: gc.BehaviorRead,
 		State:        gc.ActivityStateRunning,
 		Progress:     gc.IntPool{Max: 10},
-		Params:       &gc.TargetParams{Target: bookEntity},
+		Params:       &gc.ReadParams{Target: bookEntity},
 	}
 
 	err := ra.DoTurn(comp, actor, world)
@@ -309,7 +309,7 @@ func TestReadBehavior_DoTurn_SkillLevelUp(t *testing.T) {
 		BehaviorName: gc.BehaviorRead,
 		State:        gc.ActivityStateRunning,
 		Progress:     gc.IntPool{Max: 10},
-		Params:       &gc.TargetParams{Target: bookEntity},
+		Params:       &gc.ReadParams{Target: bookEntity},
 	}
 
 	err := ra.DoTurn(comp, actor, world)
@@ -342,7 +342,7 @@ func TestReadBehavior_NoSkillsComponent(t *testing.T) {
 		BehaviorName: gc.BehaviorRead,
 		State:        gc.ActivityStateRunning,
 		Progress:     gc.IntPool{Max: 10},
-		Params:       &gc.TargetParams{Target: bookEntity},
+		Params:       &gc.ReadParams{Target: bookEntity},
 	}
 
 	err := ra.DoTurn(comp, actor, world)
@@ -361,7 +361,7 @@ func TestReadBehavior_DoTurn_本が消えると中断する(t *testing.T) {
 	})
 
 	ra := &ReadBehavior{}
-	comp := &gc.Activity{Params: &gc.TargetParams{Target: bookEntity}, State: gc.ActivityStateRunning, Progress: gc.IntPool{Max: 10}}
+	comp := &gc.Activity{Params: &gc.ReadParams{Target: bookEntity}, State: gc.ActivityStateRunning, Progress: gc.IntPool{Max: 10}}
 
 	world.ECS.RemoveEntity(bookEntity)
 
@@ -384,7 +384,7 @@ func TestReadBehavior_Finish_本が消えていれば何もしない(t *testing.
 	})
 
 	ra := &ReadBehavior{}
-	comp := &gc.Activity{Params: &gc.TargetParams{Target: bookEntity}, State: gc.ActivityStateCompleted}
+	comp := &gc.Activity{Params: &gc.ReadParams{Target: bookEntity}, State: gc.ActivityStateCompleted}
 
 	world.ECS.RemoveEntity(bookEntity)
 

--- a/internal/activity/read_test.go
+++ b/internal/activity/read_test.go
@@ -138,15 +138,14 @@ func TestReadBehavior_DoTurn_AdvancesProgress(t *testing.T) {
 	comp := &gc.Activity{
 		BehaviorName: gc.BehaviorRead,
 		State:        gc.ActivityStateRunning,
-		TurnsTotal:   100,
-		TurnsLeft:    100,
+		Required:     100,
 		Target:       &bookEntity,
 	}
 
 	err := ra.DoTurn(comp, actor, world)
 	require.NoError(t, err)
 	assert.Equal(t, 10, book.Effort.Current, "基本工数10ぶん進んでいる")
-	assert.Equal(t, consts.Turn(99), comp.TurnsLeft, "ターンが1減っている")
+	assert.Equal(t, 10, comp.Accumulated, "進捗がactivityにも反映されている")
 }
 
 func TestReadBehavior_DoTurn_GainsSkillExp(t *testing.T) {
@@ -172,8 +171,7 @@ func TestReadBehavior_DoTurn_GainsSkillExp(t *testing.T) {
 	comp := &gc.Activity{
 		BehaviorName: gc.BehaviorRead,
 		State:        gc.ActivityStateRunning,
-		TurnsTotal:   10,
-		TurnsLeft:    10,
+		Required:     10,
 		Target:       &bookEntity,
 	}
 
@@ -206,8 +204,7 @@ func TestReadBehavior_DoTurn_NoExpWhenTooHard(t *testing.T) {
 	comp := &gc.Activity{
 		BehaviorName: gc.BehaviorRead,
 		State:        gc.ActivityStateRunning,
-		TurnsTotal:   10,
-		TurnsLeft:    10,
+		Required:     10,
 		Target:       &bookEntity,
 	}
 
@@ -238,8 +235,7 @@ func TestReadBehavior_DoTurn_CompletesWhenEffortReached(t *testing.T) {
 	comp := &gc.Activity{
 		BehaviorName: gc.BehaviorRead,
 		State:        gc.ActivityStateRunning,
-		TurnsTotal:   5,
-		TurnsLeft:    1,
+		Required:     15,
 		Target:       &bookEntity,
 	}
 
@@ -275,8 +271,7 @@ func TestReadBehavior_DoTurn_CanceledByEnemy(t *testing.T) {
 	comp := &gc.Activity{
 		BehaviorName: gc.BehaviorRead,
 		State:        gc.ActivityStateRunning,
-		TurnsTotal:   10,
-		TurnsLeft:    10,
+		Required:     10,
 		Target:       &bookEntity,
 	}
 
@@ -313,8 +308,7 @@ func TestReadBehavior_DoTurn_SkillLevelUp(t *testing.T) {
 	comp := &gc.Activity{
 		BehaviorName: gc.BehaviorRead,
 		State:        gc.ActivityStateRunning,
-		TurnsTotal:   10,
-		TurnsLeft:    10,
+		Required:     10,
 		Target:       &bookEntity,
 	}
 
@@ -347,8 +341,7 @@ func TestReadBehavior_NoSkillsComponent(t *testing.T) {
 	comp := &gc.Activity{
 		BehaviorName: gc.BehaviorRead,
 		State:        gc.ActivityStateRunning,
-		TurnsTotal:   10,
-		TurnsLeft:    10,
+		Required:     10,
 		Target:       &bookEntity,
 	}
 
@@ -368,7 +361,7 @@ func TestReadBehavior_DoTurn_本が消えると中断する(t *testing.T) {
 	})
 
 	ra := &ReadBehavior{}
-	comp := &gc.Activity{Target: &bookEntity, State: gc.ActivityStateRunning, TurnsTotal: 5, TurnsLeft: 5}
+	comp := &gc.Activity{Target: &bookEntity, State: gc.ActivityStateRunning, Required: 10}
 
 	world.ECS.RemoveEntity(bookEntity)
 

--- a/internal/activity/read_test.go
+++ b/internal/activity/read_test.go
@@ -138,14 +138,14 @@ func TestReadBehavior_DoTurn_AdvancesProgress(t *testing.T) {
 	comp := &gc.Activity{
 		BehaviorName: gc.BehaviorRead,
 		State:        gc.ActivityStateRunning,
-		Required:     100,
+		Progress:     gc.IntPool{Max: 100},
 		Target:       &bookEntity,
 	}
 
 	err := ra.DoTurn(comp, actor, world)
 	require.NoError(t, err)
 	assert.Equal(t, 10, book.Effort.Current, "基本工数10ぶん進んでいる")
-	assert.Equal(t, 10, comp.Accumulated, "進捗がactivityにも反映されている")
+	assert.Equal(t, 10, comp.Progress.Current, "進捗がactivityにも反映されている")
 }
 
 func TestReadBehavior_DoTurn_GainsSkillExp(t *testing.T) {
@@ -171,7 +171,7 @@ func TestReadBehavior_DoTurn_GainsSkillExp(t *testing.T) {
 	comp := &gc.Activity{
 		BehaviorName: gc.BehaviorRead,
 		State:        gc.ActivityStateRunning,
-		Required:     10,
+		Progress:     gc.IntPool{Max: 10},
 		Target:       &bookEntity,
 	}
 
@@ -204,7 +204,7 @@ func TestReadBehavior_DoTurn_NoExpWhenTooHard(t *testing.T) {
 	comp := &gc.Activity{
 		BehaviorName: gc.BehaviorRead,
 		State:        gc.ActivityStateRunning,
-		Required:     10,
+		Progress:     gc.IntPool{Max: 10},
 		Target:       &bookEntity,
 	}
 
@@ -235,7 +235,7 @@ func TestReadBehavior_DoTurn_CompletesWhenEffortReached(t *testing.T) {
 	comp := &gc.Activity{
 		BehaviorName: gc.BehaviorRead,
 		State:        gc.ActivityStateRunning,
-		Required:     15,
+		Progress:     gc.IntPool{Max: 15},
 		Target:       &bookEntity,
 	}
 
@@ -271,7 +271,7 @@ func TestReadBehavior_DoTurn_CanceledByEnemy(t *testing.T) {
 	comp := &gc.Activity{
 		BehaviorName: gc.BehaviorRead,
 		State:        gc.ActivityStateRunning,
-		Required:     10,
+		Progress:     gc.IntPool{Max: 10},
 		Target:       &bookEntity,
 	}
 
@@ -308,7 +308,7 @@ func TestReadBehavior_DoTurn_SkillLevelUp(t *testing.T) {
 	comp := &gc.Activity{
 		BehaviorName: gc.BehaviorRead,
 		State:        gc.ActivityStateRunning,
-		Required:     10,
+		Progress:     gc.IntPool{Max: 10},
 		Target:       &bookEntity,
 	}
 
@@ -341,7 +341,7 @@ func TestReadBehavior_NoSkillsComponent(t *testing.T) {
 	comp := &gc.Activity{
 		BehaviorName: gc.BehaviorRead,
 		State:        gc.ActivityStateRunning,
-		Required:     10,
+		Progress:     gc.IntPool{Max: 10},
 		Target:       &bookEntity,
 	}
 
@@ -361,7 +361,7 @@ func TestReadBehavior_DoTurn_本が消えると中断する(t *testing.T) {
 	})
 
 	ra := &ReadBehavior{}
-	comp := &gc.Activity{Target: &bookEntity, State: gc.ActivityStateRunning, Required: 10}
+	comp := &gc.Activity{Target: &bookEntity, State: gc.ActivityStateRunning, Progress: gc.IntPool{Max: 10}}
 
 	world.ECS.RemoveEntity(bookEntity)
 

--- a/internal/activity/reload.go
+++ b/internal/activity/reload.go
@@ -18,10 +18,10 @@ const (
 	BaseReloadEffort = 10 // 1ターンあたりの基本装填工数
 )
 
-// ReloadBehavior はリロードアクティビティの実装
-type ReloadBehavior struct {
-	effortAccum int // 蓄積した装填工数
-}
+// ReloadBehavior はリロードアクティビティの実装。
+// 継続アクションの共有シングルトンとして behaviors マップに登録されるため、
+// 蓄積した装填工数などの進捗はフィールドに持たず gc.Activity 側に持たせる。
+type ReloadBehavior struct{}
 
 // Info はBehaviorの実装
 func (rb *ReloadBehavior) Info() Info {
@@ -79,7 +79,7 @@ func (rb *ReloadBehavior) Start(comp *gc.Activity, actor ecs.Entity, world w.Wor
 	comp.TurnsTotal = maxTurns
 	comp.TurnsLeft = maxTurns
 
-	rb.effortAccum = 0
+	comp.Accumulated = 0
 
 	gamelog.New(query.GetGameLog(world)).
 		Append("装填を開始した").
@@ -98,12 +98,12 @@ func (rb *ReloadBehavior) DoTurn(comp *gc.Activity, actor ecs.Entity, world w.Wo
 
 	// 1ターンあたりの工数を計算
 	effortPerTurn := rb.calcEffortPerTurn(actor, fire, world)
-	rb.effortAccum += effortPerTurn
+	comp.Accumulated += effortPerTurn
 
 	comp.TurnsLeft--
 
 	// 工数が目標に達したら装填完了
-	if rb.effortAccum >= fire.ReloadEffort {
+	if comp.Accumulated >= fire.ReloadEffort {
 		// 装填数を計算（マガジン容量と弾薬在庫の小さい方）
 		needed := fire.MagazineSize - fire.Magazine
 		ammoEntity, found := query.FindAmmoInInventory(world, fire.AmmoTag)

--- a/internal/activity/reload.go
+++ b/internal/activity/reload.go
@@ -39,13 +39,13 @@ func (rb *ReloadBehavior) Name() gc.BehaviorName {
 	return gc.BehaviorReload
 }
 
-// BuildActivity はBehaviorの実装
-func (rb *ReloadBehavior) BuildActivity(_ ecs.Entity, _ w.World) (*gc.Activity, error) {
-	comp, err := NewActivity(rb, 0)
+// NewReloadActivity は装填アクティビティを組む。必要総工数は装備中の遠距離武器から求める。
+func NewReloadActivity(actor ecs.Entity, world w.World) (*gc.Activity, error) {
+	fire, _, err := getEquippedFire(actor, world)
 	if err != nil {
 		return nil, err
 	}
-	return comp, nil
+	return newActivity(gc.BehaviorReload, fire.ReloadEffort), nil
 }
 
 // Validate はリロードの検証を行う
@@ -68,19 +68,10 @@ func (rb *ReloadBehavior) Validate(_ *gc.Activity, actor ecs.Entity, world w.Wor
 }
 
 // Start はリロード開始時の処理
-func (rb *ReloadBehavior) Start(comp *gc.Activity, actor ecs.Entity, world w.World) error {
-	fire, _, err := getEquippedFire(actor, world)
-	if err != nil {
-		return err
-	}
-
-	// 完了に必要な総装填工数
-	comp.Progress.Max = fire.ReloadEffort
-
+func (rb *ReloadBehavior) Start(_ *gc.Activity, _ ecs.Entity, world w.World) error {
 	gamelog.New(query.GetGameLog(world)).
 		Append("装填を開始した").
 		Log()
-
 	return nil
 }
 
@@ -166,8 +157,11 @@ func (rb *ReloadBehavior) calcEffortPerTurn(actor ecs.Entity, fire *gc.Fire, wor
 
 // ExecuteReloadAction はリロードアクションを実行する
 func ExecuteReloadAction(actor ecs.Entity, world w.World) error {
-	_, err := Execute(&ReloadBehavior{}, actor, world)
+	comp, err := NewReloadActivity(actor, world)
 	if err != nil {
+		return err
+	}
+	if _, err := Execute(comp, actor, world); err != nil {
 		return err
 	}
 	return nil

--- a/internal/activity/reload.go
+++ b/internal/activity/reload.go
@@ -45,7 +45,7 @@ func NewReloadActivity(actor ecs.Entity, world w.World) (*gc.Activity, error) {
 	if err != nil {
 		return nil, err
 	}
-	return newActivity(gc.BehaviorReload, fire.ReloadEffort), nil
+	return NewActivity(gc.BehaviorReload, fire.ReloadEffort), nil
 }
 
 // Validate はリロードの検証を行う

--- a/internal/activity/reload.go
+++ b/internal/activity/reload.go
@@ -75,7 +75,7 @@ func (rb *ReloadBehavior) Start(comp *gc.Activity, actor ecs.Entity, world w.Wor
 	}
 
 	// 完了に必要な総装填工数
-	comp.Required = fire.ReloadEffort
+	comp.Progress.Max = fire.ReloadEffort
 
 	gamelog.New(query.GetGameLog(world)).
 		Append("装填を開始した").
@@ -93,10 +93,10 @@ func (rb *ReloadBehavior) DoTurn(comp *gc.Activity, actor ecs.Entity, world w.Wo
 	}
 
 	// 1ターンあたりの工数を計算。能力が高いほど速く装填する
-	comp.Accumulated += rb.calcEffortPerTurn(actor, fire, world)
+	comp.Progress.Current += rb.calcEffortPerTurn(actor, fire, world)
 
 	// 工数が目標に達したら装填完了
-	if comp.Accumulated >= comp.Required {
+	if comp.Progress.Current >= comp.Progress.Max {
 		// 装填数を計算（マガジン容量と弾薬在庫の小さい方）
 		needed := fire.MagazineSize - fire.Magazine
 		ammoEntity, found := query.FindAmmoInInventory(world, fire.AmmoTag)

--- a/internal/activity/reload.go
+++ b/internal/activity/reload.go
@@ -19,7 +19,7 @@ const (
 )
 
 // ReloadBehavior はリロードアクティビティの実装。
-// 継続アクションの共有シングルトンとして behaviors マップに登録されるため、
+// 継続処理は GetBehavior が毎回作るゼロ値インスタンスで回るため、
 // 蓄積した装填工数などの進捗はフィールドに持たず gc.Activity 側に持たせる。
 type ReloadBehavior struct{}
 

--- a/internal/activity/reload.go
+++ b/internal/activity/reload.go
@@ -79,8 +79,6 @@ func (rb *ReloadBehavior) Start(comp *gc.Activity, actor ecs.Entity, world w.Wor
 	comp.TurnsTotal = maxTurns
 	comp.TurnsLeft = maxTurns
 
-	comp.Accumulated = 0
-
 	gamelog.New(query.GetGameLog(world)).
 		Append("装填を開始した").
 		Log()

--- a/internal/activity/reload.go
+++ b/internal/activity/reload.go
@@ -41,7 +41,7 @@ func (rb *ReloadBehavior) Name() gc.BehaviorName {
 
 // BuildActivity はBehaviorの実装
 func (rb *ReloadBehavior) BuildActivity(_ ecs.Entity, _ w.World) (*gc.Activity, error) {
-	comp, err := NewActivity(rb, 1)
+	comp, err := NewActivity(rb, 0)
 	if err != nil {
 		return nil, err
 	}
@@ -74,10 +74,8 @@ func (rb *ReloadBehavior) Start(comp *gc.Activity, actor ecs.Entity, world w.Wor
 		return err
 	}
 
-	// 最大ターン数の見積もり（最低能力の場合）
-	maxTurns := consts.Turn(max((fire.ReloadEffort+BaseReloadEffort-1)/BaseReloadEffort, 1))
-	comp.TurnsTotal = maxTurns
-	comp.TurnsLeft = maxTurns
+	// 完了に必要な総装填工数
+	comp.Required = fire.ReloadEffort
 
 	gamelog.New(query.GetGameLog(world)).
 		Append("装填を開始した").
@@ -94,14 +92,11 @@ func (rb *ReloadBehavior) DoTurn(comp *gc.Activity, actor ecs.Entity, world w.Wo
 		return err
 	}
 
-	// 1ターンあたりの工数を計算
-	effortPerTurn := rb.calcEffortPerTurn(actor, fire, world)
-	comp.Accumulated += effortPerTurn
-
-	comp.TurnsLeft--
+	// 1ターンあたりの工数を計算。能力が高いほど速く装填する
+	comp.Accumulated += rb.calcEffortPerTurn(actor, fire, world)
 
 	// 工数が目標に達したら装填完了
-	if comp.Accumulated >= fire.ReloadEffort {
+	if comp.Accumulated >= comp.Required {
 		// 装填数を計算（マガジン容量と弾薬在庫の小さい方）
 		needed := fire.MagazineSize - fire.Magazine
 		ammoEntity, found := query.FindAmmoInInventory(world, fire.AmmoTag)
@@ -129,10 +124,6 @@ func (rb *ReloadBehavior) DoTurn(comp *gc.Activity, actor ecs.Entity, world w.Wo
 
 		Complete(comp)
 		return nil
-	}
-
-	if comp.TurnsLeft <= 0 {
-		Complete(comp)
 	}
 
 	return nil

--- a/internal/activity/reload_test.go
+++ b/internal/activity/reload_test.go
@@ -34,10 +34,9 @@ func TestReloadBehavior_Validate(t *testing.T) {
 		fire.Magazine = 0
 
 		ra := &ReloadBehavior{}
-		comp, err := NewActivity(gc.BehaviorReload, 0)
-		require.NoError(t, err)
+		comp := NewActivity(gc.BehaviorReload, 0)
 
-		err = ra.Validate(comp, player, world)
+		err := ra.Validate(comp, player, world)
 		assert.NoError(t, err)
 	})
 
@@ -46,10 +45,9 @@ func TestReloadBehavior_Validate(t *testing.T) {
 		world, player, _, _ := setupShootingWorld(t)
 
 		ra := &ReloadBehavior{}
-		comp, err := NewActivity(gc.BehaviorReload, 0)
-		require.NoError(t, err)
+		comp := NewActivity(gc.BehaviorReload, 0)
 
-		err = ra.Validate(comp, player, world)
+		err := ra.Validate(comp, player, world)
 		assert.ErrorIs(t, err, ErrReloadNotNeeded)
 	})
 
@@ -70,8 +68,7 @@ func TestReloadBehavior_Validate(t *testing.T) {
 		fire.Magazine = 0
 
 		ra := &ReloadBehavior{}
-		comp, err := NewActivity(gc.BehaviorReload, 0)
-		require.NoError(t, err)
+		comp := NewActivity(gc.BehaviorReload, 0)
 
 		err = ra.Validate(comp, player, world)
 		assert.ErrorIs(t, err, ErrReloadNoAmmo)
@@ -90,8 +87,7 @@ func TestReloadBehavior_Validate(t *testing.T) {
 		query.GetWeaponSelection(world).Slot = 1
 
 		ra := &ReloadBehavior{}
-		comp, err := NewActivity(gc.BehaviorReload, 0)
-		require.NoError(t, err)
+		comp := NewActivity(gc.BehaviorReload, 0)
 
 		err = ra.Validate(comp, player, world)
 		assert.ErrorIs(t, err, ErrShootNoFireWeapon)

--- a/internal/activity/reload_test.go
+++ b/internal/activity/reload_test.go
@@ -204,7 +204,7 @@ func TestReloadBehavior_共有シングルトンでも進捗が混ざらない(t
 	b, err := GetBehavior(gc.BehaviorReload)
 	require.NoError(t, err)
 	ra, ok := b.(*ReloadBehavior)
-	require.True(t, ok)
+	require.True(t, ok, "GetBehavior(BehaviorReload) は *ReloadBehavior を返すべき")
 
 	// 同一シングルトンに通す2つの独立したアクティビティを用意する
 	comp1, err := NewActivity(ra, 0)

--- a/internal/activity/reload_test.go
+++ b/internal/activity/reload_test.go
@@ -34,7 +34,7 @@ func TestReloadBehavior_Validate(t *testing.T) {
 		fire.Magazine = 0
 
 		ra := &ReloadBehavior{}
-		comp, err := NewActivity(ra, 0)
+		comp, err := NewActivity(gc.BehaviorReload, 0)
 		require.NoError(t, err)
 
 		err = ra.Validate(comp, player, world)
@@ -46,7 +46,7 @@ func TestReloadBehavior_Validate(t *testing.T) {
 		world, player, _, _ := setupShootingWorld(t)
 
 		ra := &ReloadBehavior{}
-		comp, err := NewActivity(ra, 0)
+		comp, err := NewActivity(gc.BehaviorReload, 0)
 		require.NoError(t, err)
 
 		err = ra.Validate(comp, player, world)
@@ -70,7 +70,7 @@ func TestReloadBehavior_Validate(t *testing.T) {
 		fire.Magazine = 0
 
 		ra := &ReloadBehavior{}
-		comp, err := NewActivity(ra, 0)
+		comp, err := NewActivity(gc.BehaviorReload, 0)
 		require.NoError(t, err)
 
 		err = ra.Validate(comp, player, world)
@@ -90,7 +90,7 @@ func TestReloadBehavior_Validate(t *testing.T) {
 		query.GetWeaponSelection(world).Slot = 1
 
 		ra := &ReloadBehavior{}
-		comp, err := NewActivity(ra, 0)
+		comp, err := NewActivity(gc.BehaviorReload, 0)
 		require.NoError(t, err)
 
 		err = ra.Validate(comp, player, world)
@@ -108,11 +108,7 @@ func TestReloadBehavior_Start(t *testing.T) {
 		fire := world.Components.Fire.Get(weaponEntity)
 		fire.Magazine = 0
 
-		ra := &ReloadBehavior{}
-		comp, err := NewActivity(ra, 0)
-		require.NoError(t, err)
-
-		err = ra.Start(comp, player, world)
+		comp, err := NewReloadActivity(player, world)
 		require.NoError(t, err)
 
 		assert.Equal(t, fire.ReloadEffort, comp.Progress.Max)
@@ -130,7 +126,7 @@ func TestReloadBehavior_DoTurn(t *testing.T) {
 		fire.Magazine = 0
 
 		ra := &ReloadBehavior{}
-		comp, err := NewActivity(ra, 0)
+		comp, err := NewReloadActivity(player, world)
 		require.NoError(t, err)
 
 		err = ra.Start(comp, player, world)
@@ -169,7 +165,7 @@ func TestReloadBehavior_DoTurn(t *testing.T) {
 		require.NoError(t, err)
 
 		ra := &ReloadBehavior{}
-		comp, err := NewActivity(ra, 0)
+		comp, err := NewReloadActivity(player, world)
 		require.NoError(t, err)
 
 		err = ra.Start(comp, player, world)
@@ -207,11 +203,11 @@ func TestReloadBehavior_進捗はアクティビティごとに独立する(t *t
 	require.True(t, ok, "GetBehavior(BehaviorReload) は *ReloadBehavior を返すべき")
 
 	// 同一インスタンスに通す2つの独立したアクティビティを用意する
-	comp1, err := NewActivity(ra, 0)
+	comp1, err := NewReloadActivity(player, world)
 	require.NoError(t, err)
 	require.NoError(t, ra.Start(comp1, player, world))
 
-	comp2, err := NewActivity(ra, 0)
+	comp2, err := NewReloadActivity(player, world)
 	require.NoError(t, err)
 	require.NoError(t, ra.Start(comp2, player, world))
 

--- a/internal/activity/reload_test.go
+++ b/internal/activity/reload_test.go
@@ -115,7 +115,7 @@ func TestReloadBehavior_Start(t *testing.T) {
 		err = ra.Start(comp, player, world)
 		require.NoError(t, err)
 
-		assert.Equal(t, fire.ReloadEffort, comp.Required)
+		assert.Equal(t, fire.ReloadEffort, comp.Progress.Max)
 	})
 }
 
@@ -137,7 +137,7 @@ func TestReloadBehavior_DoTurn(t *testing.T) {
 		require.NoError(t, err)
 
 		// DoTurnを繰り返してリロード完了させる
-		for range comp.Required + 1 {
+		for range comp.Progress.Max + 1 {
 			if comp.State == gc.ActivityStateCompleted {
 				break
 			}
@@ -175,7 +175,7 @@ func TestReloadBehavior_DoTurn(t *testing.T) {
 		err = ra.Start(comp, player, world)
 		require.NoError(t, err)
 
-		for range comp.Required + 1 {
+		for range comp.Progress.Max + 1 {
 			if comp.State == gc.ActivityStateCompleted {
 				break
 			}
@@ -221,14 +221,14 @@ func TestReloadBehavior_共有シングルトンでも進捗が混ざらない(t
 
 	// comp1 を1ターン進める。自分の1ターン分だけ累積し、comp2 へ漏れてはいけない
 	require.NoError(t, ra.DoTurn(comp1, player, world))
-	assert.Equal(t, expected, comp1.Accumulated)
-	assert.Zero(t, comp2.Accumulated, "comp1 の進行が comp2 に漏れてはいけない")
+	assert.Equal(t, expected, comp1.Progress.Current)
+	assert.Zero(t, comp2.Progress.Current, "comp1 の進行が comp2 に漏れてはいけない")
 
 	// comp2 を1ターン進める。comp1 の累積を引き継がず、自分の1ターン分だけになるべき。
 	// 進捗をインスタンスに置くと comp2 は expected の2倍になり、comp1 も書き換わる
 	require.NoError(t, ra.DoTurn(comp2, player, world))
-	assert.Equal(t, expected, comp2.Accumulated, "comp2 は自分の1ターン分だけを累積すべき")
-	assert.Equal(t, expected, comp1.Accumulated, "comp2 の進行が comp1 の進捗を書き換えてはいけない")
+	assert.Equal(t, expected, comp2.Progress.Current, "comp2 は自分の1ターン分だけを累積すべき")
+	assert.Equal(t, expected, comp1.Progress.Current, "comp2 の進行が comp1 の進捗を書き換えてはいけない")
 }
 
 func TestReloadBehavior_CalcEffortPerTurn(t *testing.T) {

--- a/internal/activity/reload_test.go
+++ b/internal/activity/reload_test.go
@@ -189,6 +189,49 @@ func TestReloadBehavior_DoTurn(t *testing.T) {
 	})
 }
 
+// TestReloadBehavior_共有シングルトンでも進捗が混ざらない は、装填工数の累積を
+// Behavior インスタンスのフィールドではなく gc.Activity 側に持たせる規律を固定する。
+// 継続処理は behaviors マップの共有シングルトンで回るため、進捗をインスタンスに置くと
+// 複数エンティティの同時装填で互いの累積を書き換えてしまう。
+func TestReloadBehavior_共有シングルトンでも進捗が混ざらない(t *testing.T) {
+	t.Parallel()
+	world, player, _, weaponEntity := setupShootingWorld(t)
+
+	fire := world.Components.Fire.Get(weaponEntity)
+	fire.Magazine = 0
+	fire.ReloadEffort = 1_000_000 // 1ターンでは完了しない十分な工数にする
+
+	// 本番の継続処理と同じ共有シングルトンを取得する
+	b, err := GetBehavior(gc.BehaviorReload)
+	require.NoError(t, err)
+	ra, ok := b.(*ReloadBehavior)
+	require.True(t, ok)
+
+	// 同一シングルトンに通す2つの独立したアクティビティを用意する
+	comp1, err := NewActivity(ra, 1)
+	require.NoError(t, err)
+	require.NoError(t, ra.Start(comp1, player, world))
+
+	comp2, err := NewActivity(ra, 1)
+	require.NoError(t, err)
+	require.NoError(t, ra.Start(comp2, player, world))
+
+	// 1ターンあたりの工数。同一アクター・同一武器なので両アクティビティで等しい
+	expected := ra.calcEffortPerTurn(player, fire, world)
+	require.Positive(t, expected)
+
+	// comp1 を1ターン進める。自分の1ターン分だけ累積し、comp2 へ漏れてはいけない
+	require.NoError(t, ra.DoTurn(comp1, player, world))
+	assert.Equal(t, expected, comp1.Accumulated)
+	assert.Zero(t, comp2.Accumulated, "comp1 の進行が comp2 に漏れてはいけない")
+
+	// comp2 を1ターン進める。comp1 の累積を引き継がず、自分の1ターン分だけになるべき。
+	// 進捗をインスタンスに置くと comp2 は expected の2倍になり、comp1 も書き換わる
+	require.NoError(t, ra.DoTurn(comp2, player, world))
+	assert.Equal(t, expected, comp2.Accumulated, "comp2 は自分の1ターン分だけを累積すべき")
+	assert.Equal(t, expected, comp1.Accumulated, "comp2 の進行が comp1 の進捗を書き換えてはいけない")
+}
+
 func TestReloadBehavior_CalcEffortPerTurn(t *testing.T) {
 	t.Parallel()
 

--- a/internal/activity/reload_test.go
+++ b/internal/activity/reload_test.go
@@ -34,7 +34,7 @@ func TestReloadBehavior_Validate(t *testing.T) {
 		fire.Magazine = 0
 
 		ra := &ReloadBehavior{}
-		comp, err := NewActivity(ra, 1)
+		comp, err := NewActivity(ra, 0)
 		require.NoError(t, err)
 
 		err = ra.Validate(comp, player, world)
@@ -46,7 +46,7 @@ func TestReloadBehavior_Validate(t *testing.T) {
 		world, player, _, _ := setupShootingWorld(t)
 
 		ra := &ReloadBehavior{}
-		comp, err := NewActivity(ra, 1)
+		comp, err := NewActivity(ra, 0)
 		require.NoError(t, err)
 
 		err = ra.Validate(comp, player, world)
@@ -70,7 +70,7 @@ func TestReloadBehavior_Validate(t *testing.T) {
 		fire.Magazine = 0
 
 		ra := &ReloadBehavior{}
-		comp, err := NewActivity(ra, 1)
+		comp, err := NewActivity(ra, 0)
 		require.NoError(t, err)
 
 		err = ra.Validate(comp, player, world)
@@ -90,7 +90,7 @@ func TestReloadBehavior_Validate(t *testing.T) {
 		query.GetWeaponSelection(world).Slot = 1
 
 		ra := &ReloadBehavior{}
-		comp, err := NewActivity(ra, 1)
+		comp, err := NewActivity(ra, 0)
 		require.NoError(t, err)
 
 		err = ra.Validate(comp, player, world)
@@ -101,7 +101,7 @@ func TestReloadBehavior_Validate(t *testing.T) {
 func TestReloadBehavior_Start(t *testing.T) {
 	t.Parallel()
 
-	t.Run("ターン数が設定される", func(t *testing.T) {
+	t.Run("必要工数が設定される", func(t *testing.T) {
 		t.Parallel()
 		world, player, _, weaponEntity := setupShootingWorld(t)
 
@@ -109,14 +109,13 @@ func TestReloadBehavior_Start(t *testing.T) {
 		fire.Magazine = 0
 
 		ra := &ReloadBehavior{}
-		comp, err := NewActivity(ra, 1)
+		comp, err := NewActivity(ra, 0)
 		require.NoError(t, err)
 
 		err = ra.Start(comp, player, world)
 		require.NoError(t, err)
 
-		assert.Positive(t, comp.TurnsTotal)
-		assert.Equal(t, comp.TurnsTotal, comp.TurnsLeft)
+		assert.Equal(t, fire.ReloadEffort, comp.Required)
 	})
 }
 
@@ -131,14 +130,14 @@ func TestReloadBehavior_DoTurn(t *testing.T) {
 		fire.Magazine = 0
 
 		ra := &ReloadBehavior{}
-		comp, err := NewActivity(ra, 1)
+		comp, err := NewActivity(ra, 0)
 		require.NoError(t, err)
 
 		err = ra.Start(comp, player, world)
 		require.NoError(t, err)
 
 		// DoTurnを繰り返してリロード完了させる
-		for range comp.TurnsTotal + 1 {
+		for range comp.Required + 1 {
 			if comp.State == gc.ActivityStateCompleted {
 				break
 			}
@@ -170,13 +169,13 @@ func TestReloadBehavior_DoTurn(t *testing.T) {
 		require.NoError(t, err)
 
 		ra := &ReloadBehavior{}
-		comp, err := NewActivity(ra, 1)
+		comp, err := NewActivity(ra, 0)
 		require.NoError(t, err)
 
 		err = ra.Start(comp, player, world)
 		require.NoError(t, err)
 
-		for range comp.TurnsTotal + 1 {
+		for range comp.Required + 1 {
 			if comp.State == gc.ActivityStateCompleted {
 				break
 			}
@@ -208,11 +207,11 @@ func TestReloadBehavior_共有シングルトンでも進捗が混ざらない(t
 	require.True(t, ok)
 
 	// 同一シングルトンに通す2つの独立したアクティビティを用意する
-	comp1, err := NewActivity(ra, 1)
+	comp1, err := NewActivity(ra, 0)
 	require.NoError(t, err)
 	require.NoError(t, ra.Start(comp1, player, world))
 
-	comp2, err := NewActivity(ra, 1)
+	comp2, err := NewActivity(ra, 0)
 	require.NoError(t, err)
 	require.NoError(t, ra.Start(comp2, player, world))
 

--- a/internal/activity/reload_test.go
+++ b/internal/activity/reload_test.go
@@ -188,11 +188,11 @@ func TestReloadBehavior_DoTurn(t *testing.T) {
 	})
 }
 
-// TestReloadBehavior_共有シングルトンでも進捗が混ざらない は、装填工数の累積を
+// TestReloadBehavior_進捗はアクティビティごとに独立する は、装填工数の累積を
 // Behavior インスタンスのフィールドではなく gc.Activity 側に持たせる規律を固定する。
-// 継続処理は behaviors マップの共有シングルトンで回るため、進捗をインスタンスに置くと
-// 複数エンティティの同時装填で互いの累積を書き換えてしまう。
-func TestReloadBehavior_共有シングルトンでも進捗が混ざらない(t *testing.T) {
+// 進捗をインスタンスに置くと、1つのインスタンスへ複数アクティビティを通したとき
+// 互いの累積を書き換えてしまう。同時装填の破綻に相当する。
+func TestReloadBehavior_進捗はアクティビティごとに独立する(t *testing.T) {
 	t.Parallel()
 	world, player, _, weaponEntity := setupShootingWorld(t)
 
@@ -200,13 +200,13 @@ func TestReloadBehavior_共有シングルトンでも進捗が混ざらない(t
 	fire.Magazine = 0
 	fire.ReloadEffort = 1_000_000 // 1ターンでは完了しない十分な工数にする
 
-	// 本番の継続処理と同じ共有シングルトンを取得する
+	// Behavior を1つ取得する
 	b, err := GetBehavior(gc.BehaviorReload)
 	require.NoError(t, err)
 	ra, ok := b.(*ReloadBehavior)
 	require.True(t, ok, "GetBehavior(BehaviorReload) は *ReloadBehavior を返すべき")
 
-	// 同一シングルトンに通す2つの独立したアクティビティを用意する
+	// 同一インスタンスに通す2つの独立したアクティビティを用意する
 	comp1, err := NewActivity(ra, 0)
 	require.NoError(t, err)
 	require.NoError(t, ra.Start(comp1, player, world))

--- a/internal/activity/reload_test.go
+++ b/internal/activity/reload_test.go
@@ -196,7 +196,7 @@ func TestReloadBehavior_進捗はアクティビティごとに独立する(t *t
 	b, err := GetBehavior(gc.BehaviorReload)
 	require.NoError(t, err)
 	ra, ok := b.(*ReloadBehavior)
-	require.True(t, ok, "GetBehavior(BehaviorReload) は *ReloadBehavior を返すべき")
+	require.Truef(t, ok, "GetBehavior(BehaviorReload) は *ReloadBehavior を返すべきだが %T だった", b)
 
 	// 同一インスタンスに通す2つの独立したアクティビティを用意する
 	comp1, err := NewReloadActivity(player, world)

--- a/internal/activity/rest.go
+++ b/internal/activity/rest.go
@@ -46,7 +46,7 @@ func (rb *RestBehavior) Validate(comp *gc.Activity, actor ecs.Entity, world w.Wo
 	}
 
 	// 必要量が妥当かチェック
-	if comp.Required <= 0 {
+	if comp.Progress.Max <= 0 {
 		return fmt.Errorf("休息の必要量が無効です")
 	}
 
@@ -55,7 +55,7 @@ func (rb *RestBehavior) Validate(comp *gc.Activity, actor ecs.Entity, world w.Wo
 
 // Start は休息開始時の処理を実行する
 func (rb *RestBehavior) Start(comp *gc.Activity, actor ecs.Entity, _ w.World) error {
-	log.Debug("休息開始", "actor", actor, "required", comp.Required)
+	log.Debug("休息開始", "actor", actor, "required", comp.Progress.Max)
 	return nil
 }
 
@@ -68,7 +68,7 @@ func (rb *RestBehavior) DoTurn(comp *gc.Activity, actor ecs.Entity, world w.Worl
 	}
 
 	// 今ターンのAPを注ぐ。APが高いほど速く休息が進む
-	comp.Accumulated += perTurnAP(actor, world)
+	comp.Progress.Current += perTurnAP(actor, world)
 	log.Debug("休息進行", "progress", GetProgressPercent(comp))
 
 	// HP回復処理。満タンなら早期完了する
@@ -77,7 +77,7 @@ func (rb *RestBehavior) DoTurn(comp *gc.Activity, actor ecs.Entity, world w.Worl
 	}
 
 	// 必要量に達したら完了
-	if comp.Accumulated >= comp.Required {
+	if comp.Progress.Current >= comp.Progress.Max {
 		Complete(comp)
 	}
 

--- a/internal/activity/rest.go
+++ b/internal/activity/rest.go
@@ -13,9 +13,7 @@ import (
 )
 
 // RestBehavior はBehaviorの実装
-type RestBehavior struct {
-	Duration consts.Turn
-}
+type RestBehavior struct{}
 
 // Info はBehaviorの実装
 func (rb *RestBehavior) Info() Info {
@@ -34,21 +32,10 @@ func (rb *RestBehavior) Name() gc.BehaviorName {
 	return gc.BehaviorRest
 }
 
-// BuildActivity はBehaviorの実装
-func (rb *RestBehavior) BuildActivity(actor ecs.Entity, world w.World) (*gc.Activity, error) {
-	duration := rb.Duration
-	if duration <= 0 {
-		characterAP, err := getEntityMaxAP(actor, world)
-		if err != nil {
-			return nil, err
-		}
-		duration = CalculateRequiredTurns(rb, characterAP)
-	}
-	comp, err := NewActivity(rb, duration)
-	if err != nil {
-		return nil, err
-	}
-	return comp, nil
+// BuildActivity はBehaviorの実装。完了に必要な総APを Required に据える。
+// 毎ターン注ぐAPは DoTurn で再計算するため、AP変動へ追従する。
+func (rb *RestBehavior) BuildActivity(_ ecs.Entity, _ w.World) (*gc.Activity, error) {
+	return NewActivity(rb, rb.Info().TotalRequiredAP)
 }
 
 // Validate は休息アクティビティの検証を行う
@@ -58,9 +45,9 @@ func (rb *RestBehavior) Validate(comp *gc.Activity, actor ecs.Entity, world w.Wo
 		return fmt.Errorf("周囲に敵がいるため休息できません")
 	}
 
-	// 休息時間が妥当かチェック
-	if comp.TurnsTotal <= 0 {
-		return fmt.Errorf("休息時間が無効です")
+	// 必要量が妥当かチェック
+	if comp.Required <= 0 {
+		return fmt.Errorf("休息の必要量が無効です")
 	}
 
 	return nil
@@ -68,7 +55,7 @@ func (rb *RestBehavior) Validate(comp *gc.Activity, actor ecs.Entity, world w.Wo
 
 // Start は休息開始時の処理を実行する
 func (rb *RestBehavior) Start(comp *gc.Activity, actor ecs.Entity, _ w.World) error {
-	log.Debug("休息開始", "actor", actor, "duration", comp.TurnsLeft)
+	log.Debug("休息開始", "actor", actor, "required", comp.Required)
 	return nil
 }
 
@@ -80,27 +67,18 @@ func (rb *RestBehavior) DoTurn(comp *gc.Activity, actor ecs.Entity, world w.Worl
 		return fmt.Errorf("周囲に敵がいるため休息できません")
 	}
 
-	// 基本のターン処理
-	if comp.TurnsLeft <= 0 {
-		Complete(comp)
-		return nil
-	}
+	// 今ターンのAPを注ぐ。APが高いほど速く休息が進む
+	comp.Accumulated += perTurnAP(actor, world)
+	log.Debug("休息進行", "progress", GetProgressPercent(comp))
 
-	// 1ターン進行
-	comp.TurnsLeft--
-	log.Debug("休息進行",
-		"turns_left", comp.TurnsLeft,
-		"progress", GetProgressPercent(comp))
-
-	// HP回復処理
+	// HP回復処理。満タンなら早期完了する
 	if err := rb.performHealing(comp, actor, world); err != nil {
 		return err
 	}
 
-	// 完了チェック
-	if comp.TurnsLeft <= 0 {
+	// 必要量に達したら完了
+	if comp.Accumulated >= comp.Required {
 		Complete(comp)
-		return nil
 	}
 
 	return nil
@@ -172,13 +150,6 @@ func (rb *RestBehavior) performHealing(comp *gc.Activity, actor ecs.Entity, worl
 		hp.Current = hp.Max
 	}
 	actualHealing := hp.Current - beforeHP
-
-	// 5ターン毎にゲームログ出力（プレイヤーの場合のみ）
-	if world.Components.Player.Has(actor) && comp.TurnsTotal-comp.TurnsLeft > 0 && (comp.TurnsTotal-comp.TurnsLeft)%5 == 0 {
-		gamelog.New(query.GetGameLog(world)).
-			Append(fmt.Sprintf("HPが %d 回復した。", actualHealing)).
-			Log()
-	}
 
 	log.Debug("HP回復", "actor", actor, "amount", actualHealing)
 	return nil

--- a/internal/activity/rest.go
+++ b/internal/activity/rest.go
@@ -32,10 +32,9 @@ func (rb *RestBehavior) Name() gc.BehaviorName {
 	return gc.BehaviorRest
 }
 
-// BuildActivity はBehaviorの実装。完了に必要な総APを Required に据える。
-// 毎ターン注ぐAPは DoTurn で再計算するため、AP変動へ追従する。
-func (rb *RestBehavior) BuildActivity(_ ecs.Entity, _ w.World) (*gc.Activity, error) {
-	return NewActivity(rb, rb.Info().TotalRequiredAP)
+// NewRestActivity は休息アクティビティを組む。必要総APは Info の TotalRequiredAP。
+func NewRestActivity() *gc.Activity {
+	return newActivity(gc.BehaviorRest, (&RestBehavior{}).Info().TotalRequiredAP)
 }
 
 // Validate は休息アクティビティの検証を行う

--- a/internal/activity/rest.go
+++ b/internal/activity/rest.go
@@ -34,7 +34,7 @@ func (rb *RestBehavior) Name() gc.BehaviorName {
 
 // NewRestActivity は休息アクティビティを組む。必要総APは Info の TotalRequiredAP。
 func NewRestActivity() *gc.Activity {
-	return newActivity(gc.BehaviorRest, (&RestBehavior{}).Info().TotalRequiredAP)
+	return NewActivity(gc.BehaviorRest, (&RestBehavior{}).Info().TotalRequiredAP)
 }
 
 // Validate は休息アクティビティの検証を行う

--- a/internal/activity/rest_test.go
+++ b/internal/activity/rest_test.go
@@ -77,7 +77,7 @@ func TestRestBehavior_Validate(t *testing.T) {
 
 		comp := &gc.Activity{
 			BehaviorName: gc.BehaviorRest,
-			Required:     10,
+			Progress:     gc.IntPool{Max: 10},
 		}
 
 		ra := &RestBehavior{}
@@ -99,7 +99,7 @@ func TestRestBehavior_Validate(t *testing.T) {
 
 		comp := &gc.Activity{
 			BehaviorName: gc.BehaviorRest,
-			Required:     10,
+			Progress:     gc.IntPool{Max: 10},
 		}
 
 		ra := &RestBehavior{}
@@ -117,7 +117,7 @@ func TestRestBehavior_Validate(t *testing.T) {
 
 		comp := &gc.Activity{
 			BehaviorName: gc.BehaviorRest,
-			Required:     0,
+			Progress:     gc.IntPool{Max: 0},
 		}
 
 		ra := &RestBehavior{}
@@ -144,7 +144,7 @@ func TestRestBehavior_performHealing(t *testing.T) {
 
 		comp := &gc.Activity{
 			BehaviorName: gc.BehaviorRest,
-			Required:     10,
+			Progress:     gc.IntPool{Max: 10},
 		}
 
 		ra := &RestBehavior{}
@@ -168,7 +168,7 @@ func TestRestBehavior_performHealing(t *testing.T) {
 
 		comp := &gc.Activity{
 			BehaviorName: gc.BehaviorRest,
-			Required:     10,
+			Progress:     gc.IntPool{Max: 10},
 		}
 
 		ra := &RestBehavior{}
@@ -190,7 +190,7 @@ func TestRestBehavior_performHealing(t *testing.T) {
 		comp := &gc.Activity{
 			BehaviorName: gc.BehaviorRest,
 			State:        gc.ActivityStateRunning,
-			Required:     10,
+			Progress:     gc.IntPool{Max: 10},
 		}
 
 		ra := &RestBehavior{}
@@ -209,7 +209,7 @@ func TestRestBehavior_performHealing(t *testing.T) {
 
 		comp := &gc.Activity{
 			BehaviorName: gc.BehaviorRest,
-			Required:     10,
+			Progress:     gc.IntPool{Max: 10},
 		}
 
 		ra := &RestBehavior{}
@@ -240,7 +240,7 @@ func TestRestBehavior_所要はAP量で伸縮する(t *testing.T) {
 		comp := &gc.Activity{
 			BehaviorName: gc.BehaviorRest,
 			State:        gc.ActivityStateRunning,
-			Required:     1000,
+			Progress:     gc.IntPool{Max: 1000},
 		}
 		steps := 0
 		for !IsCompleted(comp) {
@@ -274,7 +274,7 @@ func TestRestBehavior_DoTurn(t *testing.T) {
 		comp := &gc.Activity{
 			BehaviorName: gc.BehaviorRest,
 			State:        gc.ActivityStateRunning,
-			Required:     1000000,
+			Progress:     gc.IntPool{Max: 1000000},
 		}
 
 		ra := &RestBehavior{}
@@ -282,7 +282,7 @@ func TestRestBehavior_DoTurn(t *testing.T) {
 
 		require.NoError(t, err)
 		// 今ターンのAP分だけ累積が進む
-		assert.Equal(t, perTurnAP(player, world), comp.Accumulated)
+		assert.Equal(t, perTurnAP(player, world), comp.Progress.Current)
 		assert.False(t, IsCompleted(comp))
 	})
 
@@ -301,7 +301,7 @@ func TestRestBehavior_DoTurn(t *testing.T) {
 		comp := &gc.Activity{
 			BehaviorName: gc.BehaviorRest,
 			State:        gc.ActivityStateRunning,
-			Required:     5,
+			Progress:     gc.IntPool{Max: 5},
 		}
 
 		ra := &RestBehavior{}
@@ -325,7 +325,7 @@ func TestRestBehavior_DoTurn(t *testing.T) {
 		comp := &gc.Activity{
 			BehaviorName: gc.BehaviorRest,
 			State:        gc.ActivityStateRunning,
-			Required:     1,
+			Progress:     gc.IntPool{Max: 1},
 		}
 
 		ra := &RestBehavior{}
@@ -349,7 +349,7 @@ func TestRestBehavior_DoTurn(t *testing.T) {
 		comp := &gc.Activity{
 			BehaviorName: gc.BehaviorRest,
 			State:        gc.ActivityStateRunning,
-			Required:     1,
+			Progress:     gc.IntPool{Max: 1},
 		}
 
 		ra := &RestBehavior{}

--- a/internal/activity/rest_test.go
+++ b/internal/activity/rest_test.go
@@ -77,7 +77,7 @@ func TestRestBehavior_Validate(t *testing.T) {
 
 		comp := &gc.Activity{
 			BehaviorName: gc.BehaviorRest,
-			TurnsTotal:   10,
+			Required:     10,
 		}
 
 		ra := &RestBehavior{}
@@ -99,7 +99,7 @@ func TestRestBehavior_Validate(t *testing.T) {
 
 		comp := &gc.Activity{
 			BehaviorName: gc.BehaviorRest,
-			TurnsTotal:   10,
+			Required:     10,
 		}
 
 		ra := &RestBehavior{}
@@ -108,7 +108,7 @@ func TestRestBehavior_Validate(t *testing.T) {
 		assert.Contains(t, err.Error(), "敵がいる")
 	})
 
-	t.Run("TurnsTotalが0以下の場合はエラー", func(t *testing.T) {
+	t.Run("Requiredが0以下の場合はエラー", func(t *testing.T) {
 		t.Parallel()
 		world := testutil.InitTestWorld(t)
 
@@ -117,13 +117,13 @@ func TestRestBehavior_Validate(t *testing.T) {
 
 		comp := &gc.Activity{
 			BehaviorName: gc.BehaviorRest,
-			TurnsTotal:   0,
+			Required:     0,
 		}
 
 		ra := &RestBehavior{}
 		err = ra.Validate(comp, player, world)
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "休息時間が無効")
+		assert.Contains(t, err.Error(), "休息の必要量が無効")
 	})
 }
 
@@ -144,8 +144,7 @@ func TestRestBehavior_performHealing(t *testing.T) {
 
 		comp := &gc.Activity{
 			BehaviorName: gc.BehaviorRest,
-			TurnsTotal:   10,
-			TurnsLeft:    5,
+			Required:     10,
 		}
 
 		ra := &RestBehavior{}
@@ -169,8 +168,7 @@ func TestRestBehavior_performHealing(t *testing.T) {
 
 		comp := &gc.Activity{
 			BehaviorName: gc.BehaviorRest,
-			TurnsTotal:   10,
-			TurnsLeft:    5,
+			Required:     10,
 		}
 
 		ra := &RestBehavior{}
@@ -192,8 +190,7 @@ func TestRestBehavior_performHealing(t *testing.T) {
 		comp := &gc.Activity{
 			BehaviorName: gc.BehaviorRest,
 			State:        gc.ActivityStateRunning,
-			TurnsTotal:   10,
-			TurnsLeft:    5,
+			Required:     10,
 		}
 
 		ra := &RestBehavior{}
@@ -212,14 +209,51 @@ func TestRestBehavior_performHealing(t *testing.T) {
 
 		comp := &gc.Activity{
 			BehaviorName: gc.BehaviorRest,
-			TurnsTotal:   10,
-			TurnsLeft:    5,
+			Required:     10,
 		}
 
 		ra := &RestBehavior{}
 		err := ra.performHealing(comp, player, world)
 		assert.NoError(t, err)
 	})
+}
+
+// TestRestBehavior_所要はAP量で伸縮する は doc 84 の核心を固定する。
+// 同じ必要量でも、毎ターン注げるAPが多いほど少ないターンで完了する。
+// 着手時にターン数を凍結せず、毎ターンのAPを累積するモデルであることを保証する。
+func TestRestBehavior_所要はAP量で伸縮する(t *testing.T) {
+	t.Parallel()
+
+	// 指定したAP最大値で、必要量に達するまでのターン数を数える
+	stepsToComplete := func(apMax int) int {
+		world := testutil.InitTestWorld(t)
+		player, err := lifecycle.SpawnPlayer(world, consts.Coord[consts.Tile]{X: 10, Y: 10}, "Ash")
+		require.NoError(t, err)
+
+		world.Components.TurnBased.Get(player).AP.Max = apMax
+		// HP回復での早期完了を避けるため、回復が追いつかない大きな余地を作る
+		hp := world.Components.HP.Get(player)
+		hp.Max = 1000000
+		hp.Current = 1
+
+		rb := &RestBehavior{}
+		comp := &gc.Activity{
+			BehaviorName: gc.BehaviorRest,
+			State:        gc.ActivityStateRunning,
+			Required:     1000,
+		}
+		steps := 0
+		for !IsCompleted(comp) {
+			require.NoError(t, rb.DoTurn(comp, player, world))
+			steps++
+			require.Less(t, steps, 100000, "無限ループ保険")
+		}
+		return steps
+	}
+
+	fast := stepsToComplete(500)
+	slow := stepsToComplete(100)
+	assert.Less(t, fast, slow, "APが多いほど少ないターンで休息が完了する")
 }
 
 func TestRestBehavior_DoTurn(t *testing.T) {
@@ -236,18 +270,20 @@ func TestRestBehavior_DoTurn(t *testing.T) {
 		hp := world.Components.HP.Get(player)
 		hp.Current = hp.Max / 2
 
+		// 必要量を十分大きくして、1ターンでは完了しないようにする
 		comp := &gc.Activity{
 			BehaviorName: gc.BehaviorRest,
 			State:        gc.ActivityStateRunning,
-			TurnsTotal:   5,
-			TurnsLeft:    3,
+			Required:     1000000,
 		}
 
 		ra := &RestBehavior{}
 		err = ra.DoTurn(comp, player, world)
 
 		require.NoError(t, err)
-		assert.Equal(t, consts.Turn(2), comp.TurnsLeft)
+		// 今ターンのAP分だけ累積が進む
+		assert.Equal(t, perTurnAP(player, world), comp.Accumulated)
+		assert.False(t, IsCompleted(comp))
 	})
 
 	t.Run("敵が近くにいる場合はキャンセルされる", func(t *testing.T) {
@@ -265,8 +301,7 @@ func TestRestBehavior_DoTurn(t *testing.T) {
 		comp := &gc.Activity{
 			BehaviorName: gc.BehaviorRest,
 			State:        gc.ActivityStateRunning,
-			TurnsTotal:   5,
-			TurnsLeft:    3,
+			Required:     5,
 		}
 
 		ra := &RestBehavior{}
@@ -276,18 +311,21 @@ func TestRestBehavior_DoTurn(t *testing.T) {
 		assert.Equal(t, gc.ActivityStateCanceled, comp.State)
 	})
 
-	t.Run("TurnsLeftが0以下なら完了", func(t *testing.T) {
+	t.Run("必要量に達したら完了", func(t *testing.T) {
 		t.Parallel()
 		world := testutil.InitTestWorld(t)
 
 		player, err := lifecycle.SpawnPlayer(world, consts.Coord[consts.Tile]{X: 10, Y: 10}, "Ash")
 		require.NoError(t, err)
 
+		// HPを減らして満タン早期完了を避け、必要量到達での完了を確かめる
+		hp := world.Components.HP.Get(player)
+		hp.Current = hp.Max / 2
+
 		comp := &gc.Activity{
 			BehaviorName: gc.BehaviorRest,
 			State:        gc.ActivityStateRunning,
-			TurnsTotal:   5,
-			TurnsLeft:    0,
+			Required:     1,
 		}
 
 		ra := &RestBehavior{}
@@ -311,8 +349,7 @@ func TestRestBehavior_DoTurn(t *testing.T) {
 		comp := &gc.Activity{
 			BehaviorName: gc.BehaviorRest,
 			State:        gc.ActivityStateRunning,
-			TurnsTotal:   5,
-			TurnsLeft:    1,
+			Required:     1,
 		}
 
 		ra := &RestBehavior{}
@@ -320,7 +357,6 @@ func TestRestBehavior_DoTurn(t *testing.T) {
 
 		require.NoError(t, err)
 		assert.Equal(t, gc.ActivityStateCompleted, comp.State)
-		assert.Equal(t, consts.Turn(0), comp.TurnsLeft)
 	})
 }
 

--- a/internal/activity/rest_test.go
+++ b/internal/activity/rest_test.go
@@ -218,9 +218,9 @@ func TestRestBehavior_performHealing(t *testing.T) {
 	})
 }
 
-// TestRestBehavior_所要はAP量で伸縮する は doc 84 の核心を固定する。
-// 同じ必要量でも、毎ターン注げるAPが多いほど少ないターンで完了する。
-// 着手時にターン数を凍結せず、毎ターンのAPを累積するモデルであることを保証する。
+// TestRestBehavior_所要はAP量で伸縮する は、同じ必要量でも毎ターン注げるAPが多いほど
+// 少ないターンで完了することを固定する。着手時にターン数を凍結せず、毎ターンのAPを
+// 累積するモデルであることを保証する。
 func TestRestBehavior_所要はAP量で伸縮する(t *testing.T) {
 	t.Parallel()
 

--- a/internal/activity/rest_test.go
+++ b/internal/activity/rest_test.go
@@ -237,11 +237,8 @@ func TestRestBehavior_所要はAP量で伸縮する(t *testing.T) {
 		hp.Current = 1
 
 		rb := &RestBehavior{}
-		comp := &gc.Activity{
-			BehaviorName: gc.BehaviorRest,
-			State:        gc.ActivityStateRunning,
-			Progress:     gc.IntPool{Max: 1000},
-		}
+		// 休息の必要総量は NewRestActivity が Info の TotalRequiredAP から据える
+		comp := NewRestActivity()
 		steps := 0
 		for !IsCompleted(comp) {
 			require.NoError(t, rb.DoTurn(comp, player, world))

--- a/internal/activity/shoot.go
+++ b/internal/activity/shoot.go
@@ -19,9 +19,7 @@ const (
 )
 
 // ShootBehavior は射撃アクティビティの実装
-type ShootBehavior struct {
-	Target ecs.Entity
-}
+type ShootBehavior struct{}
 
 // Info はBehaviorの実装
 func (sb *ShootBehavior) Info() Info {
@@ -39,14 +37,11 @@ func (sb *ShootBehavior) Name() gc.BehaviorName {
 	return gc.BehaviorShoot
 }
 
-// BuildActivity はBehaviorの実装
-func (sb *ShootBehavior) BuildActivity(_ ecs.Entity, _ w.World) (*gc.Activity, error) {
-	comp, err := NewActivity(sb, 0)
-	if err != nil {
-		return nil, err
-	}
-	comp.Target = &sb.Target
-	return comp, nil
+// NewShootActivity は射撃対象を指定して射撃アクティビティを組む。
+func NewShootActivity(target ecs.Entity) *gc.Activity {
+	comp := newActivity(gc.BehaviorShoot, 0)
+	comp.Target = &target
+	return comp
 }
 
 // Validate は射撃の検証を行う
@@ -220,13 +215,8 @@ func checkLineOfSight(actor, target ecs.Entity, world w.World) (blocked bool, co
 // CanShootTarget はactorからtargetに射撃可能かを判定する。
 // 射撃対象選択UIでのフィルタリング用
 func CanShootTarget(actor, target ecs.Entity, world w.World) bool {
-	sb := &ShootBehavior{}
-	comp, err := NewActivity(sb, 0)
-	if err != nil {
-		return false
-	}
-	comp.Target = &target
-	return sb.Validate(comp, actor, world) == nil
+	comp := NewShootActivity(target)
+	return (&ShootBehavior{}).Validate(comp, actor, world) == nil
 }
 
 // CalculateShootHitRate は射撃の命中率を計算して返す。情報パネル表示用
@@ -244,7 +234,7 @@ func CalculateShootHitRate(actor, target ecs.Entity, world w.World) int {
 
 // ExecuteShootAction は射撃アクションを実行する
 func ExecuteShootAction(actor ecs.Entity, target ecs.Entity, world w.World) error {
-	_, err := Execute(&ShootBehavior{Target: target}, actor, world)
+	_, err := Execute(NewShootActivity(target), actor, world)
 	if err != nil {
 		return err
 	}

--- a/internal/activity/shoot.go
+++ b/internal/activity/shoot.go
@@ -39,7 +39,7 @@ func (sb *ShootBehavior) Name() gc.BehaviorName {
 
 // NewShootActivity は射撃対象を指定して射撃アクティビティを組む。
 func NewShootActivity(target ecs.Entity) *gc.Activity {
-	comp := newActivity(gc.BehaviorShoot, 0)
+	comp := NewActivity(gc.BehaviorShoot, 0)
 	comp.Target = &target
 	return comp
 }

--- a/internal/activity/shoot.go
+++ b/internal/activity/shoot.go
@@ -40,22 +40,23 @@ func (sb *ShootBehavior) Name() gc.BehaviorName {
 // NewShootActivity は射撃対象を指定して射撃アクティビティを組む。
 func NewShootActivity(target ecs.Entity) *gc.Activity {
 	comp := NewActivity(gc.BehaviorShoot, 0)
-	comp.Target = &target
+	comp.Params = &gc.TargetParams{Target: target}
 	return comp
 }
 
 // Validate は射撃の検証を行う
 func (sb *ShootBehavior) Validate(comp *gc.Activity, actor ecs.Entity, world w.World) error {
-	if comp.Target == nil {
+	p, ok := comp.Params.(*gc.TargetParams)
+	if !ok {
 		return ErrAttackTargetNotSet
 	}
 	if world.Components.Dead.Has(actor) {
 		return ErrAttackerDead
 	}
-	if !world.Components.GridElement.Has(*comp.Target) {
+	if !world.Components.GridElement.Has(p.Target) {
 		return ErrAttackTargetNotExists
 	}
-	if world.Components.Dead.Has(*comp.Target) {
+	if world.Components.Dead.Has(p.Target) {
 		return ErrAttackTargetDead
 	}
 
@@ -71,9 +72,9 @@ func (sb *ShootBehavior) Validate(comp *gc.Activity, actor ecs.Entity, world w.W
 	}
 
 	// 射程・射線チェック
-	distance := EntityDistance(actor, *comp.Target, world)
-	rangeParams, ok := gc.GetRangeParams(fire.AttackCategory)
-	if !ok {
+	distance := EntityDistance(actor, p.Target, world)
+	rangeParams, rangeOK := gc.GetRangeParams(fire.AttackCategory)
+	if !rangeOK {
 		return ErrShootNoFireWeapon
 	}
 	if distance > float64(rangeParams.MaxRange) {
@@ -81,7 +82,7 @@ func (sb *ShootBehavior) Validate(comp *gc.Activity, actor ecs.Entity, world w.W
 	}
 
 	// 射線上に壁がないか
-	if blocked, _ := checkLineOfSight(actor, *comp.Target, world); blocked {
+	if blocked, _ := checkLineOfSight(actor, p.Target, world); blocked {
 		return ErrShootLineOfSightBlocked
 	}
 
@@ -90,18 +91,21 @@ func (sb *ShootBehavior) Validate(comp *gc.Activity, actor ecs.Entity, world w.W
 
 // Start はBehaviorの実装
 func (sb *ShootBehavior) Start(comp *gc.Activity, actor ecs.Entity, _ w.World) error {
-	log.Debug("射撃開始", "actor", actor, "target", *comp.Target)
+	if p, ok := comp.Params.(*gc.TargetParams); ok {
+		log.Debug("射撃開始", "actor", actor, "target", p.Target)
+	}
 	return nil
 }
 
 // DoTurn は射撃の実行処理
 func (sb *ShootBehavior) DoTurn(comp *gc.Activity, actor ecs.Entity, world w.World) error {
-	if comp.Target == nil {
+	p, ok := comp.Params.(*gc.TargetParams)
+	if !ok {
 		Cancel(comp, "射撃対象が設定されていません")
 		return ErrAttackTargetNotSet
 	}
 
-	target := *comp.Target
+	target := p.Target
 
 	// 装備武器を取得
 	fire, weaponName, err := getEquippedFire(actor, world)

--- a/internal/activity/shoot.go
+++ b/internal/activity/shoot.go
@@ -41,7 +41,7 @@ func (sb *ShootBehavior) Name() gc.BehaviorName {
 
 // BuildActivity はBehaviorの実装
 func (sb *ShootBehavior) BuildActivity(_ ecs.Entity, _ w.World) (*gc.Activity, error) {
-	comp, err := NewActivity(sb, 1)
+	comp, err := NewActivity(sb, 0)
 	if err != nil {
 		return nil, err
 	}
@@ -221,7 +221,7 @@ func checkLineOfSight(actor, target ecs.Entity, world w.World) (blocked bool, co
 // 射撃対象選択UIでのフィルタリング用
 func CanShootTarget(actor, target ecs.Entity, world w.World) bool {
 	sb := &ShootBehavior{}
-	comp, err := NewActivity(sb, 1)
+	comp, err := NewActivity(sb, 0)
 	if err != nil {
 		return false
 	}

--- a/internal/activity/shoot.go
+++ b/internal/activity/shoot.go
@@ -40,13 +40,13 @@ func (sb *ShootBehavior) Name() gc.BehaviorName {
 // NewShootActivity は射撃対象を指定して射撃アクティビティを組む。
 func NewShootActivity(target ecs.Entity) *gc.Activity {
 	comp := NewActivity(gc.BehaviorShoot, 0)
-	comp.Params = &gc.TargetParams{Target: target}
+	comp.Params = &gc.ShootParams{Target: target}
 	return comp
 }
 
 // Validate は射撃の検証を行う
 func (sb *ShootBehavior) Validate(comp *gc.Activity, actor ecs.Entity, world w.World) error {
-	p, ok := comp.Params.(*gc.TargetParams)
+	p, ok := comp.Params.(*gc.ShootParams)
 	if !ok {
 		return ErrAttackTargetNotSet
 	}
@@ -91,7 +91,7 @@ func (sb *ShootBehavior) Validate(comp *gc.Activity, actor ecs.Entity, world w.W
 
 // Start はBehaviorの実装
 func (sb *ShootBehavior) Start(comp *gc.Activity, actor ecs.Entity, _ w.World) error {
-	if p, ok := comp.Params.(*gc.TargetParams); ok {
+	if p, ok := comp.Params.(*gc.ShootParams); ok {
 		log.Debug("射撃開始", "actor", actor, "target", p.Target)
 	}
 	return nil
@@ -99,7 +99,7 @@ func (sb *ShootBehavior) Start(comp *gc.Activity, actor ecs.Entity, _ w.World) e
 
 // DoTurn は射撃の実行処理
 func (sb *ShootBehavior) DoTurn(comp *gc.Activity, actor ecs.Entity, world w.World) error {
-	p, ok := comp.Params.(*gc.TargetParams)
+	p, ok := comp.Params.(*gc.ShootParams)
 	if !ok {
 		Cancel(comp, "射撃対象が設定されていません")
 		return ErrAttackTargetNotSet

--- a/internal/activity/shoot_test.go
+++ b/internal/activity/shoot_test.go
@@ -66,7 +66,7 @@ func TestShootBehavior_Validate(t *testing.T) {
 		world, player, enemy, _ := setupShootingWorld(t)
 
 		sa := &ShootBehavior{}
-		activity, err := NewActivity(sa, 0)
+		activity, err := NewActivity(gc.BehaviorShoot, 0)
 		require.NoError(t, err)
 		activity.Target = &enemy
 
@@ -79,7 +79,7 @@ func TestShootBehavior_Validate(t *testing.T) {
 		world, player, _, _ := setupShootingWorld(t)
 
 		sa := &ShootBehavior{}
-		activity, err := NewActivity(sa, 0)
+		activity, err := NewActivity(gc.BehaviorShoot, 0)
 		require.NoError(t, err)
 
 		err = sa.Validate(activity, player, world)
@@ -95,7 +95,7 @@ func TestShootBehavior_Validate(t *testing.T) {
 		fire.Magazine = 0
 
 		sa := &ShootBehavior{}
-		activity, err := NewActivity(sa, 0)
+		activity, err := NewActivity(gc.BehaviorShoot, 0)
 		require.NoError(t, err)
 		activity.Target = &enemy
 
@@ -120,7 +120,7 @@ func TestShootBehavior_Validate(t *testing.T) {
 		require.NoError(t, err)
 
 		sa := &ShootBehavior{}
-		activity, err := NewActivity(sa, 0)
+		activity, err := NewActivity(gc.BehaviorShoot, 0)
 		require.NoError(t, err)
 		activity.Target = &enemy
 
@@ -145,7 +145,7 @@ func TestShootBehavior_Validate(t *testing.T) {
 		require.NoError(t, err)
 
 		sa := &ShootBehavior{}
-		activity, err := NewActivity(sa, 0)
+		activity, err := NewActivity(gc.BehaviorShoot, 0)
 		require.NoError(t, err)
 		activity.Target = &enemy
 
@@ -163,7 +163,7 @@ func TestShootBehavior_Validate(t *testing.T) {
 		world.Components.BlockView.Add(wall, &gc.BlockView{})
 
 		sa := &ShootBehavior{}
-		activity, err := NewActivity(sa, 0)
+		activity, err := NewActivity(gc.BehaviorShoot, 0)
 		require.NoError(t, err)
 		activity.Target = &enemy
 
@@ -177,7 +177,7 @@ func TestShootBehavior_Validate(t *testing.T) {
 		world.Components.Dead.Add(player, &gc.Dead{})
 
 		sa := &ShootBehavior{}
-		activity, err := NewActivity(sa, 0)
+		activity, err := NewActivity(gc.BehaviorShoot, 0)
 		require.NoError(t, err)
 		activity.Target = &enemy
 
@@ -191,7 +191,7 @@ func TestShootBehavior_Validate(t *testing.T) {
 		world.Components.Dead.Add(enemy, &gc.Dead{})
 
 		sa := &ShootBehavior{}
-		activity, err := NewActivity(sa, 0)
+		activity, err := NewActivity(gc.BehaviorShoot, 0)
 		require.NoError(t, err)
 		activity.Target = &enemy
 
@@ -211,7 +211,7 @@ func TestShootBehavior_DoTurn(t *testing.T) {
 		before := fire.Magazine
 
 		sa := &ShootBehavior{}
-		comp, err := NewActivity(sa, 0)
+		comp, err := NewActivity(gc.BehaviorShoot, 0)
 		require.NoError(t, err)
 		comp.Target = &enemy
 
@@ -227,7 +227,7 @@ func TestShootBehavior_DoTurn(t *testing.T) {
 		world, player, _, _ := setupShootingWorld(t)
 
 		sa := &ShootBehavior{}
-		comp, err := NewActivity(sa, 0)
+		comp, err := NewActivity(gc.BehaviorShoot, 0)
 		require.NoError(t, err)
 
 		err = sa.DoTurn(comp, player, world)

--- a/internal/activity/shoot_test.go
+++ b/internal/activity/shoot_test.go
@@ -66,11 +66,10 @@ func TestShootBehavior_Validate(t *testing.T) {
 		world, player, enemy, _ := setupShootingWorld(t)
 
 		sa := &ShootBehavior{}
-		activity, err := NewActivity(gc.BehaviorShoot, 0)
-		require.NoError(t, err)
+		activity := NewActivity(gc.BehaviorShoot, 0)
 		activity.Target = &enemy
 
-		err = sa.Validate(activity, player, world)
+		err := sa.Validate(activity, player, world)
 		assert.NoError(t, err)
 	})
 
@@ -79,10 +78,9 @@ func TestShootBehavior_Validate(t *testing.T) {
 		world, player, _, _ := setupShootingWorld(t)
 
 		sa := &ShootBehavior{}
-		activity, err := NewActivity(gc.BehaviorShoot, 0)
-		require.NoError(t, err)
+		activity := NewActivity(gc.BehaviorShoot, 0)
 
-		err = sa.Validate(activity, player, world)
+		err := sa.Validate(activity, player, world)
 		assert.ErrorIs(t, err, ErrAttackTargetNotSet)
 	})
 
@@ -95,11 +93,10 @@ func TestShootBehavior_Validate(t *testing.T) {
 		fire.Magazine = 0
 
 		sa := &ShootBehavior{}
-		activity, err := NewActivity(gc.BehaviorShoot, 0)
-		require.NoError(t, err)
+		activity := NewActivity(gc.BehaviorShoot, 0)
 		activity.Target = &enemy
 
-		err = sa.Validate(activity, player, world)
+		err := sa.Validate(activity, player, world)
 		assert.ErrorIs(t, err, ErrShootNoAmmo)
 	})
 
@@ -120,8 +117,7 @@ func TestShootBehavior_Validate(t *testing.T) {
 		require.NoError(t, err)
 
 		sa := &ShootBehavior{}
-		activity, err := NewActivity(gc.BehaviorShoot, 0)
-		require.NoError(t, err)
+		activity := NewActivity(gc.BehaviorShoot, 0)
 		activity.Target = &enemy
 
 		err = sa.Validate(activity, player, world)
@@ -145,8 +141,7 @@ func TestShootBehavior_Validate(t *testing.T) {
 		require.NoError(t, err)
 
 		sa := &ShootBehavior{}
-		activity, err := NewActivity(gc.BehaviorShoot, 0)
-		require.NoError(t, err)
+		activity := NewActivity(gc.BehaviorShoot, 0)
 		activity.Target = &enemy
 
 		err = sa.Validate(activity, player, world)
@@ -163,11 +158,10 @@ func TestShootBehavior_Validate(t *testing.T) {
 		world.Components.BlockView.Add(wall, &gc.BlockView{})
 
 		sa := &ShootBehavior{}
-		activity, err := NewActivity(gc.BehaviorShoot, 0)
-		require.NoError(t, err)
+		activity := NewActivity(gc.BehaviorShoot, 0)
 		activity.Target = &enemy
 
-		err = sa.Validate(activity, player, world)
+		err := sa.Validate(activity, player, world)
 		assert.ErrorIs(t, err, ErrShootLineOfSightBlocked)
 	})
 
@@ -177,11 +171,10 @@ func TestShootBehavior_Validate(t *testing.T) {
 		world.Components.Dead.Add(player, &gc.Dead{})
 
 		sa := &ShootBehavior{}
-		activity, err := NewActivity(gc.BehaviorShoot, 0)
-		require.NoError(t, err)
+		activity := NewActivity(gc.BehaviorShoot, 0)
 		activity.Target = &enemy
 
-		err = sa.Validate(activity, player, world)
+		err := sa.Validate(activity, player, world)
 		assert.ErrorIs(t, err, ErrAttackerDead)
 	})
 
@@ -191,11 +184,10 @@ func TestShootBehavior_Validate(t *testing.T) {
 		world.Components.Dead.Add(enemy, &gc.Dead{})
 
 		sa := &ShootBehavior{}
-		activity, err := NewActivity(gc.BehaviorShoot, 0)
-		require.NoError(t, err)
+		activity := NewActivity(gc.BehaviorShoot, 0)
 		activity.Target = &enemy
 
-		err = sa.Validate(activity, player, world)
+		err := sa.Validate(activity, player, world)
 		assert.ErrorIs(t, err, ErrAttackTargetDead)
 	})
 }
@@ -211,11 +203,10 @@ func TestShootBehavior_DoTurn(t *testing.T) {
 		before := fire.Magazine
 
 		sa := &ShootBehavior{}
-		comp, err := NewActivity(gc.BehaviorShoot, 0)
-		require.NoError(t, err)
+		comp := NewActivity(gc.BehaviorShoot, 0)
 		comp.Target = &enemy
 
-		err = sa.DoTurn(comp, player, world)
+		err := sa.DoTurn(comp, player, world)
 		require.NoError(t, err)
 
 		assert.Equal(t, before-1, fire.Magazine)
@@ -227,10 +218,9 @@ func TestShootBehavior_DoTurn(t *testing.T) {
 		world, player, _, _ := setupShootingWorld(t)
 
 		sa := &ShootBehavior{}
-		comp, err := NewActivity(gc.BehaviorShoot, 0)
-		require.NoError(t, err)
+		comp := NewActivity(gc.BehaviorShoot, 0)
 
-		err = sa.DoTurn(comp, player, world)
+		err := sa.DoTurn(comp, player, world)
 		require.ErrorIs(t, err, ErrAttackTargetNotSet)
 		assert.Equal(t, gc.ActivityStateCanceled, comp.State)
 	})

--- a/internal/activity/shoot_test.go
+++ b/internal/activity/shoot_test.go
@@ -67,7 +67,7 @@ func TestShootBehavior_Validate(t *testing.T) {
 
 		sa := &ShootBehavior{}
 		activity := NewActivity(gc.BehaviorShoot, 0)
-		activity.Target = &enemy
+		activity.Params = &gc.TargetParams{Target: enemy}
 
 		err := sa.Validate(activity, player, world)
 		assert.NoError(t, err)
@@ -94,7 +94,7 @@ func TestShootBehavior_Validate(t *testing.T) {
 
 		sa := &ShootBehavior{}
 		activity := NewActivity(gc.BehaviorShoot, 0)
-		activity.Target = &enemy
+		activity.Params = &gc.TargetParams{Target: enemy}
 
 		err := sa.Validate(activity, player, world)
 		assert.ErrorIs(t, err, ErrShootNoAmmo)
@@ -118,7 +118,7 @@ func TestShootBehavior_Validate(t *testing.T) {
 
 		sa := &ShootBehavior{}
 		activity := NewActivity(gc.BehaviorShoot, 0)
-		activity.Target = &enemy
+		activity.Params = &gc.TargetParams{Target: enemy}
 
 		err = sa.Validate(activity, player, world)
 		assert.ErrorIs(t, err, ErrAttackOutOfRange)
@@ -142,7 +142,7 @@ func TestShootBehavior_Validate(t *testing.T) {
 
 		sa := &ShootBehavior{}
 		activity := NewActivity(gc.BehaviorShoot, 0)
-		activity.Target = &enemy
+		activity.Params = &gc.TargetParams{Target: enemy}
 
 		err = sa.Validate(activity, player, world)
 		assert.ErrorIs(t, err, ErrShootNoFireWeapon)
@@ -159,7 +159,7 @@ func TestShootBehavior_Validate(t *testing.T) {
 
 		sa := &ShootBehavior{}
 		activity := NewActivity(gc.BehaviorShoot, 0)
-		activity.Target = &enemy
+		activity.Params = &gc.TargetParams{Target: enemy}
 
 		err := sa.Validate(activity, player, world)
 		assert.ErrorIs(t, err, ErrShootLineOfSightBlocked)
@@ -172,7 +172,7 @@ func TestShootBehavior_Validate(t *testing.T) {
 
 		sa := &ShootBehavior{}
 		activity := NewActivity(gc.BehaviorShoot, 0)
-		activity.Target = &enemy
+		activity.Params = &gc.TargetParams{Target: enemy}
 
 		err := sa.Validate(activity, player, world)
 		assert.ErrorIs(t, err, ErrAttackerDead)
@@ -185,7 +185,7 @@ func TestShootBehavior_Validate(t *testing.T) {
 
 		sa := &ShootBehavior{}
 		activity := NewActivity(gc.BehaviorShoot, 0)
-		activity.Target = &enemy
+		activity.Params = &gc.TargetParams{Target: enemy}
 
 		err := sa.Validate(activity, player, world)
 		assert.ErrorIs(t, err, ErrAttackTargetDead)
@@ -204,7 +204,7 @@ func TestShootBehavior_DoTurn(t *testing.T) {
 
 		sa := &ShootBehavior{}
 		comp := NewActivity(gc.BehaviorShoot, 0)
-		comp.Target = &enemy
+		comp.Params = &gc.TargetParams{Target: enemy}
 
 		err := sa.DoTurn(comp, player, world)
 		require.NoError(t, err)

--- a/internal/activity/shoot_test.go
+++ b/internal/activity/shoot_test.go
@@ -66,7 +66,7 @@ func TestShootBehavior_Validate(t *testing.T) {
 		world, player, enemy, _ := setupShootingWorld(t)
 
 		sa := &ShootBehavior{}
-		activity, err := NewActivity(sa, 1)
+		activity, err := NewActivity(sa, 0)
 		require.NoError(t, err)
 		activity.Target = &enemy
 
@@ -79,7 +79,7 @@ func TestShootBehavior_Validate(t *testing.T) {
 		world, player, _, _ := setupShootingWorld(t)
 
 		sa := &ShootBehavior{}
-		activity, err := NewActivity(sa, 1)
+		activity, err := NewActivity(sa, 0)
 		require.NoError(t, err)
 
 		err = sa.Validate(activity, player, world)
@@ -95,7 +95,7 @@ func TestShootBehavior_Validate(t *testing.T) {
 		fire.Magazine = 0
 
 		sa := &ShootBehavior{}
-		activity, err := NewActivity(sa, 1)
+		activity, err := NewActivity(sa, 0)
 		require.NoError(t, err)
 		activity.Target = &enemy
 
@@ -120,7 +120,7 @@ func TestShootBehavior_Validate(t *testing.T) {
 		require.NoError(t, err)
 
 		sa := &ShootBehavior{}
-		activity, err := NewActivity(sa, 1)
+		activity, err := NewActivity(sa, 0)
 		require.NoError(t, err)
 		activity.Target = &enemy
 
@@ -145,7 +145,7 @@ func TestShootBehavior_Validate(t *testing.T) {
 		require.NoError(t, err)
 
 		sa := &ShootBehavior{}
-		activity, err := NewActivity(sa, 1)
+		activity, err := NewActivity(sa, 0)
 		require.NoError(t, err)
 		activity.Target = &enemy
 
@@ -163,7 +163,7 @@ func TestShootBehavior_Validate(t *testing.T) {
 		world.Components.BlockView.Add(wall, &gc.BlockView{})
 
 		sa := &ShootBehavior{}
-		activity, err := NewActivity(sa, 1)
+		activity, err := NewActivity(sa, 0)
 		require.NoError(t, err)
 		activity.Target = &enemy
 
@@ -177,7 +177,7 @@ func TestShootBehavior_Validate(t *testing.T) {
 		world.Components.Dead.Add(player, &gc.Dead{})
 
 		sa := &ShootBehavior{}
-		activity, err := NewActivity(sa, 1)
+		activity, err := NewActivity(sa, 0)
 		require.NoError(t, err)
 		activity.Target = &enemy
 
@@ -191,7 +191,7 @@ func TestShootBehavior_Validate(t *testing.T) {
 		world.Components.Dead.Add(enemy, &gc.Dead{})
 
 		sa := &ShootBehavior{}
-		activity, err := NewActivity(sa, 1)
+		activity, err := NewActivity(sa, 0)
 		require.NoError(t, err)
 		activity.Target = &enemy
 
@@ -211,7 +211,7 @@ func TestShootBehavior_DoTurn(t *testing.T) {
 		before := fire.Magazine
 
 		sa := &ShootBehavior{}
-		comp, err := NewActivity(sa, 1)
+		comp, err := NewActivity(sa, 0)
 		require.NoError(t, err)
 		comp.Target = &enemy
 
@@ -227,7 +227,7 @@ func TestShootBehavior_DoTurn(t *testing.T) {
 		world, player, _, _ := setupShootingWorld(t)
 
 		sa := &ShootBehavior{}
-		comp, err := NewActivity(sa, 1)
+		comp, err := NewActivity(sa, 0)
 		require.NoError(t, err)
 
 		err = sa.DoTurn(comp, player, world)

--- a/internal/activity/shoot_test.go
+++ b/internal/activity/shoot_test.go
@@ -67,7 +67,7 @@ func TestShootBehavior_Validate(t *testing.T) {
 
 		sa := &ShootBehavior{}
 		activity := NewActivity(gc.BehaviorShoot, 0)
-		activity.Params = &gc.TargetParams{Target: enemy}
+		activity.Params = &gc.ShootParams{Target: enemy}
 
 		err := sa.Validate(activity, player, world)
 		assert.NoError(t, err)
@@ -94,7 +94,7 @@ func TestShootBehavior_Validate(t *testing.T) {
 
 		sa := &ShootBehavior{}
 		activity := NewActivity(gc.BehaviorShoot, 0)
-		activity.Params = &gc.TargetParams{Target: enemy}
+		activity.Params = &gc.ShootParams{Target: enemy}
 
 		err := sa.Validate(activity, player, world)
 		assert.ErrorIs(t, err, ErrShootNoAmmo)
@@ -118,7 +118,7 @@ func TestShootBehavior_Validate(t *testing.T) {
 
 		sa := &ShootBehavior{}
 		activity := NewActivity(gc.BehaviorShoot, 0)
-		activity.Params = &gc.TargetParams{Target: enemy}
+		activity.Params = &gc.ShootParams{Target: enemy}
 
 		err = sa.Validate(activity, player, world)
 		assert.ErrorIs(t, err, ErrAttackOutOfRange)
@@ -142,7 +142,7 @@ func TestShootBehavior_Validate(t *testing.T) {
 
 		sa := &ShootBehavior{}
 		activity := NewActivity(gc.BehaviorShoot, 0)
-		activity.Params = &gc.TargetParams{Target: enemy}
+		activity.Params = &gc.ShootParams{Target: enemy}
 
 		err = sa.Validate(activity, player, world)
 		assert.ErrorIs(t, err, ErrShootNoFireWeapon)
@@ -159,7 +159,7 @@ func TestShootBehavior_Validate(t *testing.T) {
 
 		sa := &ShootBehavior{}
 		activity := NewActivity(gc.BehaviorShoot, 0)
-		activity.Params = &gc.TargetParams{Target: enemy}
+		activity.Params = &gc.ShootParams{Target: enemy}
 
 		err := sa.Validate(activity, player, world)
 		assert.ErrorIs(t, err, ErrShootLineOfSightBlocked)
@@ -172,7 +172,7 @@ func TestShootBehavior_Validate(t *testing.T) {
 
 		sa := &ShootBehavior{}
 		activity := NewActivity(gc.BehaviorShoot, 0)
-		activity.Params = &gc.TargetParams{Target: enemy}
+		activity.Params = &gc.ShootParams{Target: enemy}
 
 		err := sa.Validate(activity, player, world)
 		assert.ErrorIs(t, err, ErrAttackerDead)
@@ -185,7 +185,7 @@ func TestShootBehavior_Validate(t *testing.T) {
 
 		sa := &ShootBehavior{}
 		activity := NewActivity(gc.BehaviorShoot, 0)
-		activity.Params = &gc.TargetParams{Target: enemy}
+		activity.Params = &gc.ShootParams{Target: enemy}
 
 		err := sa.Validate(activity, player, world)
 		assert.ErrorIs(t, err, ErrAttackTargetDead)
@@ -204,7 +204,7 @@ func TestShootBehavior_DoTurn(t *testing.T) {
 
 		sa := &ShootBehavior{}
 		comp := NewActivity(gc.BehaviorShoot, 0)
-		comp.Params = &gc.TargetParams{Target: enemy}
+		comp.Params = &gc.ShootParams{Target: enemy}
 
 		err := sa.DoTurn(comp, player, world)
 		require.NoError(t, err)

--- a/internal/activity/talk.go
+++ b/internal/activity/talk.go
@@ -14,9 +14,7 @@ import (
 )
 
 // TalkBehavior は会話アクティビティ
-type TalkBehavior struct {
-	Target ecs.Entity
-}
+type TalkBehavior struct{}
 
 // Info はBehaviorの実装
 func (tb *TalkBehavior) Info() Info {
@@ -35,14 +33,11 @@ func (tb *TalkBehavior) Name() gc.BehaviorName {
 	return gc.BehaviorTalk
 }
 
-// BuildActivity はBehaviorの実装
-func (tb *TalkBehavior) BuildActivity(_ ecs.Entity, _ w.World) (*gc.Activity, error) {
-	comp, err := NewActivity(tb, 0)
-	if err != nil {
-		return nil, err
-	}
-	comp.Target = &tb.Target
-	return comp, nil
+// NewTalkActivity は会話対象を指定して会話アクティビティを組む。
+func NewTalkActivity(target ecs.Entity) *gc.Activity {
+	comp := newActivity(gc.BehaviorTalk, 0)
+	comp.Target = &target
+	return comp
 }
 
 // Validate は会話アクティビティの検証を行う

--- a/internal/activity/talk.go
+++ b/internal/activity/talk.go
@@ -35,7 +35,7 @@ func (tb *TalkBehavior) Name() gc.BehaviorName {
 
 // NewTalkActivity は会話対象を指定して会話アクティビティを組む。
 func NewTalkActivity(target ecs.Entity) *gc.Activity {
-	comp := newActivity(gc.BehaviorTalk, 0)
+	comp := NewActivity(gc.BehaviorTalk, 0)
 	comp.Target = &target
 	return comp
 }

--- a/internal/activity/talk.go
+++ b/internal/activity/talk.go
@@ -36,17 +36,18 @@ func (tb *TalkBehavior) Name() gc.BehaviorName {
 // NewTalkActivity は会話対象を指定して会話アクティビティを組む。
 func NewTalkActivity(target ecs.Entity) *gc.Activity {
 	comp := NewActivity(gc.BehaviorTalk, 0)
-	comp.Target = &target
+	comp.Params = &gc.TargetParams{Target: target}
 	return comp
 }
 
 // Validate は会話アクティビティの検証を行う
 func (tb *TalkBehavior) Validate(comp *gc.Activity, _ ecs.Entity, world w.World) error {
-	if comp.Target == nil {
+	p, ok := comp.Params.(*gc.TargetParams)
+	if !ok {
 		return fmt.Errorf("会話対象が指定されていません")
 	}
 
-	targetEntity := *comp.Target
+	targetEntity := p.Target
 
 	// Dialogコンポーネントを持っているか確認
 	if !world.Components.Dialog.Has(targetEntity) {
@@ -69,7 +70,12 @@ func (tb *TalkBehavior) Start(_ *gc.Activity, actor ecs.Entity, _ w.World) error
 
 // DoTurn は会話アクティビティの1ターン分の処理を実行する
 func (tb *TalkBehavior) DoTurn(comp *gc.Activity, _ ecs.Entity, world w.World) error {
-	targetEntity := *comp.Target
+	p, ok := comp.Params.(*gc.TargetParams)
+	if !ok {
+		Cancel(comp, "会話対象が指定されていません")
+		return fmt.Errorf("会話対象が指定されていません")
+	}
+	targetEntity := p.Target
 
 	if !world.Components.Dialog.Has(targetEntity) {
 		Cancel(comp, "会話データが取得できません")
@@ -96,11 +102,12 @@ func (tb *TalkBehavior) DoTurn(comp *gc.Activity, _ ecs.Entity, world w.World) e
 func (tb *TalkBehavior) Finish(comp *gc.Activity, actor ecs.Entity, world w.World) error {
 	log.Debug("会話アクティビティ完了", "actor", actor)
 
-	if comp.Target == nil {
+	p, ok := comp.Params.(*gc.TargetParams)
+	if !ok {
 		return nil
 	}
 
-	targetEntity := *comp.Target
+	targetEntity := p.Target
 
 	// プレイヤーの場合のみメッセージを表示
 	if world.Components.Player.Has(actor) {

--- a/internal/activity/talk.go
+++ b/internal/activity/talk.go
@@ -37,7 +37,7 @@ func (tb *TalkBehavior) Name() gc.BehaviorName {
 
 // BuildActivity はBehaviorの実装
 func (tb *TalkBehavior) BuildActivity(_ ecs.Entity, _ w.World) (*gc.Activity, error) {
-	comp, err := NewActivity(tb, 1)
+	comp, err := NewActivity(tb, 0)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/activity/talk.go
+++ b/internal/activity/talk.go
@@ -36,13 +36,13 @@ func (tb *TalkBehavior) Name() gc.BehaviorName {
 // NewTalkActivity は会話対象を指定して会話アクティビティを組む。
 func NewTalkActivity(target ecs.Entity) *gc.Activity {
 	comp := NewActivity(gc.BehaviorTalk, 0)
-	comp.Params = &gc.TargetParams{Target: target}
+	comp.Params = &gc.TalkParams{Target: target}
 	return comp
 }
 
 // Validate は会話アクティビティの検証を行う
 func (tb *TalkBehavior) Validate(comp *gc.Activity, _ ecs.Entity, world w.World) error {
-	p, ok := comp.Params.(*gc.TargetParams)
+	p, ok := comp.Params.(*gc.TalkParams)
 	if !ok {
 		return fmt.Errorf("会話対象が指定されていません")
 	}
@@ -70,7 +70,7 @@ func (tb *TalkBehavior) Start(_ *gc.Activity, actor ecs.Entity, _ w.World) error
 
 // DoTurn は会話アクティビティの1ターン分の処理を実行する
 func (tb *TalkBehavior) DoTurn(comp *gc.Activity, _ ecs.Entity, world w.World) error {
-	p, ok := comp.Params.(*gc.TargetParams)
+	p, ok := comp.Params.(*gc.TalkParams)
 	if !ok {
 		Cancel(comp, "会話対象が指定されていません")
 		return fmt.Errorf("会話対象が指定されていません")
@@ -102,7 +102,7 @@ func (tb *TalkBehavior) DoTurn(comp *gc.Activity, _ ecs.Entity, world w.World) e
 func (tb *TalkBehavior) Finish(comp *gc.Activity, actor ecs.Entity, world w.World) error {
 	log.Debug("会話アクティビティ完了", "actor", actor)
 
-	p, ok := comp.Params.(*gc.TargetParams)
+	p, ok := comp.Params.(*gc.TalkParams)
 	if !ok {
 		return nil
 	}

--- a/internal/activity/talk_test.go
+++ b/internal/activity/talk_test.go
@@ -27,7 +27,7 @@ func TestTalkBehavior_Validate(t *testing.T) {
 
 		comp := &gc.Activity{
 			BehaviorName: gc.BehaviorTalk,
-			Target:       &npc,
+			Params:       &gc.TargetParams{Target: npc},
 		}
 
 		ta := &TalkBehavior{}
@@ -44,7 +44,6 @@ func TestTalkBehavior_Validate(t *testing.T) {
 
 		comp := &gc.Activity{
 			BehaviorName: gc.BehaviorTalk,
-			Target:       nil,
 		}
 
 		ta := &TalkBehavior{}
@@ -66,7 +65,7 @@ func TestTalkBehavior_Validate(t *testing.T) {
 
 		comp := &gc.Activity{
 			BehaviorName: gc.BehaviorTalk,
-			Target:       &npc,
+			Params:       &gc.TargetParams{Target: npc},
 		}
 
 		ta := &TalkBehavior{}
@@ -88,7 +87,7 @@ func TestTalkBehavior_Validate(t *testing.T) {
 
 		comp := &gc.Activity{
 			BehaviorName: gc.BehaviorTalk,
-			Target:       &npc,
+			Params:       &gc.TargetParams{Target: npc},
 		}
 
 		ta := &TalkBehavior{}
@@ -132,7 +131,7 @@ func TestTalkBehavior_DoTurn(t *testing.T) {
 		comp := &gc.Activity{
 			BehaviorName: gc.BehaviorTalk,
 			State:        gc.ActivityStateRunning,
-			Target:       &npc,
+			Params:       &gc.TargetParams{Target: npc},
 		}
 
 		ta := &TalkBehavior{}
@@ -157,7 +156,7 @@ func TestTalkBehavior_DoTurn(t *testing.T) {
 		comp := &gc.Activity{
 			BehaviorName: gc.BehaviorTalk,
 			State:        gc.ActivityStateRunning,
-			Target:       &npc,
+			Params:       &gc.TargetParams{Target: npc},
 		}
 
 		ta := &TalkBehavior{}

--- a/internal/activity/talk_test.go
+++ b/internal/activity/talk_test.go
@@ -27,7 +27,7 @@ func TestTalkBehavior_Validate(t *testing.T) {
 
 		comp := &gc.Activity{
 			BehaviorName: gc.BehaviorTalk,
-			Params:       &gc.TargetParams{Target: npc},
+			Params:       &gc.TalkParams{Target: npc},
 		}
 
 		ta := &TalkBehavior{}
@@ -65,7 +65,7 @@ func TestTalkBehavior_Validate(t *testing.T) {
 
 		comp := &gc.Activity{
 			BehaviorName: gc.BehaviorTalk,
-			Params:       &gc.TargetParams{Target: npc},
+			Params:       &gc.TalkParams{Target: npc},
 		}
 
 		ta := &TalkBehavior{}
@@ -87,7 +87,7 @@ func TestTalkBehavior_Validate(t *testing.T) {
 
 		comp := &gc.Activity{
 			BehaviorName: gc.BehaviorTalk,
-			Params:       &gc.TargetParams{Target: npc},
+			Params:       &gc.TalkParams{Target: npc},
 		}
 
 		ta := &TalkBehavior{}
@@ -131,7 +131,7 @@ func TestTalkBehavior_DoTurn(t *testing.T) {
 		comp := &gc.Activity{
 			BehaviorName: gc.BehaviorTalk,
 			State:        gc.ActivityStateRunning,
-			Params:       &gc.TargetParams{Target: npc},
+			Params:       &gc.TalkParams{Target: npc},
 		}
 
 		ta := &TalkBehavior{}
@@ -156,7 +156,7 @@ func TestTalkBehavior_DoTurn(t *testing.T) {
 		comp := &gc.Activity{
 			BehaviorName: gc.BehaviorTalk,
 			State:        gc.ActivityStateRunning,
-			Params:       &gc.TargetParams{Target: npc},
+			Params:       &gc.TalkParams{Target: npc},
 		}
 
 		ta := &TalkBehavior{}

--- a/internal/activity/transfer.go
+++ b/internal/activity/transfer.go
@@ -37,25 +37,29 @@ func (tb *TransferBehavior) Name() gc.BehaviorName {
 }
 
 // NewTransferActivity は転送アイテム・受取人・個数を指定して転送アクティビティを組む。
-// count が0以下なら在庫全量を渡す。個数は gc.Activity.Count に持たせ、継続処理でも読める。
+// count が0以下なら在庫全量を渡す。個数は TransferParams.Count に持たせ、継続処理でも読める。
 func NewTransferActivity(target, recipient ecs.Entity, count int) *gc.Activity {
 	comp := NewActivity(gc.BehaviorTransfer, 0)
-	comp.Target = &target
-	comp.Recipient = &recipient
-	comp.Count = count
+	comp.Params = &gc.TransferParams{Target: target, Recipient: recipient, Count: count}
 	return comp
 }
 
 // Validate はアイテム転送アクティビティの検証を行う
 func (tb *TransferBehavior) Validate(comp *gc.Activity, _ ecs.Entity, world w.World) error {
-	if comp.Target == nil {
+	p, ok := comp.Params.(*gc.TransferParams)
+	if !ok {
 		return fmt.Errorf("転送対象が指定されていません")
 	}
-	if comp.Recipient == nil {
+	// 値型のパラメータでは未指定が無効エンティティになる。ArkのHasはゼロ値でパニックするため、
+	// Aliveで存在を確かめてから所持判定へ進む
+	if !world.ECS.Alive(p.Target) {
+		return fmt.Errorf("転送対象が指定されていません")
+	}
+	if !world.ECS.Alive(p.Recipient) {
 		return fmt.Errorf("受取人が指定されていません")
 	}
 
-	target := *comp.Target
+	target := p.Target
 	if !world.Components.LocationInBackpack.Has(target) {
 		return fmt.Errorf("アイテムがバックパック内にありません")
 	}
@@ -94,8 +98,12 @@ func (tb *TransferBehavior) Canceled(comp *gc.Activity, actor ecs.Entity, _ w.Wo
 
 // performTransfer はアイテムを受取人のバックパックに移動する
 func (tb *TransferBehavior) performTransfer(comp *gc.Activity, world w.World) error {
-	item := *comp.Target
-	recipient := *comp.Recipient
+	p, ok := comp.Params.(*gc.TransferParams)
+	if !ok {
+		return fmt.Errorf("転送対象が指定されていません")
+	}
+	item := p.Target
+	recipient := p.Recipient
 
 	// 渡す主体はアクターでなくアイテムの現所有者にする。補給ではアクターの隊員がリーダーの
 	// プールから引くため、アクターを主体にすると「隊員は隊員に渡した」と自己転送の誤ログになる。
@@ -105,8 +113,8 @@ func (tb *TransferBehavior) performTransfer(comp *gc.Activity, world w.World) er
 
 	// 実際に渡す個数を確定する。Count が0以下、または在庫以上なら在庫すべてを渡す。
 	moving := query.GetEntityCount(world, item)
-	if comp.Count > 0 && comp.Count < moving {
-		moving = comp.Count
+	if p.Count > 0 && p.Count < moving {
+		moving = p.Count
 	}
 
 	// ログ名は転送前に確定させる。在庫全体でなく実際に移す個数で表示する。
@@ -119,7 +127,7 @@ func (tb *TransferBehavior) performTransfer(comp *gc.Activity, world w.World) er
 		itemName = fmt.Sprintf("%s(%d個)", itemName, moving)
 	}
 
-	if err := lifecycle.TransferUnits(world, item, recipient, comp.Count); err != nil {
+	if err := lifecycle.TransferUnits(world, item, recipient, p.Count); err != nil {
 		return fmt.Errorf("アイテム転送に失敗: %w", err)
 	}
 

--- a/internal/activity/transfer.go
+++ b/internal/activity/transfer.go
@@ -17,11 +17,7 @@ import (
 // Targetに転送するアイテム、Recipientに受取人を指定する。
 // Countは渡す個数。在庫数以上を指定すればスタックごとまとめて渡り、少なく指定すればその分だけ分割して渡す。
 // 補給で共有プールから1食ぶんだけ引くときは1、丸ごと渡すときは在庫数を指定する
-type TransferBehavior struct {
-	Target    ecs.Entity
-	Recipient ecs.Entity
-	Count     int
-}
+type TransferBehavior struct{}
 
 // Info はBehaviorの実装
 func (tb *TransferBehavior) Info() Info {
@@ -40,15 +36,14 @@ func (tb *TransferBehavior) Name() gc.BehaviorName {
 	return gc.BehaviorTransfer
 }
 
-// BuildActivity はBehaviorの実装
-func (tb *TransferBehavior) BuildActivity(_ ecs.Entity, _ w.World) (*gc.Activity, error) {
-	comp, err := NewActivity(tb, 0)
-	if err != nil {
-		return nil, err
-	}
-	comp.Target = &tb.Target
-	comp.Recipient = &tb.Recipient
-	return comp, nil
+// NewTransferActivity は転送アイテム・受取人・個数を指定して転送アクティビティを組む。
+// count が0以下なら在庫全量を渡す。個数は gc.Activity.Count に持たせ、継続処理でも読める。
+func NewTransferActivity(target, recipient ecs.Entity, count int) *gc.Activity {
+	comp := newActivity(gc.BehaviorTransfer, 0)
+	comp.Target = &target
+	comp.Recipient = &recipient
+	comp.Count = count
+	return comp
 }
 
 // Validate はアイテム転送アクティビティの検証を行う
@@ -110,8 +105,8 @@ func (tb *TransferBehavior) performTransfer(comp *gc.Activity, world w.World) er
 
 	// 実際に渡す個数を確定する。Count が0以下、または在庫以上なら在庫すべてを渡す。
 	moving := query.GetEntityCount(world, item)
-	if tb.Count > 0 && tb.Count < moving {
-		moving = tb.Count
+	if comp.Count > 0 && comp.Count < moving {
+		moving = comp.Count
 	}
 
 	// ログ名は転送前に確定させる。在庫全体でなく実際に移す個数で表示する。
@@ -124,7 +119,7 @@ func (tb *TransferBehavior) performTransfer(comp *gc.Activity, world w.World) er
 		itemName = fmt.Sprintf("%s(%d個)", itemName, moving)
 	}
 
-	if err := lifecycle.TransferUnits(world, item, recipient, tb.Count); err != nil {
+	if err := lifecycle.TransferUnits(world, item, recipient, comp.Count); err != nil {
 		return fmt.Errorf("アイテム転送に失敗: %w", err)
 	}
 

--- a/internal/activity/transfer.go
+++ b/internal/activity/transfer.go
@@ -39,7 +39,7 @@ func (tb *TransferBehavior) Name() gc.BehaviorName {
 // NewTransferActivity は転送アイテム・受取人・個数を指定して転送アクティビティを組む。
 // count が0以下なら在庫全量を渡す。個数は gc.Activity.Count に持たせ、継続処理でも読める。
 func NewTransferActivity(target, recipient ecs.Entity, count int) *gc.Activity {
-	comp := newActivity(gc.BehaviorTransfer, 0)
+	comp := NewActivity(gc.BehaviorTransfer, 0)
 	comp.Target = &target
 	comp.Recipient = &recipient
 	comp.Count = count

--- a/internal/activity/transfer.go
+++ b/internal/activity/transfer.go
@@ -42,7 +42,7 @@ func (tb *TransferBehavior) Name() gc.BehaviorName {
 
 // BuildActivity はBehaviorの実装
 func (tb *TransferBehavior) BuildActivity(_ ecs.Entity, _ w.World) (*gc.Activity, error) {
-	comp, err := NewActivity(tb, 1)
+	comp, err := NewActivity(tb, 0)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/activity/transfer_test.go
+++ b/internal/activity/transfer_test.go
@@ -125,9 +125,10 @@ func TestTransferBehavior_DoTurn(t *testing.T) {
 			State:        gc.ActivityStateRunning,
 			Target:       &item,
 			Recipient:    &leader,
+			Count:        1,
 		}
 
-		ta := &TransferBehavior{Target: item, Recipient: leader, Count: 1}
+		ta := &TransferBehavior{}
 		err = ta.DoTurn(comp, member, world)
 		require.NoError(t, err)
 
@@ -155,9 +156,10 @@ func TestTransferBehavior_DoTurn(t *testing.T) {
 			State:        gc.ActivityStateRunning,
 			Target:       &pool,
 			Recipient:    &member,
+			Count:        1,
 		}
 		// アクターは受け取る隊員。丸ごとでなく1個だけ引く
-		ta := &TransferBehavior{Target: pool, Recipient: member, Count: 1}
+		ta := &TransferBehavior{}
 		require.NoError(t, ta.DoTurn(comp, member, world))
 
 		// 元スタックは1減り、隊員は1個だけ受け取る
@@ -192,8 +194,9 @@ func TestTransferBehavior_DoTurn(t *testing.T) {
 			State:        gc.ActivityStateRunning,
 			Target:       &pool,
 			Recipient:    &member,
+			Count:        2,
 		}
-		ta := &TransferBehavior{Target: pool, Recipient: member, Count: 2}
+		ta := &TransferBehavior{}
 		require.NoError(t, ta.DoTurn(comp, member, world))
 
 		assert.Equal(t, 3, world.Components.Stackable.Get(pool).Count, "プールは指定個数ぶん減る")

--- a/internal/activity/transfer_test.go
+++ b/internal/activity/transfer_test.go
@@ -50,8 +50,7 @@ func TestTransferBehavior_Validate(t *testing.T) {
 
 		comp := &gc.Activity{
 			BehaviorName: gc.BehaviorTransfer,
-			Target:       &item,
-			Recipient:    &leader,
+			Params:       &gc.TransferParams{Target: item, Recipient: leader},
 		}
 
 		ta := &TransferBehavior{}
@@ -68,7 +67,7 @@ func TestTransferBehavior_Validate(t *testing.T) {
 
 		comp := &gc.Activity{
 			BehaviorName: gc.BehaviorTransfer,
-			Recipient:    &leader,
+			Params:       &gc.TransferParams{Recipient: leader},
 		}
 
 		ta := &TransferBehavior{}
@@ -90,7 +89,7 @@ func TestTransferBehavior_Validate(t *testing.T) {
 
 		comp := &gc.Activity{
 			BehaviorName: gc.BehaviorTransfer,
-			Target:       &item,
+			Params:       &gc.TransferParams{Target: item},
 		}
 
 		ta := &TransferBehavior{}
@@ -123,9 +122,7 @@ func TestTransferBehavior_DoTurn(t *testing.T) {
 		comp := &gc.Activity{
 			BehaviorName: gc.BehaviorTransfer,
 			State:        gc.ActivityStateRunning,
-			Target:       &item,
-			Recipient:    &leader,
-			Count:        1,
+			Params:       &gc.TransferParams{Target: item, Recipient: leader, Count: 1},
 		}
 
 		ta := &TransferBehavior{}
@@ -154,9 +151,7 @@ func TestTransferBehavior_DoTurn(t *testing.T) {
 		comp := &gc.Activity{
 			BehaviorName: gc.BehaviorTransfer,
 			State:        gc.ActivityStateRunning,
-			Target:       &pool,
-			Recipient:    &member,
-			Count:        1,
+			Params:       &gc.TransferParams{Target: pool, Recipient: member, Count: 1},
 		}
 		// アクターは受け取る隊員。丸ごとでなく1個だけ引く
 		ta := &TransferBehavior{}
@@ -192,9 +187,7 @@ func TestTransferBehavior_DoTurn(t *testing.T) {
 		comp := &gc.Activity{
 			BehaviorName: gc.BehaviorTransfer,
 			State:        gc.ActivityStateRunning,
-			Target:       &pool,
-			Recipient:    &member,
-			Count:        2,
+			Params:       &gc.TransferParams{Target: pool, Recipient: member, Count: 2},
 		}
 		ta := &TransferBehavior{}
 		require.NoError(t, ta.DoTurn(comp, member, world))

--- a/internal/activity/transfer_test.go
+++ b/internal/activity/transfer_test.go
@@ -125,8 +125,6 @@ func TestTransferBehavior_DoTurn(t *testing.T) {
 			State:        gc.ActivityStateRunning,
 			Target:       &item,
 			Recipient:    &leader,
-			TurnsTotal:   1,
-			TurnsLeft:    1,
 		}
 
 		ta := &TransferBehavior{Target: item, Recipient: leader, Count: 1}
@@ -157,8 +155,6 @@ func TestTransferBehavior_DoTurn(t *testing.T) {
 			State:        gc.ActivityStateRunning,
 			Target:       &pool,
 			Recipient:    &member,
-			TurnsTotal:   1,
-			TurnsLeft:    1,
 		}
 		// アクターは受け取る隊員。丸ごとでなく1個だけ引く
 		ta := &TransferBehavior{Target: pool, Recipient: member, Count: 1}
@@ -196,8 +192,6 @@ func TestTransferBehavior_DoTurn(t *testing.T) {
 			State:        gc.ActivityStateRunning,
 			Target:       &pool,
 			Recipient:    &member,
-			TurnsTotal:   1,
-			TurnsLeft:    1,
 		}
 		ta := &TransferBehavior{Target: pool, Recipient: member, Count: 2}
 		require.NoError(t, ta.DoTurn(comp, member, world))

--- a/internal/activity/use_item.go
+++ b/internal/activity/use_item.go
@@ -36,7 +36,7 @@ func (u *UseItemBehavior) Name() gc.BehaviorName {
 
 // NewUseItemActivity は使用アイテムを指定してアイテム使用アクティビティを組む。
 func NewUseItemActivity(target ecs.Entity) *gc.Activity {
-	comp := newActivity(gc.BehaviorUseItem, 0)
+	comp := NewActivity(gc.BehaviorUseItem, 0)
 	comp.Target = &target
 	return comp
 }

--- a/internal/activity/use_item.go
+++ b/internal/activity/use_item.go
@@ -38,7 +38,7 @@ func (u *UseItemBehavior) Name() gc.BehaviorName {
 
 // BuildActivity はBehaviorの実装
 func (u *UseItemBehavior) BuildActivity(_ ecs.Entity, _ w.World) (*gc.Activity, error) {
-	comp, err := NewActivity(u, 1)
+	comp, err := NewActivity(u, 0)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/activity/use_item.go
+++ b/internal/activity/use_item.go
@@ -15,9 +15,7 @@ import (
 )
 
 // UseItemBehavior はBehaviorの実装
-type UseItemBehavior struct {
-	Target ecs.Entity
-}
+type UseItemBehavior struct{}
 
 // Info はBehaviorの実装
 func (u *UseItemBehavior) Info() Info {
@@ -36,14 +34,11 @@ func (u *UseItemBehavior) Name() gc.BehaviorName {
 	return gc.BehaviorUseItem
 }
 
-// BuildActivity はBehaviorの実装
-func (u *UseItemBehavior) BuildActivity(_ ecs.Entity, _ w.World) (*gc.Activity, error) {
-	comp, err := NewActivity(u, 0)
-	if err != nil {
-		return nil, err
-	}
-	comp.Target = &u.Target
-	return comp, nil
+// NewUseItemActivity は使用アイテムを指定してアイテム使用アクティビティを組む。
+func NewUseItemActivity(target ecs.Entity) *gc.Activity {
+	comp := newActivity(gc.BehaviorUseItem, 0)
+	comp.Target = &target
+	return comp
 }
 
 // Validate はBehaviorの実装

--- a/internal/activity/use_item.go
+++ b/internal/activity/use_item.go
@@ -37,13 +37,13 @@ func (u *UseItemBehavior) Name() gc.BehaviorName {
 // NewUseItemActivity は使用アイテムを指定してアイテム使用アクティビティを組む。
 func NewUseItemActivity(target ecs.Entity) *gc.Activity {
 	comp := NewActivity(gc.BehaviorUseItem, 0)
-	comp.Params = &gc.TargetParams{Target: target}
+	comp.Params = &gc.UseItemParams{Target: target}
 	return comp
 }
 
 // Validate はBehaviorの実装
 func (u *UseItemBehavior) Validate(comp *gc.Activity, actor ecs.Entity, world w.World) error {
-	p, ok := comp.Params.(*gc.TargetParams)
+	p, ok := comp.Params.(*gc.UseItemParams)
 	if !ok {
 		return ErrItemNotSet
 	}
@@ -69,7 +69,7 @@ func (u *UseItemBehavior) Validate(comp *gc.Activity, actor ecs.Entity, world w.
 
 // Start はBehaviorの実装
 func (u *UseItemBehavior) Start(comp *gc.Activity, actor ecs.Entity, _ w.World) error {
-	if p, ok := comp.Params.(*gc.TargetParams); ok {
+	if p, ok := comp.Params.(*gc.UseItemParams); ok {
 		log.Debug("アイテム使用開始", "actor", actor, "item", p.Target)
 	}
 	return nil
@@ -77,7 +77,7 @@ func (u *UseItemBehavior) Start(comp *gc.Activity, actor ecs.Entity, _ w.World) 
 
 // DoTurn はBehaviorの実装
 func (u *UseItemBehavior) DoTurn(comp *gc.Activity, actor ecs.Entity, world w.World) error {
-	p, ok := comp.Params.(*gc.TargetParams)
+	p, ok := comp.Params.(*gc.UseItemParams)
 	if !ok {
 		Cancel(comp, "アイテムが指定されていません")
 		return ErrItemNotSet

--- a/internal/activity/use_item.go
+++ b/internal/activity/use_item.go
@@ -37,17 +37,18 @@ func (u *UseItemBehavior) Name() gc.BehaviorName {
 // NewUseItemActivity は使用アイテムを指定してアイテム使用アクティビティを組む。
 func NewUseItemActivity(target ecs.Entity) *gc.Activity {
 	comp := NewActivity(gc.BehaviorUseItem, 0)
-	comp.Target = &target
+	comp.Params = &gc.TargetParams{Target: target}
 	return comp
 }
 
 // Validate はBehaviorの実装
 func (u *UseItemBehavior) Validate(comp *gc.Activity, actor ecs.Entity, world w.World) error {
-	if comp.Target == nil {
+	p, ok := comp.Params.(*gc.TargetParams)
+	if !ok {
 		return ErrItemNotSet
 	}
 
-	item := *comp.Target
+	item := p.Target
 
 	// 何らかの効果があるかチェック
 	hasEffect := world.Components.ProvidesHealing.Has(item) ||
@@ -68,18 +69,21 @@ func (u *UseItemBehavior) Validate(comp *gc.Activity, actor ecs.Entity, world w.
 
 // Start はBehaviorの実装
 func (u *UseItemBehavior) Start(comp *gc.Activity, actor ecs.Entity, _ w.World) error {
-	log.Debug("アイテム使用開始", "actor", actor, "item", *comp.Target)
+	if p, ok := comp.Params.(*gc.TargetParams); ok {
+		log.Debug("アイテム使用開始", "actor", actor, "item", p.Target)
+	}
 	return nil
 }
 
 // DoTurn はBehaviorの実装
 func (u *UseItemBehavior) DoTurn(comp *gc.Activity, actor ecs.Entity, world w.World) error {
-	if comp.Target == nil {
+	p, ok := comp.Params.(*gc.TargetParams)
+	if !ok {
 		Cancel(comp, "アイテムが指定されていません")
 		return ErrItemNotSet
 	}
 
-	item := *comp.Target
+	item := p.Target
 
 	// 回復効果があるかチェック
 	if world.Components.ProvidesHealing.Has(item) {

--- a/internal/activity/use_item_test.go
+++ b/internal/activity/use_item_test.go
@@ -24,13 +24,12 @@ func TestUseItemBehavior_applyNutrition(t *testing.T) {
 		world.Components.Hunger.Add(actor, hunger)
 
 		item := world.ECS.NewEntity()
-		comp, err := NewActivity(gc.BehaviorUseItem, 1)
-		require.NoError(t, err)
+		comp := NewActivity(gc.BehaviorUseItem, 1)
 
 		useItemActivity := &UseItemBehavior{}
 
 		// 100の満腹度回復
-		err = useItemActivity.applyNutrition(comp, actor, world, 100, item)
+		err := useItemActivity.applyNutrition(comp, actor, world, 100, item)
 		require.NoError(t, err)
 
 		// 満腹度が250 + 100 = 350になっているはず
@@ -50,13 +49,12 @@ func TestUseItemBehavior_applyNutrition(t *testing.T) {
 		world.Components.Hunger.Add(actor, hunger)
 
 		item := world.ECS.NewEntity()
-		comp, err := NewActivity(gc.BehaviorUseItem, 1)
-		require.NoError(t, err)
+		comp := NewActivity(gc.BehaviorUseItem, 1)
 
 		useItemActivity := &UseItemBehavior{}
 
 		// 100の満腹度回復（上限を超える）
-		err = useItemActivity.applyNutrition(comp, actor, world, 100, item)
+		err := useItemActivity.applyNutrition(comp, actor, world, 100, item)
 		require.NoError(t, err)
 
 		hungerComp := world.Components.Hunger.Get(actor)
@@ -78,13 +76,12 @@ func TestUseItemBehavior_applyNutrition(t *testing.T) {
 		item := world.ECS.NewEntity()
 		world.Components.Name.Add(item, &gc.Name{Name: "パン"})
 
-		comp, err := NewActivity(gc.BehaviorUseItem, 1)
-		require.NoError(t, err)
+		comp := NewActivity(gc.BehaviorUseItem, 1)
 
 		useItemActivity := &UseItemBehavior{}
 
 		// 50の満腹度回復で95%以上になる
-		err = useItemActivity.applyNutrition(comp, actor, world, 50, item)
+		err := useItemActivity.applyNutrition(comp, actor, world, 50, item)
 		require.NoError(t, err)
 
 		hungerComp := world.Components.Hunger.Get(actor)
@@ -101,13 +98,12 @@ func TestUseItemBehavior_applyNutrition(t *testing.T) {
 		// Hungerコンポーネントを追加しない
 
 		item := world.ECS.NewEntity()
-		comp, err := NewActivity(gc.BehaviorUseItem, 1)
-		require.NoError(t, err)
+		comp := NewActivity(gc.BehaviorUseItem, 1)
 
 		useItemActivity := &UseItemBehavior{}
 
 		// エラーにならずに完了する
-		err = useItemActivity.applyNutrition(comp, actor, world, 200, item)
+		err := useItemActivity.applyNutrition(comp, actor, world, 200, item)
 		assert.NoError(t, err)
 	})
 
@@ -122,15 +118,14 @@ func TestUseItemBehavior_applyNutrition(t *testing.T) {
 		world.Components.Hunger.Add(actor, hunger)
 
 		item := world.ECS.NewEntity()
-		comp, err := NewActivity(gc.BehaviorUseItem, 1)
-		require.NoError(t, err)
+		comp := NewActivity(gc.BehaviorUseItem, 1)
 
 		useItemActivity := &UseItemBehavior{}
 
 		assert.Equal(t, gc.HungerStarving, hunger.GetLevel(), "初期状態は飢餓状態")
 
 		// 300の満腹度回復で70%になる
-		err = useItemActivity.applyNutrition(comp, actor, world, 300, item)
+		err := useItemActivity.applyNutrition(comp, actor, world, 300, item)
 		require.NoError(t, err)
 
 		hungerComp := world.Components.Hunger.Get(actor)

--- a/internal/activity/use_item_test.go
+++ b/internal/activity/use_item_test.go
@@ -24,7 +24,7 @@ func TestUseItemBehavior_applyNutrition(t *testing.T) {
 		world.Components.Hunger.Add(actor, hunger)
 
 		item := world.ECS.NewEntity()
-		comp, err := NewActivity(&UseItemBehavior{}, 1)
+		comp, err := NewActivity(gc.BehaviorUseItem, 1)
 		require.NoError(t, err)
 
 		useItemActivity := &UseItemBehavior{}
@@ -50,7 +50,7 @@ func TestUseItemBehavior_applyNutrition(t *testing.T) {
 		world.Components.Hunger.Add(actor, hunger)
 
 		item := world.ECS.NewEntity()
-		comp, err := NewActivity(&UseItemBehavior{}, 1)
+		comp, err := NewActivity(gc.BehaviorUseItem, 1)
 		require.NoError(t, err)
 
 		useItemActivity := &UseItemBehavior{}
@@ -78,7 +78,7 @@ func TestUseItemBehavior_applyNutrition(t *testing.T) {
 		item := world.ECS.NewEntity()
 		world.Components.Name.Add(item, &gc.Name{Name: "パン"})
 
-		comp, err := NewActivity(&UseItemBehavior{}, 1)
+		comp, err := NewActivity(gc.BehaviorUseItem, 1)
 		require.NoError(t, err)
 
 		useItemActivity := &UseItemBehavior{}
@@ -101,7 +101,7 @@ func TestUseItemBehavior_applyNutrition(t *testing.T) {
 		// Hungerコンポーネントを追加しない
 
 		item := world.ECS.NewEntity()
-		comp, err := NewActivity(&UseItemBehavior{}, 1)
+		comp, err := NewActivity(gc.BehaviorUseItem, 1)
 		require.NoError(t, err)
 
 		useItemActivity := &UseItemBehavior{}
@@ -122,7 +122,7 @@ func TestUseItemBehavior_applyNutrition(t *testing.T) {
 		world.Components.Hunger.Add(actor, hunger)
 
 		item := world.ECS.NewEntity()
-		comp, err := NewActivity(&UseItemBehavior{}, 1)
+		comp, err := NewActivity(gc.BehaviorUseItem, 1)
 		require.NoError(t, err)
 
 		useItemActivity := &UseItemBehavior{}

--- a/internal/activity/use_item_test.go
+++ b/internal/activity/use_item_test.go
@@ -158,7 +158,7 @@ func TestUseItemBehavior_DoTurn(t *testing.T) {
 		comp := &gc.Activity{
 			BehaviorName: gc.BehaviorUseItem,
 			State:        gc.ActivityStateRunning,
-			Target:       &item,
+			Params:       &gc.TargetParams{Target: item},
 		}
 
 		ua := &UseItemBehavior{}
@@ -187,7 +187,6 @@ func TestUseItemBehavior_DoTurn(t *testing.T) {
 		comp := &gc.Activity{
 			BehaviorName: gc.BehaviorUseItem,
 			State:        gc.ActivityStateRunning,
-			Target:       nil,
 		}
 
 		ua := &UseItemBehavior{}
@@ -215,7 +214,7 @@ func TestUseItemBehavior_Validate(t *testing.T) {
 
 		comp := &gc.Activity{
 			BehaviorName: gc.BehaviorUseItem,
-			Target:       &item,
+			Params:       &gc.TargetParams{Target: item},
 		}
 
 		ua := &UseItemBehavior{}
@@ -232,7 +231,6 @@ func TestUseItemBehavior_Validate(t *testing.T) {
 
 		comp := &gc.Activity{
 			BehaviorName: gc.BehaviorUseItem,
-			Target:       nil,
 		}
 
 		ua := &UseItemBehavior{}
@@ -250,7 +248,7 @@ func TestUseItemBehavior_Validate(t *testing.T) {
 
 		comp := &gc.Activity{
 			BehaviorName: gc.BehaviorUseItem,
-			Target:       new(world.ECS.NewEntity()),
+			Params:       &gc.TargetParams{Target: world.ECS.NewEntity()},
 		}
 
 		ua := &UseItemBehavior{}
@@ -271,7 +269,7 @@ func TestUseItemBehavior_Validate(t *testing.T) {
 
 		comp := &gc.Activity{
 			BehaviorName: gc.BehaviorUseItem,
-			Target:       &item,
+			Params:       &gc.TargetParams{Target: item},
 		}
 
 		ua := &UseItemBehavior{}
@@ -293,7 +291,7 @@ func TestUseItemBehavior_Validate(t *testing.T) {
 
 		comp := &gc.Activity{
 			BehaviorName: gc.BehaviorUseItem,
-			Target:       &item,
+			Params:       &gc.TargetParams{Target: item},
 		}
 
 		ua := &UseItemBehavior{}

--- a/internal/activity/use_item_test.go
+++ b/internal/activity/use_item_test.go
@@ -158,7 +158,7 @@ func TestUseItemBehavior_DoTurn(t *testing.T) {
 		comp := &gc.Activity{
 			BehaviorName: gc.BehaviorUseItem,
 			State:        gc.ActivityStateRunning,
-			Params:       &gc.TargetParams{Target: item},
+			Params:       &gc.UseItemParams{Target: item},
 		}
 
 		ua := &UseItemBehavior{}
@@ -214,7 +214,7 @@ func TestUseItemBehavior_Validate(t *testing.T) {
 
 		comp := &gc.Activity{
 			BehaviorName: gc.BehaviorUseItem,
-			Params:       &gc.TargetParams{Target: item},
+			Params:       &gc.UseItemParams{Target: item},
 		}
 
 		ua := &UseItemBehavior{}
@@ -248,7 +248,7 @@ func TestUseItemBehavior_Validate(t *testing.T) {
 
 		comp := &gc.Activity{
 			BehaviorName: gc.BehaviorUseItem,
-			Params:       &gc.TargetParams{Target: world.ECS.NewEntity()},
+			Params:       &gc.UseItemParams{Target: world.ECS.NewEntity()},
 		}
 
 		ua := &UseItemBehavior{}
@@ -269,7 +269,7 @@ func TestUseItemBehavior_Validate(t *testing.T) {
 
 		comp := &gc.Activity{
 			BehaviorName: gc.BehaviorUseItem,
-			Params:       &gc.TargetParams{Target: item},
+			Params:       &gc.UseItemParams{Target: item},
 		}
 
 		ua := &UseItemBehavior{}
@@ -291,7 +291,7 @@ func TestUseItemBehavior_Validate(t *testing.T) {
 
 		comp := &gc.Activity{
 			BehaviorName: gc.BehaviorUseItem,
-			Params:       &gc.TargetParams{Target: item},
+			Params:       &gc.UseItemParams{Target: item},
 		}
 
 		ua := &UseItemBehavior{}

--- a/internal/activity/wait.go
+++ b/internal/activity/wait.go
@@ -13,10 +13,7 @@ import (
 )
 
 // WaitBehavior はBehaviorの実装
-type WaitBehavior struct {
-	Duration consts.Turn
-	Reason   string
-}
+type WaitBehavior struct{}
 
 // Info はBehaviorの実装
 func (wb *WaitBehavior) Info() Info {
@@ -35,14 +32,14 @@ func (wb *WaitBehavior) Name() gc.BehaviorName {
 	return gc.BehaviorWait
 }
 
-// BuildActivity はBehaviorの実装。待機は作業ではなく時間経過なので、
-// 待機回数を Required に据え、DoTurn で毎ターン 1 ずつ注ぐ。
-func (wb *WaitBehavior) BuildActivity(_ ecs.Entity, _ w.World) (*gc.Activity, error) {
-	turns := int(wb.Duration)
+// NewWaitActivity は待機回数を指定して待機アクティビティを組む。待機は時間経過なので
+// Progress.Max に待機回数を直接据える。
+func NewWaitActivity(duration consts.Turn) *gc.Activity {
+	turns := int(duration)
 	if turns <= 0 {
 		turns = 1
 	}
-	return NewActivity(wb, turns)
+	return newActivity(gc.BehaviorWait, turns)
 }
 
 // Validate は待機アクティビティの検証を行う
@@ -60,7 +57,7 @@ func (wb *WaitBehavior) Validate(comp *gc.Activity, _ ecs.Entity, _ w.World) err
 
 // Start は待機開始時の処理を実行する
 func (wb *WaitBehavior) Start(comp *gc.Activity, actor ecs.Entity, _ w.World) error {
-	log.Debug("待機開始", "actor", actor, "reason", wb.Reason, "required", comp.Progress.Max)
+	log.Debug("待機開始", "actor", actor, "required", comp.Progress.Max)
 	return nil
 }
 

--- a/internal/activity/wait.go
+++ b/internal/activity/wait.go
@@ -26,7 +26,7 @@ func (wb *WaitBehavior) Info() Info {
 		Interruptible:   true,
 		Resumable:       true,
 		ActionPointCost: consts.StandardActionCost,
-		TotalRequiredAP: 500,
+		// 待機は時間経過なので TotalRequiredAP は使わない。Required は待機回数を直接持つ
 	}
 }
 

--- a/internal/activity/wait.go
+++ b/internal/activity/wait.go
@@ -39,7 +39,7 @@ func NewWaitActivity(duration consts.Turn) *gc.Activity {
 	if turns <= 0 {
 		turns = 1
 	}
-	return newActivity(gc.BehaviorWait, turns)
+	return NewActivity(gc.BehaviorWait, turns)
 }
 
 // Validate は待機アクティビティの検証を行う

--- a/internal/activity/wait.go
+++ b/internal/activity/wait.go
@@ -23,7 +23,6 @@ func (wb *WaitBehavior) Info() Info {
 		Interruptible:   true,
 		Resumable:       true,
 		ActionPointCost: consts.StandardActionCost,
-		// 待機は時間経過なので TotalRequiredAP は使わない。Required は待機回数を直接持つ
 	}
 }
 

--- a/internal/activity/wait.go
+++ b/internal/activity/wait.go
@@ -51,7 +51,7 @@ func (wb *WaitBehavior) Validate(comp *gc.Activity, _ ecs.Entity, _ w.World) err
 	// ただし、最低限のチェックは行う
 
 	// 待機回数が妥当かチェック
-	if comp.Required <= 0 {
+	if comp.Progress.Max <= 0 {
 		return fmt.Errorf("待機回数が無効です")
 	}
 
@@ -60,7 +60,7 @@ func (wb *WaitBehavior) Validate(comp *gc.Activity, _ ecs.Entity, _ w.World) err
 
 // Start は待機開始時の処理を実行する
 func (wb *WaitBehavior) Start(comp *gc.Activity, actor ecs.Entity, _ w.World) error {
-	log.Debug("待機開始", "actor", actor, "reason", wb.Reason, "required", comp.Required)
+	log.Debug("待機開始", "actor", actor, "reason", wb.Reason, "required", comp.Progress.Max)
 	return nil
 }
 
@@ -68,17 +68,17 @@ func (wb *WaitBehavior) Start(comp *gc.Activity, actor ecs.Entity, _ w.World) er
 func (wb *WaitBehavior) DoTurn(comp *gc.Activity, actor ecs.Entity, world w.World) error {
 	// 長い待機は敵が近づいたら中断する。1回だけのターン送りとAIの手番調整は
 	// その場で完結する行動なので対象にしない
-	if comp.Required > 1 && !isAreaSafe(actor, world) {
+	if comp.Progress.Max > 1 && !isAreaSafe(actor, world) {
 		Cancel(comp, "周囲に敵がいるため待機を中断")
 		return nil
 	}
 
 	// 1ターン進行
-	comp.Accumulated++
+	comp.Progress.Current++
 	log.Debug("待機進行", "progress", GetProgressPercent(comp))
 
 	// 完了チェック
-	if comp.Accumulated >= comp.Required {
+	if comp.Progress.Current >= comp.Progress.Max {
 		Complete(comp)
 	}
 
@@ -90,7 +90,7 @@ func (wb *WaitBehavior) Finish(comp *gc.Activity, actor ecs.Entity, world w.Worl
 	log.Debug("待機完了", "actor", actor)
 
 	// 複数ターン待機の場合のみログを表示する
-	if comp.Required > 1 && world.Components.Player.Has(actor) {
+	if comp.Progress.Max > 1 && world.Components.Player.Has(actor) {
 		gamelog.New(query.GetGameLog(world)).
 			Append("待機を終了した").
 			Log()

--- a/internal/activity/wait.go
+++ b/internal/activity/wait.go
@@ -35,17 +35,14 @@ func (wb *WaitBehavior) Name() gc.BehaviorName {
 	return gc.BehaviorWait
 }
 
-// BuildActivity はBehaviorの実装
+// BuildActivity はBehaviorの実装。待機は作業ではなく時間経過なので、
+// 待機回数を Required に据え、DoTurn で毎ターン 1 ずつ注ぐ。
 func (wb *WaitBehavior) BuildActivity(_ ecs.Entity, _ w.World) (*gc.Activity, error) {
-	duration := wb.Duration
-	if duration <= 0 {
-		duration = 1
+	turns := int(wb.Duration)
+	if turns <= 0 {
+		turns = 1
 	}
-	comp, err := NewActivity(wb, duration)
-	if err != nil {
-		return nil, err
-	}
-	return comp, nil
+	return NewActivity(wb, turns)
 }
 
 // Validate は待機アクティビティの検証を行う
@@ -53,9 +50,9 @@ func (wb *WaitBehavior) Validate(comp *gc.Activity, _ ecs.Entity, _ w.World) err
 	// 待機は基本的に常に実行可能
 	// ただし、最低限のチェックは行う
 
-	// 待機時間が妥当かチェック
-	if comp.TurnsTotal <= 0 {
-		return fmt.Errorf("待機時間が無効です")
+	// 待機回数が妥当かチェック
+	if comp.Required <= 0 {
+		return fmt.Errorf("待機回数が無効です")
 	}
 
 	return nil
@@ -63,38 +60,26 @@ func (wb *WaitBehavior) Validate(comp *gc.Activity, _ ecs.Entity, _ w.World) err
 
 // Start は待機開始時の処理を実行する
 func (wb *WaitBehavior) Start(comp *gc.Activity, actor ecs.Entity, _ w.World) error {
-	log.Debug("待機開始", "actor", actor, "reason", wb.Reason, "duration", comp.TurnsLeft)
+	log.Debug("待機開始", "actor", actor, "reason", wb.Reason, "required", comp.Required)
 	return nil
 }
 
 // DoTurn は待機アクティビティの1ターン分の処理を実行する
 func (wb *WaitBehavior) DoTurn(comp *gc.Activity, actor ecs.Entity, world w.World) error {
-	// 長い待機は敵が近づいたら中断する。1ターンのターン送りとAIの手番調整は
+	// 長い待機は敵が近づいたら中断する。1回だけのターン送りとAIの手番調整は
 	// その場で完結する行動なので対象にしない
-	if comp.TurnsTotal > 1 && !isAreaSafe(actor, world) {
+	if comp.Required > 1 && !isAreaSafe(actor, world) {
 		Cancel(comp, "周囲に敵がいるため待機を中断")
 		return nil
 	}
 
-	// 環境を観察
-	wb.observeEnvironment(comp, actor, world)
-
-	// 基本のターン処理
-	if comp.TurnsLeft <= 0 {
-		Complete(comp)
-		return nil
-	}
-
 	// 1ターン進行
-	comp.TurnsLeft--
-	log.Debug("待機進行",
-		"turns_left", comp.TurnsLeft,
-		"progress", GetProgressPercent(comp))
+	comp.Accumulated++
+	log.Debug("待機進行", "progress", GetProgressPercent(comp))
 
 	// 完了チェック
-	if comp.TurnsLeft <= 0 {
+	if comp.Accumulated >= comp.Required {
 		Complete(comp)
-		return nil
 	}
 
 	return nil
@@ -105,7 +90,7 @@ func (wb *WaitBehavior) Finish(comp *gc.Activity, actor ecs.Entity, world w.Worl
 	log.Debug("待機完了", "actor", actor)
 
 	// 複数ターン待機の場合のみログを表示する
-	if comp.TurnsTotal > 1 && world.Components.Player.Has(actor) {
+	if comp.Required > 1 && world.Components.Player.Has(actor) {
 		gamelog.New(query.GetGameLog(world)).
 			Append("待機を終了した").
 			Log()
@@ -118,16 +103,4 @@ func (wb *WaitBehavior) Finish(comp *gc.Activity, actor ecs.Entity, world w.Worl
 func (wb *WaitBehavior) Canceled(comp *gc.Activity, actor ecs.Entity, _ w.World) error {
 	log.Debug("待機キャンセル", "actor", actor, "reason", comp.CancelReason)
 	return nil
-}
-
-// observeEnvironment は環境観察処理を実行する
-func (wb *WaitBehavior) observeEnvironment(comp *gc.Activity, actor ecs.Entity, _ w.World) {
-	// 待機中の環境観察（5ターン毎）
-	if (comp.TurnsTotal-comp.TurnsLeft)%5 == 0 {
-		// TODO: 環境観察の実装
-		// - 周囲の敵の発見
-		// - アイテムの発見
-		// - 天候の変化など
-		log.Debug("環境観察", "actor", actor)
-	}
 }

--- a/internal/activity/wait_test.go
+++ b/internal/activity/wait_test.go
@@ -16,7 +16,7 @@ import (
 func TestWaitBehavior_Validate(t *testing.T) {
 	t.Parallel()
 
-	t.Run("有効なdurationの場合は成功", func(t *testing.T) {
+	t.Run("有効な待機回数の場合は成功", func(t *testing.T) {
 		t.Parallel()
 		world := testutil.InitTestWorld(t)
 
@@ -25,7 +25,7 @@ func TestWaitBehavior_Validate(t *testing.T) {
 
 		comp := &gc.Activity{
 			BehaviorName: gc.BehaviorWait,
-			TurnsTotal:   1,
+			Required:     1,
 		}
 
 		wa := &WaitBehavior{}
@@ -33,7 +33,7 @@ func TestWaitBehavior_Validate(t *testing.T) {
 		assert.NoError(t, err)
 	})
 
-	t.Run("TurnsTotalが0以下の場合はエラー", func(t *testing.T) {
+	t.Run("Requiredが0以下の場合はエラー", func(t *testing.T) {
 		t.Parallel()
 		world := testutil.InitTestWorld(t)
 
@@ -42,13 +42,13 @@ func TestWaitBehavior_Validate(t *testing.T) {
 
 		comp := &gc.Activity{
 			BehaviorName: gc.BehaviorWait,
-			TurnsTotal:   0,
+			Required:     0,
 		}
 
 		wa := &WaitBehavior{}
 		err = wa.Validate(comp, player, world)
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "待機時間が無効")
+		assert.Contains(t, err.Error(), "待機回数が無効")
 	})
 }
 
@@ -65,18 +65,19 @@ func TestWaitBehavior_DoTurn(t *testing.T) {
 		comp := &gc.Activity{
 			BehaviorName: gc.BehaviorWait,
 			State:        gc.ActivityStateRunning,
-			TurnsTotal:   5,
-			TurnsLeft:    3,
+			Required:     5,
+			Accumulated:  2,
 		}
 
 		wa := &WaitBehavior{}
 		err = wa.DoTurn(comp, player, world)
 
 		require.NoError(t, err)
-		assert.Equal(t, consts.Turn(2), comp.TurnsLeft)
+		assert.Equal(t, 3, comp.Accumulated)
+		assert.False(t, IsCompleted(comp))
 	})
 
-	t.Run("TurnsLeftが0以下なら完了", func(t *testing.T) {
+	t.Run("必要量に達したら完了", func(t *testing.T) {
 		t.Parallel()
 		world := testutil.InitTestWorld(t)
 
@@ -86,8 +87,8 @@ func TestWaitBehavior_DoTurn(t *testing.T) {
 		comp := &gc.Activity{
 			BehaviorName: gc.BehaviorWait,
 			State:        gc.ActivityStateRunning,
-			TurnsTotal:   5,
-			TurnsLeft:    0,
+			Required:     5,
+			Accumulated:  4,
 		}
 
 		wa := &WaitBehavior{}
@@ -107,8 +108,8 @@ func TestWaitBehavior_DoTurn(t *testing.T) {
 		comp := &gc.Activity{
 			BehaviorName: gc.BehaviorWait,
 			State:        gc.ActivityStateRunning,
-			TurnsTotal:   5,
-			TurnsLeft:    1,
+			Required:     5,
+			Accumulated:  4,
 		}
 
 		wa := &WaitBehavior{}
@@ -116,7 +117,7 @@ func TestWaitBehavior_DoTurn(t *testing.T) {
 
 		require.NoError(t, err)
 		assert.Equal(t, gc.ActivityStateCompleted, comp.State)
-		assert.Equal(t, consts.Turn(0), comp.TurnsLeft)
+		assert.Equal(t, 5, comp.Accumulated)
 	})
 }
 
@@ -132,7 +133,7 @@ func TestWaitBehavior_Finish(t *testing.T) {
 
 		comp := &gc.Activity{
 			BehaviorName: gc.BehaviorWait,
-			TurnsTotal:   1,
+			Required:     1,
 		}
 
 		wa := &WaitBehavior{}
@@ -152,7 +153,7 @@ func TestWaitBehavior_Finish(t *testing.T) {
 
 		comp := &gc.Activity{
 			BehaviorName: gc.BehaviorWait,
-			TurnsTotal:   5,
+			Required:     5,
 		}
 
 		wa := &WaitBehavior{}
@@ -174,7 +175,7 @@ func TestWaitBehavior_長い待機は敵接近で中断する(t *testing.T) {
 	spawnHostileAt(world, 11, 10)
 
 	wa := &WaitBehavior{}
-	comp := &gc.Activity{BehaviorName: gc.BehaviorWait, State: gc.ActivityStateRunning, TurnsTotal: 5, TurnsLeft: 5}
+	comp := &gc.Activity{BehaviorName: gc.BehaviorWait, State: gc.ActivityStateRunning, Required: 5}
 
 	require.NoError(t, wa.DoTurn(comp, actor, world))
 	assert.Equal(t, gc.ActivityStateCanceled, comp.State)
@@ -189,7 +190,7 @@ func TestWaitBehavior_1ターンの待機は敵が隣接していても完結す
 	spawnHostileAt(world, 11, 10)
 
 	wa := &WaitBehavior{}
-	comp := &gc.Activity{BehaviorName: gc.BehaviorWait, State: gc.ActivityStateRunning, TurnsTotal: 1, TurnsLeft: 1}
+	comp := &gc.Activity{BehaviorName: gc.BehaviorWait, State: gc.ActivityStateRunning, Required: 1}
 
 	require.NoError(t, wa.DoTurn(comp, actor, world))
 	require.NoError(t, wa.DoTurn(comp, actor, world))

--- a/internal/activity/wait_test.go
+++ b/internal/activity/wait_test.go
@@ -25,7 +25,7 @@ func TestWaitBehavior_Validate(t *testing.T) {
 
 		comp := &gc.Activity{
 			BehaviorName: gc.BehaviorWait,
-			Required:     1,
+			Progress:     gc.IntPool{Max: 1},
 		}
 
 		wa := &WaitBehavior{}
@@ -42,7 +42,7 @@ func TestWaitBehavior_Validate(t *testing.T) {
 
 		comp := &gc.Activity{
 			BehaviorName: gc.BehaviorWait,
-			Required:     0,
+			Progress:     gc.IntPool{Max: 0},
 		}
 
 		wa := &WaitBehavior{}
@@ -65,15 +65,14 @@ func TestWaitBehavior_DoTurn(t *testing.T) {
 		comp := &gc.Activity{
 			BehaviorName: gc.BehaviorWait,
 			State:        gc.ActivityStateRunning,
-			Required:     5,
-			Accumulated:  2,
+			Progress:     gc.IntPool{Max: 5, Current: 2},
 		}
 
 		wa := &WaitBehavior{}
 		err = wa.DoTurn(comp, player, world)
 
 		require.NoError(t, err)
-		assert.Equal(t, 3, comp.Accumulated)
+		assert.Equal(t, 3, comp.Progress.Current)
 		assert.False(t, IsCompleted(comp))
 	})
 
@@ -87,8 +86,7 @@ func TestWaitBehavior_DoTurn(t *testing.T) {
 		comp := &gc.Activity{
 			BehaviorName: gc.BehaviorWait,
 			State:        gc.ActivityStateRunning,
-			Required:     5,
-			Accumulated:  4,
+			Progress:     gc.IntPool{Max: 5, Current: 4},
 		}
 
 		wa := &WaitBehavior{}
@@ -108,8 +106,7 @@ func TestWaitBehavior_DoTurn(t *testing.T) {
 		comp := &gc.Activity{
 			BehaviorName: gc.BehaviorWait,
 			State:        gc.ActivityStateRunning,
-			Required:     5,
-			Accumulated:  4,
+			Progress:     gc.IntPool{Max: 5, Current: 4},
 		}
 
 		wa := &WaitBehavior{}
@@ -117,7 +114,7 @@ func TestWaitBehavior_DoTurn(t *testing.T) {
 
 		require.NoError(t, err)
 		assert.Equal(t, gc.ActivityStateCompleted, comp.State)
-		assert.Equal(t, 5, comp.Accumulated)
+		assert.Equal(t, 5, comp.Progress.Current)
 	})
 }
 
@@ -133,7 +130,7 @@ func TestWaitBehavior_Finish(t *testing.T) {
 
 		comp := &gc.Activity{
 			BehaviorName: gc.BehaviorWait,
-			Required:     1,
+			Progress:     gc.IntPool{Max: 1},
 		}
 
 		wa := &WaitBehavior{}
@@ -153,7 +150,7 @@ func TestWaitBehavior_Finish(t *testing.T) {
 
 		comp := &gc.Activity{
 			BehaviorName: gc.BehaviorWait,
-			Required:     5,
+			Progress:     gc.IntPool{Max: 5},
 		}
 
 		wa := &WaitBehavior{}
@@ -175,7 +172,7 @@ func TestWaitBehavior_長い待機は敵接近で中断する(t *testing.T) {
 	spawnHostileAt(world, 11, 10)
 
 	wa := &WaitBehavior{}
-	comp := &gc.Activity{BehaviorName: gc.BehaviorWait, State: gc.ActivityStateRunning, Required: 5}
+	comp := &gc.Activity{BehaviorName: gc.BehaviorWait, State: gc.ActivityStateRunning, Progress: gc.IntPool{Max: 5}}
 
 	require.NoError(t, wa.DoTurn(comp, actor, world))
 	assert.Equal(t, gc.ActivityStateCanceled, comp.State)
@@ -190,7 +187,7 @@ func TestWaitBehavior_1ターンの待機は敵が隣接していても完結す
 	spawnHostileAt(world, 11, 10)
 
 	wa := &WaitBehavior{}
-	comp := &gc.Activity{BehaviorName: gc.BehaviorWait, State: gc.ActivityStateRunning, Required: 1}
+	comp := &gc.Activity{BehaviorName: gc.BehaviorWait, State: gc.ActivityStateRunning, Progress: gc.IntPool{Max: 1}}
 
 	require.NoError(t, wa.DoTurn(comp, actor, world))
 	require.NoError(t, wa.DoTurn(comp, actor, world))

--- a/internal/aiinput/action_planner_test.go
+++ b/internal/aiinput/action_planner_test.go
@@ -4,7 +4,6 @@ import (
 	"math/rand/v2"
 	"testing"
 
-	"github.com/kijimaD/ruins/internal/activity"
 	gc "github.com/kijimaD/ruins/internal/components"
 	"github.com/kijimaD/ruins/internal/consts"
 	"github.com/kijimaD/ruins/internal/testutil"
@@ -60,7 +59,7 @@ func TestPlanAction_WaitingState(t *testing.T) {
 	// Waiting状態では待機を返す（視界外のプレイヤーでは遷移しない）
 	// Plan()経由でテスト。状態遷移も含む
 	behavior := rp.Plan(world, entity)
-	assert.Equal(t, gc.BehaviorWait, behavior.Name())
+	assert.Equal(t, gc.BehaviorWait, behavior.BehaviorName)
 }
 
 func TestPlanAction_ChasingState_Adjacent(t *testing.T) {
@@ -84,9 +83,8 @@ func TestPlanAction_ChasingState_Adjacent(t *testing.T) {
 	rp := newSoloPlanner(newTestRNG())
 
 	behavior := rp.Plan(world, entity)
-	assert.Equal(t, gc.BehaviorAttack, behavior.Name())
-	attack, ok := behavior.(*activity.AttackBehavior)
-	require.True(t, ok, "型が *activity.AttackBehavior であるべき")
+	assert.Equal(t, gc.BehaviorAttack, behavior.BehaviorName)
+	attack := behavior
 	assert.NotZero(t, attack.Target)
 }
 
@@ -111,9 +109,8 @@ func TestPlanAction_ChasingState_NotAdjacent(t *testing.T) {
 	rp := newSoloPlanner(newTestRNG())
 
 	behavior := rp.Plan(world, entity)
-	assert.Equal(t, gc.BehaviorMove, behavior.Name())
-	move, ok := behavior.(*activity.MoveBehavior)
-	require.True(t, ok, "型が *activity.MoveBehavior であるべき")
+	assert.Equal(t, gc.BehaviorMove, behavior.BehaviorName)
+	move := behavior
 	assert.NotZero(t, move.Destination)
 }
 
@@ -138,7 +135,7 @@ func TestPlanAction_FleeingState(t *testing.T) {
 	rp := newSoloPlanner(newTestRNG())
 
 	behavior := rp.Plan(world, entity)
-	name := behavior.Name()
+	name := behavior.BehaviorName
 	assert.True(t, name == gc.BehaviorMove || name == gc.BehaviorWait,
 		"逃亡時は移動か待機を返すべき: got %s", name)
 }
@@ -164,7 +161,7 @@ func TestPlanAction_DrivingState(t *testing.T) {
 	rp := newSoloPlanner(newTestRNG())
 
 	behavior := rp.Plan(world, entity)
-	name := behavior.Name()
+	name := behavior.BehaviorName
 	assert.True(t, name == gc.BehaviorMove || name == gc.BehaviorWait,
 		"Driving状態は移動か待機を返すべき: got %s", name)
 }
@@ -190,7 +187,7 @@ func TestPlanAction_UnknownState(t *testing.T) {
 	rp := newSoloPlanner(newTestRNG())
 
 	behavior := rp.Plan(world, entity)
-	assert.Equal(t, gc.BehaviorWait, behavior.Name())
+	assert.Equal(t, gc.BehaviorWait, behavior.BehaviorName)
 }
 
 func TestPlanDrivingAction_Stationary(t *testing.T) {
@@ -212,7 +209,7 @@ func TestPlanDrivingAction_Stationary(t *testing.T) {
 	grid := world.Components.GridElement.Get(entity)
 
 	behavior := rp.planDrivingAction(world, entity, solo, grid)
-	assert.Equal(t, gc.BehaviorWait, behavior.Name())
+	assert.Equal(t, gc.BehaviorWait, behavior.BehaviorName)
 }
 
 func TestPlanDrivingAction_Wander(t *testing.T) {
@@ -234,7 +231,7 @@ func TestPlanDrivingAction_Wander(t *testing.T) {
 	grid := world.Components.GridElement.Get(entity)
 
 	behavior := rp.planDrivingAction(world, entity, solo, grid)
-	name := behavior.Name()
+	name := behavior.BehaviorName
 	assert.True(t, name == gc.BehaviorMove || name == gc.BehaviorWait)
 }
 
@@ -257,7 +254,7 @@ func TestPlanDrivingAction_WallHug(t *testing.T) {
 	grid := world.Components.GridElement.Get(entity)
 
 	behavior := rp.planDrivingAction(world, entity, solo, grid)
-	name := behavior.Name()
+	name := behavior.BehaviorName
 	assert.True(t, name == gc.BehaviorMove || name == gc.BehaviorWait)
 }
 
@@ -280,7 +277,7 @@ func TestPlanDrivingAction_Swarm(t *testing.T) {
 	grid := world.Components.GridElement.Get(entity)
 
 	behavior := rp.planDrivingAction(world, entity, solo, grid)
-	name := behavior.Name()
+	name := behavior.BehaviorName
 	assert.True(t, name == gc.BehaviorMove || name == gc.BehaviorWait)
 }
 
@@ -305,7 +302,7 @@ func TestPlanDrivingAction_Territorial(t *testing.T) {
 	grid := world.Components.GridElement.Get(entity)
 
 	behavior := rp.planDrivingAction(world, entity, solo, grid)
-	assert.Equal(t, gc.BehaviorMove, behavior.Name())
+	assert.Equal(t, gc.BehaviorMove, behavior.BehaviorName)
 }
 
 func TestPlanDrivingAction_Random(t *testing.T) {
@@ -327,7 +324,7 @@ func TestPlanDrivingAction_Random(t *testing.T) {
 	grid := world.Components.GridElement.Get(entity)
 
 	behavior := rp.planDrivingAction(world, entity, solo, grid)
-	name := behavior.Name()
+	name := behavior.BehaviorName
 	assert.True(t, name == gc.BehaviorMove || name == gc.BehaviorWait)
 }
 
@@ -354,9 +351,8 @@ func TestPlanDrivingAction_Patrol(t *testing.T) {
 	grid := world.Components.GridElement.Get(entity)
 
 	behavior := rp.planDrivingAction(world, entity, solo, grid)
-	assert.Equal(t, gc.BehaviorMove, behavior.Name())
-	move, ok := behavior.(*activity.MoveBehavior)
-	require.True(t, ok, "型が *activity.MoveBehavior であるべき")
+	assert.Equal(t, gc.BehaviorMove, behavior.BehaviorName)
+	move := behavior
 	assert.Equal(t, consts.Tile(21), move.Destination.X)
 	assert.Equal(t, consts.Tile(20), move.Destination.Y)
 }
@@ -388,9 +384,8 @@ func TestPlanPatrolAction_ReverseOnBlock(t *testing.T) {
 	grid := world.Components.GridElement.Get(entity)
 
 	behavior := rp.planPatrolAction(world, entity, solo, grid)
-	assert.Equal(t, gc.BehaviorMove, behavior.Name())
-	move, ok := behavior.(*activity.MoveBehavior)
-	require.True(t, ok, "型が *activity.MoveBehavior であるべき")
+	assert.Equal(t, gc.BehaviorMove, behavior.BehaviorName)
+	move := behavior
 	assert.Equal(t, consts.Tile(19), move.Destination.X)
 	assert.Equal(t, -1, int(solo.PatrolDir.X))
 }
@@ -424,7 +419,7 @@ func TestPlanPatrolAction_BothBlocked(t *testing.T) {
 	grid := world.Components.GridElement.Get(entity)
 
 	behavior := rp.planPatrolAction(world, entity, solo, grid)
-	assert.Equal(t, gc.BehaviorWait, behavior.Name())
+	assert.Equal(t, gc.BehaviorWait, behavior.BehaviorName)
 }
 
 func TestPlanTerritorialAction_StaysInRange(t *testing.T) {
@@ -450,9 +445,8 @@ func TestPlanTerritorialAction_StaysInRange(t *testing.T) {
 		grid := world.Components.GridElement.Get(entity)
 
 		behavior := rp.planTerritorialAction(world, entity, solo, grid)
-		if behavior.Name() == gc.BehaviorMove {
-			move, ok := behavior.(*activity.MoveBehavior)
-			require.True(t, ok, "型が *activity.MoveBehavior であるべき")
+		if behavior.BehaviorName == gc.BehaviorMove {
+			move := behavior
 			grid.X = move.Destination.X
 			grid.Y = move.Destination.Y
 		}
@@ -492,9 +486,8 @@ func TestPlanTerritorialAction_AtBoundary(t *testing.T) {
 
 	for i := range 50 {
 		behavior := rp.planTerritorialAction(world, entity, solo, grid)
-		if behavior.Name() == gc.BehaviorMove {
-			move, ok := behavior.(*activity.MoveBehavior)
-			require.True(t, ok, "型が *activity.MoveBehavior であるべき")
+		if behavior.BehaviorName == gc.BehaviorMove {
+			move := behavior
 			dx := move.Destination.X - solo.Origin.X
 			dy := move.Destination.Y - solo.Origin.Y
 			if dx < 0 {
@@ -531,7 +524,7 @@ func TestPlanWanderAction(t *testing.T) {
 	gotWait := false
 	for range 50 {
 		behavior := rp.planWanderAction(world, entity, grid)
-		switch behavior.Name() { //nolint:exhaustive // テストはMove/Waitの発生のみ検証するため全caseは扱わない
+		switch behavior.BehaviorName { //nolint:exhaustive // テストはMove/Waitの発生のみ検証するため全caseは扱わない
 		case gc.BehaviorMove:
 			gotMove = true
 		case gc.BehaviorWait:
@@ -572,7 +565,7 @@ func TestPlanWallHugAction(t *testing.T) {
 	moved := false
 	for range 50 {
 		behavior := rp.planWallHugAction(world, entity, grid)
-		if behavior.Name() == gc.BehaviorMove {
+		if behavior.BehaviorName == gc.BehaviorMove {
 			moved = true
 			break
 		}
@@ -599,7 +592,7 @@ func TestPlanSwarmAction_NoAllies(t *testing.T) {
 	grid := world.Components.GridElement.Get(entity)
 
 	behavior := rp.planSwarmAction(world, entity, grid)
-	name := behavior.Name()
+	name := behavior.BehaviorName
 	assert.True(t, name == gc.BehaviorMove || name == gc.BehaviorWait,
 		"仲間がいない場合は移動か待機を返すべき: got %s", name)
 }
@@ -635,9 +628,8 @@ func TestPlanSwarmAction_WithAlly(t *testing.T) {
 	moved := false
 	for range 50 {
 		behavior := rp.planSwarmAction(world, entity, grid)
-		if behavior.Name() == gc.BehaviorMove {
-			move, ok := behavior.(*activity.MoveBehavior)
-			require.True(t, ok, "型が *activity.MoveBehavior であるべき")
+		if behavior.BehaviorName == gc.BehaviorMove {
+			move := behavior
 			if move.Destination.X > grid.X || move.Destination.Y > grid.Y {
 				moved = true
 				break
@@ -724,7 +716,7 @@ func TestPlanRandomMoveAction(t *testing.T) {
 	gotWait := false
 	for range 50 {
 		behavior := rp.planRandomMoveAction(world, entity, grid)
-		switch behavior.Name() { //nolint:exhaustive // テストはMove/Waitの発生のみ検証するため全caseは扱わない
+		switch behavior.BehaviorName { //nolint:exhaustive // テストはMove/Waitの発生のみ検証するため全caseは扱わない
 		case gc.BehaviorMove:
 			gotMove = true
 		case gc.BehaviorWait:
@@ -839,9 +831,8 @@ func TestPlanAction_ChasingState_隊員に隣接で攻撃(t *testing.T) {
 
 	rp := newSoloPlanner(newTestRNG())
 	behavior := rp.Plan(world, entity)
-	assert.Equal(t, gc.BehaviorAttack, behavior.Name(), "隣接する隊員を攻撃すべき")
-	attack, ok := behavior.(*activity.AttackBehavior)
-	require.True(t, ok, "型が *activity.AttackBehavior であるべき")
+	assert.Equal(t, gc.BehaviorAttack, behavior.BehaviorName, "隣接する隊員を攻撃すべき")
+	attack := behavior
 	assert.NotZero(t, attack.Target)
 }
 
@@ -876,8 +867,7 @@ func TestPlanAction_ChasingState_隊員に接近(t *testing.T) {
 
 	rp := newSoloPlanner(newTestRNG())
 	behavior := rp.Plan(world, entity)
-	assert.Equal(t, gc.BehaviorMove, behavior.Name(), "離れた隊員に向かって移動すべき")
-	move, ok := behavior.(*activity.MoveBehavior)
-	require.True(t, ok, "型が *activity.MoveBehavior であるべき")
+	assert.Equal(t, gc.BehaviorMove, behavior.BehaviorName, "離れた隊員に向かって移動すべき")
+	move := behavior
 	assert.Greater(t, int(move.Destination.X), 5, "隊員方向に移動すべき")
 }

--- a/internal/aiinput/action_planner_test.go
+++ b/internal/aiinput/action_planner_test.go
@@ -21,6 +21,30 @@ func newTestRNG() *rand.Rand {
 	return rand.New(rand.NewPCG(0, 0))
 }
 
+// moveParams はActivityから移動パラメータを取り出す。型が違えばテストを失敗させる
+func moveParams(t *testing.T, comp *gc.Activity) *gc.MoveParams {
+	t.Helper()
+	p, ok := comp.Params.(*gc.MoveParams)
+	require.True(t, ok, "MoveParams を期待")
+	return p
+}
+
+// targetParams はActivityから単一対象パラメータを取り出す。型が違えばテストを失敗させる
+func targetParams(t *testing.T, comp *gc.Activity) *gc.TargetParams {
+	t.Helper()
+	p, ok := comp.Params.(*gc.TargetParams)
+	require.True(t, ok, "TargetParams を期待")
+	return p
+}
+
+// transferParams はActivityから転送パラメータを取り出す。型が違えばテストを失敗させる
+func transferParams(t *testing.T, comp *gc.Activity) *gc.TransferParams {
+	t.Helper()
+	p, ok := comp.Params.(*gc.TransferParams)
+	require.True(t, ok, "TransferParams を期待")
+	return p
+}
+
 // setupTestAI はテスト用の敵AIエンティティを作成する
 func setupTestAI(t *testing.T, world w.World, x, y int, solo *gc.SoloAI) ecs.Entity {
 	t.Helper()
@@ -84,7 +108,7 @@ func TestPlanAction_ChasingState_Adjacent(t *testing.T) {
 
 	behavior := rp.Plan(world, entity)
 	assert.Equal(t, gc.BehaviorAttack, behavior.BehaviorName)
-	attack := behavior
+	attack := targetParams(t, behavior)
 	assert.NotZero(t, attack.Target)
 }
 
@@ -110,7 +134,7 @@ func TestPlanAction_ChasingState_NotAdjacent(t *testing.T) {
 
 	behavior := rp.Plan(world, entity)
 	assert.Equal(t, gc.BehaviorMove, behavior.BehaviorName)
-	move := behavior
+	move := moveParams(t, behavior)
 	assert.NotZero(t, move.Destination)
 }
 
@@ -352,7 +376,7 @@ func TestPlanDrivingAction_Patrol(t *testing.T) {
 
 	behavior := rp.planDrivingAction(world, entity, solo, grid)
 	assert.Equal(t, gc.BehaviorMove, behavior.BehaviorName)
-	move := behavior
+	move := moveParams(t, behavior)
 	assert.Equal(t, consts.Tile(21), move.Destination.X)
 	assert.Equal(t, consts.Tile(20), move.Destination.Y)
 }
@@ -385,7 +409,7 @@ func TestPlanPatrolAction_ReverseOnBlock(t *testing.T) {
 
 	behavior := rp.planPatrolAction(world, entity, solo, grid)
 	assert.Equal(t, gc.BehaviorMove, behavior.BehaviorName)
-	move := behavior
+	move := moveParams(t, behavior)
 	assert.Equal(t, consts.Tile(19), move.Destination.X)
 	assert.Equal(t, -1, int(solo.PatrolDir.X))
 }
@@ -446,7 +470,7 @@ func TestPlanTerritorialAction_StaysInRange(t *testing.T) {
 
 		behavior := rp.planTerritorialAction(world, entity, solo, grid)
 		if behavior.BehaviorName == gc.BehaviorMove {
-			move := behavior
+			move := moveParams(t, behavior)
 			grid.X = move.Destination.X
 			grid.Y = move.Destination.Y
 		}
@@ -487,7 +511,7 @@ func TestPlanTerritorialAction_AtBoundary(t *testing.T) {
 	for i := range 50 {
 		behavior := rp.planTerritorialAction(world, entity, solo, grid)
 		if behavior.BehaviorName == gc.BehaviorMove {
-			move := behavior
+			move := moveParams(t, behavior)
 			dx := move.Destination.X - solo.Origin.X
 			dy := move.Destination.Y - solo.Origin.Y
 			if dx < 0 {
@@ -629,7 +653,7 @@ func TestPlanSwarmAction_WithAlly(t *testing.T) {
 	for range 50 {
 		behavior := rp.planSwarmAction(world, entity, grid)
 		if behavior.BehaviorName == gc.BehaviorMove {
-			move := behavior
+			move := moveParams(t, behavior)
 			if move.Destination.X > grid.X || move.Destination.Y > grid.Y {
 				moved = true
 				break
@@ -832,7 +856,7 @@ func TestPlanAction_ChasingState_隊員に隣接で攻撃(t *testing.T) {
 	rp := newSoloPlanner(newTestRNG())
 	behavior := rp.Plan(world, entity)
 	assert.Equal(t, gc.BehaviorAttack, behavior.BehaviorName, "隣接する隊員を攻撃すべき")
-	attack := behavior
+	attack := targetParams(t, behavior)
 	assert.NotZero(t, attack.Target)
 }
 
@@ -868,6 +892,6 @@ func TestPlanAction_ChasingState_隊員に接近(t *testing.T) {
 	rp := newSoloPlanner(newTestRNG())
 	behavior := rp.Plan(world, entity)
 	assert.Equal(t, gc.BehaviorMove, behavior.BehaviorName, "離れた隊員に向かって移動すべき")
-	move := behavior
+	move := moveParams(t, behavior)
 	assert.Greater(t, int(move.Destination.X), 5, "隊員方向に移動すべき")
 }

--- a/internal/aiinput/action_planner_test.go
+++ b/internal/aiinput/action_planner_test.go
@@ -21,27 +21,11 @@ func newTestRNG() *rand.Rand {
 	return rand.New(rand.NewPCG(0, 0))
 }
 
-// moveParams はActivityから移動パラメータを取り出す。型が違えばテストを失敗させる
-func moveParams(t *testing.T, comp *gc.Activity) *gc.MoveParams {
+// activityParams はActivityから指定型のパラメータを取り出す。型が違えばテストを失敗させる
+func activityParams[T gc.ActivityParams](t *testing.T, comp *gc.Activity) T {
 	t.Helper()
-	p, ok := comp.Params.(*gc.MoveParams)
-	require.True(t, ok, "MoveParams を期待")
-	return p
-}
-
-// targetParams はActivityから単一対象パラメータを取り出す。型が違えばテストを失敗させる
-func targetParams(t *testing.T, comp *gc.Activity) *gc.TargetParams {
-	t.Helper()
-	p, ok := comp.Params.(*gc.TargetParams)
-	require.True(t, ok, "TargetParams を期待")
-	return p
-}
-
-// transferParams はActivityから転送パラメータを取り出す。型が違えばテストを失敗させる
-func transferParams(t *testing.T, comp *gc.Activity) *gc.TransferParams {
-	t.Helper()
-	p, ok := comp.Params.(*gc.TransferParams)
-	require.True(t, ok, "TransferParams を期待")
+	p, ok := comp.Params.(T)
+	require.True(t, ok, "期待した Params 型ではない")
 	return p
 }
 
@@ -108,7 +92,7 @@ func TestPlanAction_ChasingState_Adjacent(t *testing.T) {
 
 	behavior := rp.Plan(world, entity)
 	assert.Equal(t, gc.BehaviorAttack, behavior.BehaviorName)
-	attack := targetParams(t, behavior)
+	attack := activityParams[*gc.AttackParams](t, behavior)
 	assert.NotZero(t, attack.Target)
 }
 
@@ -134,7 +118,7 @@ func TestPlanAction_ChasingState_NotAdjacent(t *testing.T) {
 
 	behavior := rp.Plan(world, entity)
 	assert.Equal(t, gc.BehaviorMove, behavior.BehaviorName)
-	move := moveParams(t, behavior)
+	move := activityParams[*gc.MoveParams](t, behavior)
 	assert.NotZero(t, move.Destination)
 }
 
@@ -376,7 +360,7 @@ func TestPlanDrivingAction_Patrol(t *testing.T) {
 
 	behavior := rp.planDrivingAction(world, entity, solo, grid)
 	assert.Equal(t, gc.BehaviorMove, behavior.BehaviorName)
-	move := moveParams(t, behavior)
+	move := activityParams[*gc.MoveParams](t, behavior)
 	assert.Equal(t, consts.Tile(21), move.Destination.X)
 	assert.Equal(t, consts.Tile(20), move.Destination.Y)
 }
@@ -409,7 +393,7 @@ func TestPlanPatrolAction_ReverseOnBlock(t *testing.T) {
 
 	behavior := rp.planPatrolAction(world, entity, solo, grid)
 	assert.Equal(t, gc.BehaviorMove, behavior.BehaviorName)
-	move := moveParams(t, behavior)
+	move := activityParams[*gc.MoveParams](t, behavior)
 	assert.Equal(t, consts.Tile(19), move.Destination.X)
 	assert.Equal(t, -1, int(solo.PatrolDir.X))
 }
@@ -470,7 +454,7 @@ func TestPlanTerritorialAction_StaysInRange(t *testing.T) {
 
 		behavior := rp.planTerritorialAction(world, entity, solo, grid)
 		if behavior.BehaviorName == gc.BehaviorMove {
-			move := moveParams(t, behavior)
+			move := activityParams[*gc.MoveParams](t, behavior)
 			grid.X = move.Destination.X
 			grid.Y = move.Destination.Y
 		}
@@ -511,7 +495,7 @@ func TestPlanTerritorialAction_AtBoundary(t *testing.T) {
 	for i := range 50 {
 		behavior := rp.planTerritorialAction(world, entity, solo, grid)
 		if behavior.BehaviorName == gc.BehaviorMove {
-			move := moveParams(t, behavior)
+			move := activityParams[*gc.MoveParams](t, behavior)
 			dx := move.Destination.X - solo.Origin.X
 			dy := move.Destination.Y - solo.Origin.Y
 			if dx < 0 {
@@ -653,7 +637,7 @@ func TestPlanSwarmAction_WithAlly(t *testing.T) {
 	for range 50 {
 		behavior := rp.planSwarmAction(world, entity, grid)
 		if behavior.BehaviorName == gc.BehaviorMove {
-			move := moveParams(t, behavior)
+			move := activityParams[*gc.MoveParams](t, behavior)
 			if move.Destination.X > grid.X || move.Destination.Y > grid.Y {
 				moved = true
 				break
@@ -856,7 +840,7 @@ func TestPlanAction_ChasingState_隊員に隣接で攻撃(t *testing.T) {
 	rp := newSoloPlanner(newTestRNG())
 	behavior := rp.Plan(world, entity)
 	assert.Equal(t, gc.BehaviorAttack, behavior.BehaviorName, "隣接する隊員を攻撃すべき")
-	attack := targetParams(t, behavior)
+	attack := activityParams[*gc.AttackParams](t, behavior)
 	assert.NotZero(t, attack.Target)
 }
 
@@ -892,6 +876,6 @@ func TestPlanAction_ChasingState_隊員に接近(t *testing.T) {
 	rp := newSoloPlanner(newTestRNG())
 	behavior := rp.Plan(world, entity)
 	assert.Equal(t, gc.BehaviorMove, behavior.BehaviorName, "離れた隊員に向かって移動すべき")
-	move := moveParams(t, behavior)
+	move := activityParams[*gc.MoveParams](t, behavior)
 	assert.Greater(t, int(move.Destination.X), 5, "隊員方向に移動すべき")
 }

--- a/internal/aiinput/planner.go
+++ b/internal/aiinput/planner.go
@@ -16,7 +16,7 @@ import (
 // Planner はエンティティの行動計画を担うインターフェースを表す。
 // 各ターンのAPループ内で呼ばれ、次のアクションを返す
 type Planner interface {
-	Plan(world w.World, entity ecs.Entity) activity.Behavior
+	Plan(world w.World, entity ecs.Entity) *gc.Activity
 }
 
 // maxActivitiesPerTurn は1ターン中に実行可能なアクティビティの上限を表す
@@ -32,25 +32,30 @@ func runAPLoop(world w.World, entity ecs.Entity, planner Planner, log *logger.Lo
 			break
 		}
 
-		behavior := planner.Plan(world, entity)
-		if behavior == nil {
+		comp := planner.Plan(world, entity)
+		if comp == nil {
 			break
 		}
 
-		actionCost := behavior.Info().ActionPointCost
+		b, err := activity.GetBehavior(comp.BehaviorName)
+		if err != nil {
+			log.Warn("Behavior取得失敗", "entity", entity, "activity", comp.BehaviorName, "error", err.Error())
+			break
+		}
+		actionCost := b.Info().ActionPointCost
 		tbComp := world.Components.TurnBased.Get(entity)
 		if tbComp == nil || tbComp.AP.Current < actionCost {
-			log.Debug("AP不足", "entity", entity, "activity", behavior.Name(), "cost", actionCost)
+			log.Debug("AP不足", "entity", entity, "activity", comp.BehaviorName, "cost", actionCost)
 			break
 		}
 
-		result, err := activity.Execute(behavior, entity, world)
+		result, err := activity.Execute(comp, entity, world)
 		if err != nil {
-			log.Warn("アクション実行失敗", "entity", entity, "activity", behavior.Name(), "error", err.Error())
+			log.Warn("アクション実行失敗", "entity", entity, "activity", comp.BehaviorName, "error", err.Error())
 			break
 		}
 
-		log.Debug("アクション実行", "entity", entity, "activity", behavior.Name(), "success", result.Success)
+		log.Debug("アクション実行", "entity", entity, "activity", comp.BehaviorName, "success", result.Success)
 		executed++
 
 		if !result.Success {
@@ -117,7 +122,7 @@ func calculateMoveCandidates(delta consts.Coord[consts.Tile]) []consts.Coord[con
 }
 
 // tryMoveCandidates は移動候補を順に試行し、最初に移動可能な方向へ移動するアクションを返す
-func tryMoveCandidates(world w.World, entity ecs.Entity, from *gc.GridElement, candidates []consts.Coord[consts.Tile]) (activity.Behavior, bool) {
+func tryMoveCandidates(world w.World, entity ecs.Entity, from *gc.GridElement, candidates []consts.Coord[consts.Tile]) (*gc.Activity, bool) {
 	fromPos := from.Coord
 	for _, c := range candidates {
 		dest := fromPos.Add(c)
@@ -129,15 +134,13 @@ func tryMoveCandidates(world w.World, entity ecs.Entity, from *gc.GridElement, c
 }
 
 // moveAction は指定座標への移動アクションを生成する
-func moveAction(dest consts.Coord[consts.Tile]) activity.Behavior {
-	return &activity.MoveBehavior{
-		Destination: gc.GridElement{Coord: dest},
-	}
+func moveAction(dest consts.Coord[consts.Tile]) *gc.Activity {
+	return activity.NewMoveActivity(gc.GridElement{Coord: dest})
 }
 
 // waitAction は待機アクションを生成する
-func waitAction(reason string) activity.Behavior {
-	return &activity.WaitBehavior{Duration: 1, Reason: reason}
+func waitAction() *gc.Activity {
+	return activity.NewWaitActivity(1)
 }
 
 // shuffledEightDirections は8方向をシャッフルして返す

--- a/internal/aiinput/planner_solo.go
+++ b/internal/aiinput/planner_solo.go
@@ -35,7 +35,7 @@ func newSoloPlanner(rng *rand.Rand) *soloPlanner {
 
 // Plan は状態遷移の評価とアクション決定を一体的に行う。
 // APループ内で繰り返し呼ばれ、状態遷移は同一ターン内でべき等
-func (rp *soloPlanner) Plan(world w.World, entity ecs.Entity) activity.Behavior {
+func (rp *soloPlanner) Plan(world w.World, entity ecs.Entity) *gc.Activity {
 	solo := world.Components.SoloAI.Get(entity)
 	if solo == nil {
 		rp.logger.Warn("SoloAIコンポーネントなし", "entity", entity)
@@ -60,9 +60,9 @@ func (rp *soloPlanner) Plan(world w.World, entity ecs.Entity) activity.Behavior 
 	case gc.AIStateDriving:
 		return rp.planDrivingAction(world, entity, solo, grid)
 	case gc.AIStateWaiting:
-		return waitAction("AI待機")
+		return waitAction()
 	default:
-		return waitAction("AIデフォルト待機")
+		return waitAction()
 	}
 }
 
@@ -174,11 +174,11 @@ func (rp *soloPlanner) initializeToWaiting(solo *gc.SoloAI, currentTurn consts.T
 
 // ========== アクション計画ロジック ==========
 
-func (rp *soloPlanner) planChaseAction(world w.World, aiEntity, playerEntity ecs.Entity, aiGrid *gc.GridElement) activity.Behavior {
+func (rp *soloPlanner) planChaseAction(world w.World, aiEntity, playerEntity ecs.Entity, aiGrid *gc.GridElement) *gc.Activity {
 	playerGrid := world.Components.GridElement.Get(playerEntity)
 
 	if isAdjacent(aiGrid, playerGrid) {
-		return &activity.AttackBehavior{Target: playerEntity}
+		return activity.NewAttackActivity(playerEntity)
 	}
 
 	dx := playerGrid.X - aiGrid.X
@@ -189,10 +189,10 @@ func (rp *soloPlanner) planChaseAction(world w.World, aiEntity, playerEntity ecs
 		return b
 	}
 
-	return waitAction("AI追跡失敗")
+	return waitAction()
 }
 
-func (rp *soloPlanner) planFleeAction(world w.World, aiEntity, playerEntity ecs.Entity, aiGrid *gc.GridElement) activity.Behavior {
+func (rp *soloPlanner) planFleeAction(world w.World, aiEntity, playerEntity ecs.Entity, aiGrid *gc.GridElement) *gc.Activity {
 	playerGrid := world.Components.GridElement.Get(playerEntity)
 
 	dx := aiGrid.X - playerGrid.X
@@ -206,9 +206,9 @@ func (rp *soloPlanner) planFleeAction(world w.World, aiEntity, playerEntity ecs.
 	return rp.planRandomMoveAction(world, aiEntity, aiGrid)
 }
 
-func (rp *soloPlanner) planRandomMoveAction(world w.World, aiEntity ecs.Entity, aiGrid *gc.GridElement) activity.Behavior {
+func (rp *soloPlanner) planRandomMoveAction(world w.World, aiEntity ecs.Entity, aiGrid *gc.GridElement) *gc.Activity {
 	if rp.rng.Float64() < 0.3 {
-		return waitAction("AIランダム待機")
+		return waitAction()
 	}
 
 	from := aiGrid.Coord
@@ -219,13 +219,13 @@ func (rp *soloPlanner) planRandomMoveAction(world w.World, aiEntity ecs.Entity, 
 		}
 	}
 
-	return waitAction("AIランダム移動失敗")
+	return waitAction()
 }
 
-func (rp *soloPlanner) planDrivingAction(world w.World, aiEntity ecs.Entity, solo *gc.SoloAI, grid *gc.GridElement) activity.Behavior {
+func (rp *soloPlanner) planDrivingAction(world w.World, aiEntity ecs.Entity, solo *gc.SoloAI, grid *gc.GridElement) *gc.Activity {
 	switch solo.Movement {
 	case gc.SoloStationary:
-		return waitAction("AI固定待機")
+		return waitAction()
 	case gc.SoloWander:
 		return rp.planWanderAction(world, aiEntity, grid)
 	case gc.SoloWallHug:
@@ -241,16 +241,16 @@ func (rp *soloPlanner) planDrivingAction(world w.World, aiEntity ecs.Entity, sol
 	}
 }
 
-func (rp *soloPlanner) planWanderAction(world w.World, aiEntity ecs.Entity, aiGrid *gc.GridElement) activity.Behavior {
+func (rp *soloPlanner) planWanderAction(world w.World, aiEntity ecs.Entity, aiGrid *gc.GridElement) *gc.Activity {
 	if rp.rng.Float64() < 0.8 {
-		return waitAction("AI徘徊待機")
+		return waitAction()
 	}
 	return rp.planRandomMoveAction(world, aiEntity, aiGrid)
 }
 
-func (rp *soloPlanner) planWallHugAction(world w.World, aiEntity ecs.Entity, aiGrid *gc.GridElement) activity.Behavior {
+func (rp *soloPlanner) planWallHugAction(world w.World, aiEntity ecs.Entity, aiGrid *gc.GridElement) *gc.Activity {
 	if rp.rng.Float64() < 0.3 {
-		return waitAction("AI壁沿い待機")
+		return waitAction()
 	}
 
 	si := query.GetSpatialIndex(world)
@@ -279,7 +279,7 @@ func (rp *soloPlanner) planWallHugAction(world w.World, aiEntity ecs.Entity, aiG
 	}
 
 	if len(candidates) == 0 {
-		return waitAction("AI壁沿い移動失敗")
+		return waitAction()
 	}
 
 	best := candidates[0].score
@@ -299,7 +299,7 @@ func (rp *soloPlanner) planWallHugAction(world w.World, aiEntity ecs.Entity, aiG
 	return moveAction(consts.Coord[consts.Tile]{X: from.X + chosen.X, Y: from.Y + chosen.Y})
 }
 
-func (rp *soloPlanner) planSwarmAction(world w.World, aiEntity ecs.Entity, aiGrid *gc.GridElement) activity.Behavior {
+func (rp *soloPlanner) planSwarmAction(world w.World, aiEntity ecs.Entity, aiGrid *gc.GridElement) *gc.Activity {
 	_, nearestGrid, nearestDist := query.FindNearestCharacter(world, aiEntity, aiGrid, func(entity ecs.Entity) bool {
 		return world.Components.SoloAI.Has(entity) || world.Components.SquadAI.Has(entity)
 	})
@@ -319,7 +319,7 @@ func (rp *soloPlanner) planSwarmAction(world w.World, aiEntity ecs.Entity, aiGri
 	return rp.planRandomMoveAction(world, aiEntity, aiGrid)
 }
 
-func (rp *soloPlanner) planPatrolAction(world w.World, aiEntity ecs.Entity, solo *gc.SoloAI, grid *gc.GridElement) activity.Behavior {
+func (rp *soloPlanner) planPatrolAction(world w.World, aiEntity ecs.Entity, solo *gc.SoloAI, grid *gc.GridElement) *gc.Activity {
 	from := grid.Coord
 
 	dest := from.Add(solo.PatrolDir)
@@ -335,10 +335,10 @@ func (rp *soloPlanner) planPatrolAction(world w.World, aiEntity ecs.Entity, solo
 		return moveAction(dest)
 	}
 
-	return waitAction("AI巡回移動失敗")
+	return waitAction()
 }
 
-func (rp *soloPlanner) planTerritorialAction(world w.World, aiEntity ecs.Entity, solo *gc.SoloAI, grid *gc.GridElement) activity.Behavior {
+func (rp *soloPlanner) planTerritorialAction(world w.World, aiEntity ecs.Entity, solo *gc.SoloAI, grid *gc.GridElement) *gc.Activity {
 	from := grid.Coord
 
 	for _, d := range shuffledEightDirections(rp.rng) {
@@ -355,5 +355,5 @@ func (rp *soloPlanner) planTerritorialAction(world w.World, aiEntity ecs.Entity,
 		}
 	}
 
-	return waitAction("AI縄張り移動失敗")
+	return waitAction()
 }

--- a/internal/aiinput/planner_squad.go
+++ b/internal/aiinput/planner_squad.go
@@ -284,7 +284,7 @@ func (sp *squadPlanner) planItemPickupAction(world w.World, entity ecs.Entity, s
 	if hasPickableHere {
 		sp.logger.Debug("隊員アイテム拾得", "entity", entity, "x", snap.Grid.X, "y", snap.Grid.Y)
 		dest := *snap.Grid
-		return activity.NewPickupActivity(nil, &dest), true
+		return activity.NewPickupTileActivity(world, dest.Coord), true
 	}
 
 	if nearestItemGrid != nil {

--- a/internal/aiinput/planner_squad.go
+++ b/internal/aiinput/planner_squad.go
@@ -47,7 +47,7 @@ type squadSnapshot struct {
 }
 
 // Plan はsquadSnapshotを収集し、優先度チェーンで行動を決定する
-func (sp *squadPlanner) Plan(world w.World, entity ecs.Entity) activity.Behavior {
+func (sp *squadPlanner) Plan(world w.World, entity ecs.Entity) *gc.Activity {
 	snap, ok := sp.gatherSquadSnapshot(world, entity)
 	if !ok {
 		return nil
@@ -87,7 +87,7 @@ func (sp *squadPlanner) gatherSquadSnapshot(world w.World, entity ecs.Entity) (*
 
 // planAction はポリシーと状況に基づいてアクションを決定する。
 // 優先順位: HP低下時後退 → エリア制限 → 補給 → 戦闘 → アイテム転送 → アイテム拾得 → 位置ポリシー
-func (sp *squadPlanner) planAction(world w.World, entity ecs.Entity, snap *squadSnapshot) activity.Behavior {
+func (sp *squadPlanner) planAction(world w.World, entity ecs.Entity, snap *squadSnapshot) *gc.Activity {
 	if sp.shouldRetreatLowHP(world, entity) {
 		if b, ok := sp.planRetreatAction(world, entity, snap); ok {
 			return b
@@ -132,7 +132,7 @@ func (sp *squadPlanner) shouldRetreatLowHP(world w.World, entity ecs.Entity) boo
 }
 
 // planRetreatAction はリーダーに向かって後退するアクションを計画する
-func (sp *squadPlanner) planRetreatAction(world w.World, entity ecs.Entity, snap *squadSnapshot) (activity.Behavior, bool) {
+func (sp *squadPlanner) planRetreatAction(world w.World, entity ecs.Entity, snap *squadSnapshot) (*gc.Activity, bool) {
 	sp.logger.Debug("隊員HP低下、後退", "entity", entity)
 	return sp.tryMoveToward(world, entity, snap.Grid, snap.LeaderGrid)
 }
@@ -147,13 +147,13 @@ func (sp *squadPlanner) isOutsideExploredArea(world w.World, grid *gc.GridElemen
 }
 
 // planReturnToExploredArea は最寄りの探索済みマスへ移動するアクションを計画する
-func (sp *squadPlanner) planReturnToExploredArea(world w.World, entity ecs.Entity, snap *squadSnapshot) (activity.Behavior, bool) {
+func (sp *squadPlanner) planReturnToExploredArea(world w.World, entity ecs.Entity, snap *squadSnapshot) (*gc.Activity, bool) {
 	sp.logger.Debug("隊員がエリア外、リーダーに向かう", "entity", entity)
 	return sp.tryMoveToward(world, entity, snap.Grid, snap.LeaderGrid)
 }
 
 // planCombatAction は戦闘ポリシーに基づくアクションを計画する
-func (sp *squadPlanner) planCombatAction(world w.World, entity ecs.Entity, snap *squadSnapshot) (activity.Behavior, bool) {
+func (sp *squadPlanner) planCombatAction(world w.World, entity ecs.Entity, snap *squadSnapshot) (*gc.Activity, bool) {
 	switch snap.Squad.CombatCurrent {
 	case gc.CombatAttack:
 		return sp.planAttackAction(world, entity, snap)
@@ -167,14 +167,14 @@ func (sp *squadPlanner) planCombatAction(world w.World, entity ecs.Entity, snap 
 // planAttackAction は攻撃ポリシーに基づくアクションを計画する。
 // 隣接する敵がいれば攻撃し、視界内の敵がいれば接近する。
 // 移動しても敵に近づけない場合は諦めて次の優先度に進む
-func (sp *squadPlanner) planAttackAction(world w.World, entity ecs.Entity, snap *squadSnapshot) (activity.Behavior, bool) {
+func (sp *squadPlanner) planAttackAction(world w.World, entity ecs.Entity, snap *squadSnapshot) (*gc.Activity, bool) {
 	nearestEnemy, nearestGrid, dist := sp.findNearestEnemy(world, entity, snap)
 	if nearestEnemy == nil {
 		return nil, false
 	}
 
 	if dist == 1 {
-		return &activity.AttackBehavior{Target: *nearestEnemy}, true
+		return activity.NewAttackActivity(*nearestEnemy), true
 	}
 
 	return sp.tryMoveToward(world, entity, snap.Grid, nearestGrid)
@@ -182,7 +182,7 @@ func (sp *squadPlanner) planAttackAction(world w.World, entity ecs.Entity, snap 
 
 // planEvadeAction は回避ポリシーに基づくアクションを計画する。
 // 視界内の最寄りの敵から距離を取る
-func (sp *squadPlanner) planEvadeAction(world w.World, entity ecs.Entity, snap *squadSnapshot) (activity.Behavior, bool) {
+func (sp *squadPlanner) planEvadeAction(world w.World, entity ecs.Entity, snap *squadSnapshot) (*gc.Activity, bool) {
 	nearestEnemy, _, _ := sp.findNearestEnemy(world, entity, snap)
 	if nearestEnemy == nil {
 		return nil, false
@@ -193,7 +193,7 @@ func (sp *squadPlanner) planEvadeAction(world w.World, entity ecs.Entity, snap *
 }
 
 // planPositionAction は位置ポリシーに基づくアクションを計画する
-func (sp *squadPlanner) planPositionAction(world w.World, entity ecs.Entity, snap *squadSnapshot) activity.Behavior {
+func (sp *squadPlanner) planPositionAction(world w.World, entity ecs.Entity, snap *squadSnapshot) *gc.Activity {
 	switch snap.Squad.Movement {
 	case gc.SquadEscort:
 		return sp.planEscortAction(world, entity, snap)
@@ -202,54 +202,54 @@ func (sp *squadPlanner) planPositionAction(world w.World, entity ecs.Entity, sna
 	case gc.SquadPatrol:
 		return sp.planSquadPatrolAction(world, entity, snap)
 	case gc.SquadStationary:
-		return waitAction("隊員待機")
+		return waitAction()
 	case gc.SquadRetreat:
 		return sp.planEscortAction(world, entity, snap)
 	default:
-		return waitAction("隊員デフォルト待機")
+		return waitAction()
 	}
 }
 
 // planEscortAction はリーダーから2マス以内にとどまるアクションを計画する
-func (sp *squadPlanner) planEscortAction(world w.World, entity ecs.Entity, snap *squadSnapshot) activity.Behavior {
+func (sp *squadPlanner) planEscortAction(world w.World, entity ecs.Entity, snap *squadSnapshot) *gc.Activity {
 	dist := gridDistance(snap.Grid, snap.LeaderGrid)
 	if dist <= escortMaxDistance {
-		return waitAction("隊員護衛位置")
+		return waitAction()
 	}
 	if b, ok := sp.tryMoveToward(world, entity, snap.Grid, snap.LeaderGrid); ok {
 		return b
 	}
-	return waitAction("隊員護衛移動失敗")
+	return waitAction()
 }
 
 // planVanguardAction はリーダーの前方に展開するアクションを計画する。
 // リーダーから離れすぎている場合はリーダーに接近する
-func (sp *squadPlanner) planVanguardAction(world w.World, entity ecs.Entity, snap *squadSnapshot) activity.Behavior {
+func (sp *squadPlanner) planVanguardAction(world w.World, entity ecs.Entity, snap *squadSnapshot) *gc.Activity {
 	dist := gridDistance(snap.Grid, snap.LeaderGrid)
 	if dist > vanguardMaxDistance {
 		if b, ok := sp.tryMoveToward(world, entity, snap.Grid, snap.LeaderGrid); ok {
 			return b
 		}
-		return waitAction("隊員前衛接近失敗")
+		return waitAction()
 	}
 	if b, ok := sp.tryRandomMove(world, entity, snap); ok {
 		return b
 	}
-	return waitAction("隊員前衛移動失敗")
+	return waitAction()
 }
 
 // planSquadPatrolAction は探索済みエリア内を自律的に巡回するアクションを計画する
-func (sp *squadPlanner) planSquadPatrolAction(world w.World, entity ecs.Entity, snap *squadSnapshot) activity.Behavior {
+func (sp *squadPlanner) planSquadPatrolAction(world w.World, entity ecs.Entity, snap *squadSnapshot) *gc.Activity {
 	if b, ok := sp.tryRandomMove(world, entity, snap); ok {
 		return b
 	}
-	return waitAction("隊員巡回移動失敗")
+	return waitAction()
 }
 
 // planItemPickupAction は拾得可能アイテムを拾うアクションを計画する。
 // 足元にアイテムがあれば拾い、なければ視界内のアイテムに向かって移動する。
 // PolicyIgnoreの場合は何もしない
-func (sp *squadPlanner) planItemPickupAction(world w.World, entity ecs.Entity, snap *squadSnapshot) (activity.Behavior, bool) {
+func (sp *squadPlanner) planItemPickupAction(world w.World, entity ecs.Entity, snap *squadSnapshot) (*gc.Activity, bool) {
 	if snap.Squad.ItemPickup == gc.PolicyIgnore {
 		return nil, false
 	}
@@ -284,7 +284,7 @@ func (sp *squadPlanner) planItemPickupAction(world w.World, entity ecs.Entity, s
 	if hasPickableHere {
 		sp.logger.Debug("隊員アイテム拾得", "entity", entity, "x", snap.Grid.X, "y", snap.Grid.Y)
 		dest := *snap.Grid
-		return &activity.PickupBehavior{Destination: &dest}, true
+		return activity.NewPickupActivity(nil, &dest), true
 	}
 
 	if nearestItemGrid != nil {
@@ -298,7 +298,7 @@ func (sp *squadPlanner) planItemPickupAction(world w.World, entity ecs.Entity, s
 // planSupplyAction は空腹の隊員に補給行動を計画する。
 // まず自分の背嚢の食料を食べ、無ければ共有プールであるリーダーの所持品へ接近して受け取る。
 // 敵が視界内にいる間は発火しない
-func (sp *squadPlanner) planSupplyAction(world w.World, entity ecs.Entity, snap *squadSnapshot) (activity.Behavior, bool) {
+func (sp *squadPlanner) planSupplyAction(world w.World, entity ecs.Entity, snap *squadSnapshot) (*gc.Activity, bool) {
 	if snap.Squad.Supply != gc.SupplyAuto {
 		return nil, false
 	}
@@ -316,7 +316,7 @@ func (sp *squadPlanner) planSupplyAction(world w.World, entity ecs.Entity, snap 
 	// 自分の背嚢から食べる。栄養価の低いものを先に消費して高価値食料を温存する
 	if food, ok := findLowestNutritionFood(world, entity); ok {
 		sp.logger.Debug("隊員が食事する", "entity", entity)
-		return &activity.UseItemBehavior{Target: food}, true
+		return activity.NewUseItemActivity(food), true
 	}
 
 	// 共有プールから受け取る
@@ -329,7 +329,7 @@ func (sp *squadPlanner) planSupplyAction(world w.World, entity ecs.Entity, snap 
 	if gridDistance(snap.Grid, snap.LeaderGrid) <= 1 {
 		sp.logger.Debug("隊員が食料を受け取る", "entity", entity)
 		// 1食ぶんだけ引く。丸ごと受け取ると共有プールが一気に空になり、他の隊員が飢える
-		return &activity.TransferBehavior{Target: poolFood, Recipient: entity, Count: 1}, true
+		return activity.NewTransferActivity(poolFood, entity, 1), true
 	}
 	return sp.tryMoveToward(world, entity, snap.Grid, snap.LeaderGrid)
 }
@@ -358,7 +358,7 @@ func findLowestNutritionFood(world w.World, owner ecs.Entity) (ecs.Entity, bool)
 
 // planItemHandlingAction はバックパック内のアイテムをポリシーに基づいて処理する。
 // PolicyDistributeの場合はリーダーにアイテムを転送する
-func (sp *squadPlanner) planItemHandlingAction(world w.World, entity ecs.Entity, snap *squadSnapshot) (activity.Behavior, bool) {
+func (sp *squadPlanner) planItemHandlingAction(world w.World, entity ecs.Entity, snap *squadSnapshot) (*gc.Activity, bool) {
 	if snap.Squad.ItemHandling != gc.PolicyDistribute {
 		return nil, false
 	}
@@ -388,7 +388,7 @@ func (sp *squadPlanner) planItemHandlingAction(world w.World, entity ecs.Entity,
 	sp.logger.Debug("隊員アイテム転送", "entity", entity, "item", *itemToTransfer)
 	// 拾った物はスタックごとリーダーへ渡す。在庫数を指定してまとめて転送する
 	count := query.GetEntityCount(world, *itemToTransfer)
-	return &activity.TransferBehavior{Target: *itemToTransfer, Recipient: snap.LeaderEntity, Count: count}, true
+	return activity.NewTransferActivity(*itemToTransfer, snap.LeaderEntity, count), true
 }
 
 // findNearestEnemy は視界内の最も近い敵を探す
@@ -400,7 +400,7 @@ func (sp *squadPlanner) findNearestEnemy(world w.World, entity ecs.Entity, snap 
 }
 
 // tryMoveToward はBFSで壁を迂回した最短経路でターゲットに向かう移動を試みる
-func (sp *squadPlanner) tryMoveToward(world w.World, entity ecs.Entity, from, target *gc.GridElement) (activity.Behavior, bool) {
+func (sp *squadPlanner) tryMoveToward(world w.World, entity ecs.Entity, from, target *gc.GridElement) (*gc.Activity, bool) {
 	next, ok := activity.FindNextStep(world, entity, from.Coord, target.Coord)
 	if !ok {
 		return nil, false
@@ -414,13 +414,13 @@ func (sp *squadPlanner) tryMoveToward(world w.World, entity ecs.Entity, from, ta
 }
 
 // tryMoveAway はターゲットから離れる移動を試みる
-func (sp *squadPlanner) tryMoveAway(world w.World, entity ecs.Entity, from, threat *gc.GridElement) (activity.Behavior, bool) {
+func (sp *squadPlanner) tryMoveAway(world w.World, entity ecs.Entity, from, threat *gc.GridElement) (*gc.Activity, bool) {
 	candidates := calculateMoveCandidates(from.Sub(threat.Coord))
 	return tryMoveCandidates(world, entity, from, candidates)
 }
 
 // tryRandomMove は探索済みエリア内でランダム移動を試みる
-func (sp *squadPlanner) tryRandomMove(world w.World, entity ecs.Entity, snap *squadSnapshot) (activity.Behavior, bool) {
+func (sp *squadPlanner) tryRandomMove(world w.World, entity ecs.Entity, snap *squadSnapshot) (*gc.Activity, bool) {
 	field := query.GetCurrentStageField(world)
 	from := snap.Grid.Coord
 

--- a/internal/aiinput/planner_squad_advanced_test.go
+++ b/internal/aiinput/planner_squad_advanced_test.go
@@ -3,7 +3,6 @@ package aiinput
 import (
 	"testing"
 
-	"github.com/kijimaD/ruins/internal/activity"
 	gc "github.com/kijimaD/ruins/internal/components"
 	"github.com/kijimaD/ruins/internal/consts"
 	"github.com/kijimaD/ruins/internal/testutil"
@@ -108,7 +107,7 @@ func TestSquadPlanner_PlanRetreatAction(t *testing.T) {
 	b, ok := sp.planRetreatAction(world, member, snap)
 	require.True(t, ok, "リーダーに向かって後退できるべき")
 	require.NotNil(t, b)
-	assert.Equal(t, gc.BehaviorMove, b.Name())
+	assert.Equal(t, gc.BehaviorMove, b.BehaviorName)
 }
 
 func TestSquadPlanner_IsOutsideExploredArea(t *testing.T) {
@@ -147,7 +146,7 @@ func TestSquadPlanner_PlanReturnToExploredArea(t *testing.T) {
 
 	b, ok := sp.planReturnToExploredArea(world, member, snap)
 	require.True(t, ok, "リーダーに向かって移動できるべき")
-	assert.Equal(t, gc.BehaviorMove, b.Name())
+	assert.Equal(t, gc.BehaviorMove, b.BehaviorName)
 }
 
 func TestSquadPlanner_PlanAction(t *testing.T) {
@@ -181,9 +180,9 @@ func TestSquadPlanner_PlanAction(t *testing.T) {
 
 		b := sp.planAction(world, member, snap)
 		require.NotNil(t, b)
-		_, isAttack := b.(*activity.AttackBehavior)
+		isAttack := b.BehaviorName == gc.BehaviorAttack
 		assert.False(t, isAttack, "HP低下時は攻撃せず後退するべき")
-		assert.Equal(t, gc.BehaviorMove, b.Name())
+		assert.Equal(t, gc.BehaviorMove, b.BehaviorName)
 	})
 
 	t.Run("HP低下でも後退できなければ次の優先度に進む", func(t *testing.T) {
@@ -212,7 +211,7 @@ func TestSquadPlanner_PlanAction(t *testing.T) {
 
 		b := sp.planAction(world, member, snap)
 		require.NotNil(t, b)
-		assert.Equal(t, gc.BehaviorWait, b.Name(), "後退できなければ位置ポリシーの待機に落ちる")
+		assert.Equal(t, gc.BehaviorWait, b.BehaviorName, "後退できなければ位置ポリシーの待機に落ちる")
 	})
 
 	t.Run("エリア外なら戦闘より復帰を優先する", func(t *testing.T) {
@@ -241,9 +240,9 @@ func TestSquadPlanner_PlanAction(t *testing.T) {
 
 		b := sp.planAction(world, member, snap)
 		require.NotNil(t, b)
-		_, isAttack := b.(*activity.AttackBehavior)
+		isAttack := b.BehaviorName == gc.BehaviorAttack
 		assert.False(t, isAttack, "未探索エリアでは攻撃せずリーダーへ復帰するべき")
-		assert.Equal(t, gc.BehaviorMove, b.Name())
+		assert.Equal(t, gc.BehaviorMove, b.BehaviorName)
 	})
 
 	t.Run("何も優先条件がなければ位置ポリシーに委ねる", func(t *testing.T) {
@@ -271,7 +270,7 @@ func TestSquadPlanner_PlanAction(t *testing.T) {
 
 		b := sp.planAction(world, member, snap)
 		require.NotNil(t, b)
-		assert.Equal(t, gc.BehaviorWait, b.Name(), "護衛距離内では待機するべき")
+		assert.Equal(t, gc.BehaviorWait, b.BehaviorName, "護衛距離内では待機するべき")
 	})
 }
 
@@ -303,9 +302,8 @@ func TestSquadPlanner_PlanCombatAction(t *testing.T) {
 
 		b, ok := sp.planCombatAction(world, member, snap)
 		require.True(t, ok)
-		attack, ok := b.(*activity.AttackBehavior)
-		require.True(t, ok, "型が *activity.AttackBehavior であるべき")
-		assert.Equal(t, enemy, attack.Target)
+		assert.Equal(t, gc.BehaviorAttack, b.BehaviorName)
+		assert.Equal(t, enemy, *b.Target)
 	})
 
 	t.Run("CombatEvadeなら回避計画に委譲する", func(t *testing.T) {
@@ -333,7 +331,7 @@ func TestSquadPlanner_PlanCombatAction(t *testing.T) {
 
 		b, ok := sp.planCombatAction(world, member, snap)
 		require.True(t, ok)
-		assert.Equal(t, gc.BehaviorMove, b.Name())
+		assert.Equal(t, gc.BehaviorMove, b.BehaviorName)
 	})
 
 	t.Run("CombatIgnoreでは何もしない", func(t *testing.T) {
@@ -405,7 +403,7 @@ func TestSquadPlanner_PlanAttackAction(t *testing.T) {
 
 		b, ok := sp.planAttackAction(world, member, snap)
 		require.True(t, ok)
-		assert.Equal(t, gc.BehaviorMove, b.Name())
+		assert.Equal(t, gc.BehaviorMove, b.BehaviorName)
 	})
 }
 
@@ -459,9 +457,8 @@ func TestSquadPlanner_PlanEvadeAction(t *testing.T) {
 
 		b, ok := sp.planEvadeAction(world, member, snap)
 		require.True(t, ok)
-		move, ok := b.(*activity.MoveBehavior)
-		require.True(t, ok)
-		assert.Less(t, int(move.Destination.X), initialX, "敵から離れる方向に移動するべき")
+		assert.Equal(t, gc.BehaviorMove, b.BehaviorName)
+		assert.Less(t, int(b.Destination.X), initialX, "敵から離れる方向に移動するべき")
 	})
 }
 
@@ -528,7 +525,7 @@ func TestSquadPlanner_PlanEscortAction(t *testing.T) {
 		snap := &squadSnapshot{Grid: memberGrid, LeaderGrid: leaderGrid}
 
 		b := sp.planEscortAction(world, member, snap)
-		assert.Equal(t, gc.BehaviorWait, b.Name())
+		assert.Equal(t, gc.BehaviorWait, b.BehaviorName)
 	})
 
 	t.Run("離れていれば追従移動する", func(t *testing.T) {
@@ -548,7 +545,7 @@ func TestSquadPlanner_PlanEscortAction(t *testing.T) {
 		snap := &squadSnapshot{Grid: memberGrid, LeaderGrid: world.Components.GridElement.Get(leader)}
 
 		b := sp.planEscortAction(world, member, snap)
-		assert.Equal(t, gc.BehaviorMove, b.Name())
+		assert.Equal(t, gc.BehaviorMove, b.BehaviorName)
 	})
 
 	t.Run("離れていて移動もできなければ待機にフォールバックする", func(t *testing.T) {
@@ -568,7 +565,7 @@ func TestSquadPlanner_PlanEscortAction(t *testing.T) {
 		snap := &squadSnapshot{Grid: memberGrid, LeaderGrid: world.Components.GridElement.Get(leader)}
 
 		b := sp.planEscortAction(world, member, snap)
-		assert.Equal(t, gc.BehaviorWait, b.Name(), "壁に囲まれて移動できないときは待機する")
+		assert.Equal(t, gc.BehaviorWait, b.BehaviorName, "壁に囲まれて移動できないときは待機する")
 	})
 }
 
@@ -592,7 +589,7 @@ func TestSquadPlanner_PlanVanguardAction(t *testing.T) {
 		snap := &squadSnapshot{Grid: memberGrid, LeaderGrid: world.Components.GridElement.Get(leader)}
 
 		b := sp.planVanguardAction(world, member, snap)
-		assert.Equal(t, gc.BehaviorMove, b.Name())
+		assert.Equal(t, gc.BehaviorMove, b.BehaviorName)
 	})
 
 	t.Run("距離内でランダム移動できれば移動する", func(t *testing.T) {
@@ -610,7 +607,7 @@ func TestSquadPlanner_PlanVanguardAction(t *testing.T) {
 		snap := &squadSnapshot{Grid: memberGrid, Squad: &gc.SquadAI{}, LeaderGrid: world.Components.GridElement.Get(leader)}
 
 		b := sp.planVanguardAction(world, member, snap)
-		assert.Equal(t, gc.BehaviorMove, b.Name())
+		assert.Equal(t, gc.BehaviorMove, b.BehaviorName)
 	})
 
 	t.Run("距離内で移動先がなければ待機する", func(t *testing.T) {
@@ -627,7 +624,7 @@ func TestSquadPlanner_PlanVanguardAction(t *testing.T) {
 		snap := &squadSnapshot{Grid: memberGrid, Squad: &gc.SquadAI{}, LeaderGrid: world.Components.GridElement.Get(leader)}
 
 		b := sp.planVanguardAction(world, member, snap)
-		assert.Equal(t, gc.BehaviorWait, b.Name())
+		assert.Equal(t, gc.BehaviorWait, b.BehaviorName)
 	})
 }
 
@@ -648,7 +645,7 @@ func TestSquadPlanner_PlanSquadPatrolAction(t *testing.T) {
 		snap := &squadSnapshot{Grid: world.Components.GridElement.Get(member), Squad: &gc.SquadAI{}}
 
 		b := sp.planSquadPatrolAction(world, member, snap)
-		assert.Equal(t, gc.BehaviorMove, b.Name())
+		assert.Equal(t, gc.BehaviorMove, b.BehaviorName)
 	})
 
 	t.Run("移動先がなければ待機する", func(t *testing.T) {
@@ -663,7 +660,7 @@ func TestSquadPlanner_PlanSquadPatrolAction(t *testing.T) {
 		snap := &squadSnapshot{Grid: world.Components.GridElement.Get(member), Squad: &gc.SquadAI{}}
 
 		b := sp.planSquadPatrolAction(world, member, snap)
-		assert.Equal(t, gc.BehaviorWait, b.Name())
+		assert.Equal(t, gc.BehaviorWait, b.BehaviorName)
 	})
 }
 
@@ -743,7 +740,7 @@ func TestSquadPlanner_TryMoveToward(t *testing.T) {
 		sp := newSquadPlanner(newTestRNG())
 		b, ok := sp.tryMoveToward(world, member, memberGrid, target)
 		require.True(t, ok)
-		assert.Equal(t, gc.BehaviorMove, b.Name())
+		assert.Equal(t, gc.BehaviorMove, b.BehaviorName)
 	})
 
 	t.Run("既に目的地にいれば移動しない", func(t *testing.T) {
@@ -800,9 +797,8 @@ func TestSquadPlanner_TryMoveAway(t *testing.T) {
 	sp := newSquadPlanner(newTestRNG())
 	b, ok := sp.tryMoveAway(world, member, memberGrid, threat)
 	require.True(t, ok)
-	move, ok := b.(*activity.MoveBehavior)
-	require.True(t, ok)
-	assert.Less(t, int(move.Destination.X), int(memberGrid.X), "脅威から離れる方向に移動する")
+	assert.Equal(t, gc.BehaviorMove, b.BehaviorName)
+	assert.Less(t, int(b.Destination.X), int(memberGrid.X), "脅威から離れる方向に移動する")
 }
 
 func TestSquadPlanner_TryRandomMove(t *testing.T) {

--- a/internal/aiinput/planner_squad_advanced_test.go
+++ b/internal/aiinput/planner_squad_advanced_test.go
@@ -303,7 +303,7 @@ func TestSquadPlanner_PlanCombatAction(t *testing.T) {
 		b, ok := sp.planCombatAction(world, member, snap)
 		require.True(t, ok)
 		assert.Equal(t, gc.BehaviorAttack, b.BehaviorName)
-		assert.Equal(t, enemy, targetParams(t, b).Target)
+		assert.Equal(t, enemy, activityParams[*gc.AttackParams](t, b).Target)
 	})
 
 	t.Run("CombatEvadeなら回避計画に委譲する", func(t *testing.T) {
@@ -458,7 +458,7 @@ func TestSquadPlanner_PlanEvadeAction(t *testing.T) {
 		b, ok := sp.planEvadeAction(world, member, snap)
 		require.True(t, ok)
 		assert.Equal(t, gc.BehaviorMove, b.BehaviorName)
-		assert.Less(t, int(moveParams(t, b).Destination.X), initialX, "敵から離れる方向に移動するべき")
+		assert.Less(t, int(activityParams[*gc.MoveParams](t, b).Destination.X), initialX, "敵から離れる方向に移動するべき")
 	})
 }
 
@@ -798,7 +798,7 @@ func TestSquadPlanner_TryMoveAway(t *testing.T) {
 	b, ok := sp.tryMoveAway(world, member, memberGrid, threat)
 	require.True(t, ok)
 	assert.Equal(t, gc.BehaviorMove, b.BehaviorName)
-	assert.Less(t, int(moveParams(t, b).Destination.X), int(memberGrid.X), "脅威から離れる方向に移動する")
+	assert.Less(t, int(activityParams[*gc.MoveParams](t, b).Destination.X), int(memberGrid.X), "脅威から離れる方向に移動する")
 }
 
 func TestSquadPlanner_TryRandomMove(t *testing.T) {

--- a/internal/aiinput/planner_squad_advanced_test.go
+++ b/internal/aiinput/planner_squad_advanced_test.go
@@ -303,7 +303,7 @@ func TestSquadPlanner_PlanCombatAction(t *testing.T) {
 		b, ok := sp.planCombatAction(world, member, snap)
 		require.True(t, ok)
 		assert.Equal(t, gc.BehaviorAttack, b.BehaviorName)
-		assert.Equal(t, enemy, *b.Target)
+		assert.Equal(t, enemy, targetParams(t, b).Target)
 	})
 
 	t.Run("CombatEvadeなら回避計画に委譲する", func(t *testing.T) {
@@ -458,7 +458,7 @@ func TestSquadPlanner_PlanEvadeAction(t *testing.T) {
 		b, ok := sp.planEvadeAction(world, member, snap)
 		require.True(t, ok)
 		assert.Equal(t, gc.BehaviorMove, b.BehaviorName)
-		assert.Less(t, int(b.Destination.X), initialX, "敵から離れる方向に移動するべき")
+		assert.Less(t, int(moveParams(t, b).Destination.X), initialX, "敵から離れる方向に移動するべき")
 	})
 }
 
@@ -798,7 +798,7 @@ func TestSquadPlanner_TryMoveAway(t *testing.T) {
 	b, ok := sp.tryMoveAway(world, member, memberGrid, threat)
 	require.True(t, ok)
 	assert.Equal(t, gc.BehaviorMove, b.BehaviorName)
-	assert.Less(t, int(b.Destination.X), int(memberGrid.X), "脅威から離れる方向に移動する")
+	assert.Less(t, int(moveParams(t, b).Destination.X), int(memberGrid.X), "脅威から離れる方向に移動する")
 }
 
 func TestSquadPlanner_TryRandomMove(t *testing.T) {

--- a/internal/aiinput/planner_squad_test.go
+++ b/internal/aiinput/planner_squad_test.go
@@ -3,7 +3,6 @@ package aiinput
 import (
 	"testing"
 
-	"github.com/kijimaD/ruins/internal/activity"
 	gc "github.com/kijimaD/ruins/internal/components"
 	"github.com/kijimaD/ruins/internal/consts"
 	"github.com/kijimaD/ruins/internal/testutil"
@@ -116,10 +115,10 @@ func TestSquadPlanner_Plan(t *testing.T) {
 		b := sp.Plan(world, member)
 		require.NotNil(t, b, "デフォルトポリシーでは常に何らかの行動を返す")
 
-		switch b.(type) {
-		case *activity.WaitBehavior, *activity.MoveBehavior:
+		switch b.BehaviorName {
+		case gc.BehaviorWait, gc.BehaviorMove:
 		default:
-			require.Failf(t, "想定外の行動種別", "%T", b)
+			require.Failf(t, "想定外の行動種別", "%s", b.BehaviorName)
 		}
 	})
 }
@@ -192,9 +191,8 @@ func TestPlanRetreatAction(t *testing.T) {
 
 	b, ok := sp.planRetreatAction(world, member, snap)
 	require.True(t, ok)
-	move, ok := b.(*activity.MoveBehavior)
-	require.True(t, ok, "型が *activity.MoveBehavior であるべき")
-	newGrid := &gc.GridElement{Coord: move.Destination.Coord}
+	require.Equal(t, gc.BehaviorMove, b.BehaviorName)
+	newGrid := &gc.GridElement{Coord: b.Destination.Coord}
 	assert.Less(t, gridDistance(newGrid, snap.LeaderGrid), gridDistance(snap.Grid, snap.LeaderGrid), "リーダーに近づく")
 }
 
@@ -211,9 +209,8 @@ func TestPlanReturnToExploredArea(t *testing.T) {
 
 	b, ok := sp.planReturnToExploredArea(world, member, snap)
 	require.True(t, ok)
-	move, ok := b.(*activity.MoveBehavior)
-	require.True(t, ok, "型が *activity.MoveBehavior であるべき")
-	newGrid := &gc.GridElement{Coord: move.Destination.Coord}
+	require.Equal(t, gc.BehaviorMove, b.BehaviorName)
+	newGrid := &gc.GridElement{Coord: b.Destination.Coord}
 	assert.Less(t, gridDistance(newGrid, snap.LeaderGrid), gridDistance(snap.Grid, snap.LeaderGrid), "リーダーに近づく")
 }
 
@@ -265,9 +262,8 @@ func TestPlanAttackAction(t *testing.T) {
 
 		b, ok := sp.planAttackAction(world, member, snap)
 		require.True(t, ok)
-		attack, ok := b.(*activity.AttackBehavior)
-		require.True(t, ok, "型が *activity.AttackBehavior であるべき")
-		assert.Equal(t, enemy, attack.Target)
+		require.Equal(t, gc.BehaviorAttack, b.BehaviorName)
+		assert.Equal(t, enemy, *b.Target)
 	})
 
 	t.Run("視界内の離れた敵に接近する", func(t *testing.T) {
@@ -285,8 +281,7 @@ func TestPlanAttackAction(t *testing.T) {
 
 		b, ok := sp.planAttackAction(world, member, snap)
 		require.True(t, ok)
-		_, ok = b.(*activity.MoveBehavior)
-		assert.True(t, ok, "型が *activity.MoveBehavior であるべき")
+		assert.Equal(t, gc.BehaviorMove, b.BehaviorName, "型が Move であるべき")
 	})
 
 	t.Run("視界内に敵がいなければ何もしない", func(t *testing.T) {
@@ -325,10 +320,9 @@ func TestPlanEvadeAction(t *testing.T) {
 
 		b, ok := sp.planEvadeAction(world, member, snap)
 		require.True(t, ok)
-		move, ok := b.(*activity.MoveBehavior)
-		require.True(t, ok, "型が *activity.MoveBehavior であるべき")
+		require.Equal(t, gc.BehaviorMove, b.BehaviorName)
 
-		newGrid := &gc.GridElement{Coord: move.Destination.Coord}
+		newGrid := &gc.GridElement{Coord: b.Destination.Coord}
 		after := gridDistance(newGrid, world.Components.GridElement.Get(enemy))
 		assert.Greater(t, after, before, "敵から遠ざかる")
 	})
@@ -353,16 +347,15 @@ func TestPlanPositionAction(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name       string
-		movement   gc.SquadMovement
-		wantReason string
+		name     string
+		movement gc.SquadMovement
 	}{
-		{"護衛は近距離なら待機する", gc.SquadEscort, "隊員護衛位置"},
-		{"前衛は近距離かつ未探索なら移動失敗で待機する", gc.SquadVanguard, "隊員前衛移動失敗"},
-		{"巡回は未探索なら移動失敗で待機する", gc.SquadPatrol, "隊員巡回移動失敗"},
-		{"待機ポリシーは常に待機する", gc.SquadStationary, "隊員待機"},
-		{"退避は護衛と同じ挙動をする", gc.SquadRetreat, "隊員護衛位置"},
-		{"未対応ポリシーはデフォルト待機する", gc.SquadMovement(""), "隊員デフォルト待機"},
+		{"護衛は近距離なら待機する", gc.SquadEscort},
+		{"前衛は近距離かつ未探索なら移動失敗で待機する", gc.SquadVanguard},
+		{"巡回は未探索なら移動失敗で待機する", gc.SquadPatrol},
+		{"待機ポリシーは常に待機する", gc.SquadStationary},
+		{"退避は護衛と同じ挙動をする", gc.SquadRetreat},
+		{"未対応ポリシーはデフォルト待機する", gc.SquadMovement("")},
 	}
 
 	for _, tt := range tests {
@@ -379,9 +372,7 @@ func TestPlanPositionAction(t *testing.T) {
 			}
 
 			b := sp.planPositionAction(world, member, snap)
-			wait, ok := b.(*activity.WaitBehavior)
-			require.True(t, ok, "型が *activity.WaitBehavior であるべき")
-			assert.Equal(t, tt.wantReason, wait.Reason)
+			assert.Equal(t, gc.BehaviorWait, b.BehaviorName)
 		})
 	}
 }
@@ -401,9 +392,7 @@ func TestPlanEscortAction(t *testing.T) {
 		}
 
 		b := sp.planEscortAction(world, member, snap)
-		wait, ok := b.(*activity.WaitBehavior)
-		require.True(t, ok, "型が *activity.WaitBehavior であるべき")
-		assert.Equal(t, "隊員護衛位置", wait.Reason)
+		assert.Equal(t, gc.BehaviorWait, b.BehaviorName)
 	})
 
 	t.Run("護衛距離を超えたらリーダーに近づく", func(t *testing.T) {
@@ -418,9 +407,8 @@ func TestPlanEscortAction(t *testing.T) {
 		}
 
 		b := sp.planEscortAction(world, member, snap)
-		move, ok := b.(*activity.MoveBehavior)
-		require.True(t, ok, "型が *activity.MoveBehavior であるべき")
-		newGrid := &gc.GridElement{Coord: move.Destination.Coord}
+		require.Equal(t, gc.BehaviorMove, b.BehaviorName)
+		newGrid := &gc.GridElement{Coord: b.Destination.Coord}
 		assert.Less(t, gridDistance(newGrid, snap.LeaderGrid), gridDistance(snap.Grid, snap.LeaderGrid))
 	})
 }
@@ -440,9 +428,8 @@ func TestPlanVanguardAction(t *testing.T) {
 		}
 
 		b := sp.planVanguardAction(world, member, snap)
-		move, ok := b.(*activity.MoveBehavior)
-		require.True(t, ok, "型が *activity.MoveBehavior であるべき")
-		newGrid := &gc.GridElement{Coord: move.Destination.Coord}
+		require.Equal(t, gc.BehaviorMove, b.BehaviorName)
+		newGrid := &gc.GridElement{Coord: b.Destination.Coord}
 		assert.Less(t, gridDistance(newGrid, snap.LeaderGrid), gridDistance(snap.Grid, snap.LeaderGrid))
 	})
 
@@ -458,9 +445,7 @@ func TestPlanVanguardAction(t *testing.T) {
 		}
 
 		b := sp.planVanguardAction(world, member, snap)
-		wait, ok := b.(*activity.WaitBehavior)
-		require.True(t, ok, "型が *activity.WaitBehavior であるべき")
-		assert.Equal(t, "隊員前衛移動失敗", wait.Reason)
+		assert.Equal(t, gc.BehaviorWait, b.BehaviorName)
 	})
 
 	t.Run("前衛距離内かつ探索済みなら周辺を移動する", func(t *testing.T) {
@@ -478,11 +463,10 @@ func TestPlanVanguardAction(t *testing.T) {
 		}
 
 		b := sp.planVanguardAction(world, member, snap)
-		move, ok := b.(*activity.MoveBehavior)
-		require.True(t, ok, "型が *activity.MoveBehavior であるべき")
+		require.Equal(t, gc.BehaviorMove, b.BehaviorName)
 
 		field := query.GetCurrentStageField(world)
-		assert.True(t, field.ExploredTiles[move.Destination], "探索済みの隣接マスへ移動する")
+		assert.True(t, field.ExploredTiles[*b.Destination], "探索済みの隣接マスへ移動する")
 	})
 }
 
@@ -498,9 +482,7 @@ func TestPlanSquadPatrolAction(t *testing.T) {
 		snap := &squadSnapshot{Grid: world.Components.GridElement.Get(member)}
 
 		b := sp.planSquadPatrolAction(world, member, snap)
-		wait, ok := b.(*activity.WaitBehavior)
-		require.True(t, ok, "型が *activity.WaitBehavior であるべき")
-		assert.Equal(t, "隊員巡回移動失敗", wait.Reason)
+		assert.Equal(t, gc.BehaviorWait, b.BehaviorName)
 	})
 
 	t.Run("探索済みエリアなら周辺を移動する", func(t *testing.T) {
@@ -515,11 +497,10 @@ func TestPlanSquadPatrolAction(t *testing.T) {
 		snap := &squadSnapshot{Grid: grid}
 
 		b := sp.planSquadPatrolAction(world, member, snap)
-		move, ok := b.(*activity.MoveBehavior)
-		require.True(t, ok, "型が *activity.MoveBehavior であるべき")
+		require.Equal(t, gc.BehaviorMove, b.BehaviorName)
 
 		field := query.GetCurrentStageField(world)
-		assert.True(t, field.ExploredTiles[move.Destination], "探索済みの隣接マスへ移動する")
+		assert.True(t, field.ExploredTiles[*b.Destination], "探索済みの隣接マスへ移動する")
 	})
 }
 
@@ -537,9 +518,8 @@ func TestTryMoveToward(t *testing.T) {
 
 		b, ok := sp.tryMoveToward(world, member, from, target)
 		require.True(t, ok)
-		move, ok := b.(*activity.MoveBehavior)
-		require.True(t, ok, "型が *activity.MoveBehavior であるべき")
-		newGrid := &gc.GridElement{Coord: move.Destination.Coord}
+		require.Equal(t, gc.BehaviorMove, b.BehaviorName)
+		newGrid := &gc.GridElement{Coord: b.Destination.Coord}
 		assert.Less(t, gridDistance(newGrid, target), gridDistance(from, target))
 	})
 
@@ -568,8 +548,7 @@ func TestTryMoveAway(t *testing.T) {
 
 	b, ok := sp.tryMoveAway(world, member, from, threat)
 	require.True(t, ok)
-	move, ok := b.(*activity.MoveBehavior)
-	require.True(t, ok, "型が *activity.MoveBehavior であるべき")
-	newGrid := &gc.GridElement{Coord: move.Destination.Coord}
+	require.Equal(t, gc.BehaviorMove, b.BehaviorName)
+	newGrid := &gc.GridElement{Coord: b.Destination.Coord}
 	assert.Greater(t, gridDistance(newGrid, threat), gridDistance(from, threat))
 }

--- a/internal/aiinput/planner_squad_test.go
+++ b/internal/aiinput/planner_squad_test.go
@@ -192,7 +192,7 @@ func TestPlanRetreatAction(t *testing.T) {
 	b, ok := sp.planRetreatAction(world, member, snap)
 	require.True(t, ok)
 	require.Equal(t, gc.BehaviorMove, b.BehaviorName)
-	newGrid := &gc.GridElement{Coord: b.Destination.Coord}
+	newGrid := &gc.GridElement{Coord: moveParams(t, b).Destination.Coord}
 	assert.Less(t, gridDistance(newGrid, snap.LeaderGrid), gridDistance(snap.Grid, snap.LeaderGrid), "リーダーに近づく")
 }
 
@@ -210,7 +210,7 @@ func TestPlanReturnToExploredArea(t *testing.T) {
 	b, ok := sp.planReturnToExploredArea(world, member, snap)
 	require.True(t, ok)
 	require.Equal(t, gc.BehaviorMove, b.BehaviorName)
-	newGrid := &gc.GridElement{Coord: b.Destination.Coord}
+	newGrid := &gc.GridElement{Coord: moveParams(t, b).Destination.Coord}
 	assert.Less(t, gridDistance(newGrid, snap.LeaderGrid), gridDistance(snap.Grid, snap.LeaderGrid), "リーダーに近づく")
 }
 
@@ -263,7 +263,7 @@ func TestPlanAttackAction(t *testing.T) {
 		b, ok := sp.planAttackAction(world, member, snap)
 		require.True(t, ok)
 		require.Equal(t, gc.BehaviorAttack, b.BehaviorName)
-		assert.Equal(t, enemy, *b.Target)
+		assert.Equal(t, enemy, targetParams(t, b).Target)
 	})
 
 	t.Run("視界内の離れた敵に接近する", func(t *testing.T) {
@@ -322,7 +322,7 @@ func TestPlanEvadeAction(t *testing.T) {
 		require.True(t, ok)
 		require.Equal(t, gc.BehaviorMove, b.BehaviorName)
 
-		newGrid := &gc.GridElement{Coord: b.Destination.Coord}
+		newGrid := &gc.GridElement{Coord: moveParams(t, b).Destination.Coord}
 		after := gridDistance(newGrid, world.Components.GridElement.Get(enemy))
 		assert.Greater(t, after, before, "敵から遠ざかる")
 	})
@@ -408,7 +408,7 @@ func TestPlanEscortAction(t *testing.T) {
 
 		b := sp.planEscortAction(world, member, snap)
 		require.Equal(t, gc.BehaviorMove, b.BehaviorName)
-		newGrid := &gc.GridElement{Coord: b.Destination.Coord}
+		newGrid := &gc.GridElement{Coord: moveParams(t, b).Destination.Coord}
 		assert.Less(t, gridDistance(newGrid, snap.LeaderGrid), gridDistance(snap.Grid, snap.LeaderGrid))
 	})
 }
@@ -429,7 +429,7 @@ func TestPlanVanguardAction(t *testing.T) {
 
 		b := sp.planVanguardAction(world, member, snap)
 		require.Equal(t, gc.BehaviorMove, b.BehaviorName)
-		newGrid := &gc.GridElement{Coord: b.Destination.Coord}
+		newGrid := &gc.GridElement{Coord: moveParams(t, b).Destination.Coord}
 		assert.Less(t, gridDistance(newGrid, snap.LeaderGrid), gridDistance(snap.Grid, snap.LeaderGrid))
 	})
 
@@ -466,7 +466,7 @@ func TestPlanVanguardAction(t *testing.T) {
 		require.Equal(t, gc.BehaviorMove, b.BehaviorName)
 
 		field := query.GetCurrentStageField(world)
-		assert.True(t, field.ExploredTiles[*b.Destination], "探索済みの隣接マスへ移動する")
+		assert.True(t, field.ExploredTiles[moveParams(t, b).Destination], "探索済みの隣接マスへ移動する")
 	})
 }
 
@@ -500,7 +500,7 @@ func TestPlanSquadPatrolAction(t *testing.T) {
 		require.Equal(t, gc.BehaviorMove, b.BehaviorName)
 
 		field := query.GetCurrentStageField(world)
-		assert.True(t, field.ExploredTiles[*b.Destination], "探索済みの隣接マスへ移動する")
+		assert.True(t, field.ExploredTiles[moveParams(t, b).Destination], "探索済みの隣接マスへ移動する")
 	})
 }
 
@@ -519,7 +519,7 @@ func TestTryMoveToward(t *testing.T) {
 		b, ok := sp.tryMoveToward(world, member, from, target)
 		require.True(t, ok)
 		require.Equal(t, gc.BehaviorMove, b.BehaviorName)
-		newGrid := &gc.GridElement{Coord: b.Destination.Coord}
+		newGrid := &gc.GridElement{Coord: moveParams(t, b).Destination.Coord}
 		assert.Less(t, gridDistance(newGrid, target), gridDistance(from, target))
 	})
 
@@ -549,6 +549,6 @@ func TestTryMoveAway(t *testing.T) {
 	b, ok := sp.tryMoveAway(world, member, from, threat)
 	require.True(t, ok)
 	require.Equal(t, gc.BehaviorMove, b.BehaviorName)
-	newGrid := &gc.GridElement{Coord: b.Destination.Coord}
+	newGrid := &gc.GridElement{Coord: moveParams(t, b).Destination.Coord}
 	assert.Greater(t, gridDistance(newGrid, threat), gridDistance(from, threat))
 }

--- a/internal/aiinput/planner_squad_test.go
+++ b/internal/aiinput/planner_squad_test.go
@@ -192,7 +192,7 @@ func TestPlanRetreatAction(t *testing.T) {
 	b, ok := sp.planRetreatAction(world, member, snap)
 	require.True(t, ok)
 	require.Equal(t, gc.BehaviorMove, b.BehaviorName)
-	newGrid := &gc.GridElement{Coord: moveParams(t, b).Destination.Coord}
+	newGrid := &gc.GridElement{Coord: activityParams[*gc.MoveParams](t, b).Destination.Coord}
 	assert.Less(t, gridDistance(newGrid, snap.LeaderGrid), gridDistance(snap.Grid, snap.LeaderGrid), "リーダーに近づく")
 }
 
@@ -210,7 +210,7 @@ func TestPlanReturnToExploredArea(t *testing.T) {
 	b, ok := sp.planReturnToExploredArea(world, member, snap)
 	require.True(t, ok)
 	require.Equal(t, gc.BehaviorMove, b.BehaviorName)
-	newGrid := &gc.GridElement{Coord: moveParams(t, b).Destination.Coord}
+	newGrid := &gc.GridElement{Coord: activityParams[*gc.MoveParams](t, b).Destination.Coord}
 	assert.Less(t, gridDistance(newGrid, snap.LeaderGrid), gridDistance(snap.Grid, snap.LeaderGrid), "リーダーに近づく")
 }
 
@@ -263,7 +263,7 @@ func TestPlanAttackAction(t *testing.T) {
 		b, ok := sp.planAttackAction(world, member, snap)
 		require.True(t, ok)
 		require.Equal(t, gc.BehaviorAttack, b.BehaviorName)
-		assert.Equal(t, enemy, targetParams(t, b).Target)
+		assert.Equal(t, enemy, activityParams[*gc.AttackParams](t, b).Target)
 	})
 
 	t.Run("視界内の離れた敵に接近する", func(t *testing.T) {
@@ -322,7 +322,7 @@ func TestPlanEvadeAction(t *testing.T) {
 		require.True(t, ok)
 		require.Equal(t, gc.BehaviorMove, b.BehaviorName)
 
-		newGrid := &gc.GridElement{Coord: moveParams(t, b).Destination.Coord}
+		newGrid := &gc.GridElement{Coord: activityParams[*gc.MoveParams](t, b).Destination.Coord}
 		after := gridDistance(newGrid, world.Components.GridElement.Get(enemy))
 		assert.Greater(t, after, before, "敵から遠ざかる")
 	})
@@ -408,7 +408,7 @@ func TestPlanEscortAction(t *testing.T) {
 
 		b := sp.planEscortAction(world, member, snap)
 		require.Equal(t, gc.BehaviorMove, b.BehaviorName)
-		newGrid := &gc.GridElement{Coord: moveParams(t, b).Destination.Coord}
+		newGrid := &gc.GridElement{Coord: activityParams[*gc.MoveParams](t, b).Destination.Coord}
 		assert.Less(t, gridDistance(newGrid, snap.LeaderGrid), gridDistance(snap.Grid, snap.LeaderGrid))
 	})
 }
@@ -429,7 +429,7 @@ func TestPlanVanguardAction(t *testing.T) {
 
 		b := sp.planVanguardAction(world, member, snap)
 		require.Equal(t, gc.BehaviorMove, b.BehaviorName)
-		newGrid := &gc.GridElement{Coord: moveParams(t, b).Destination.Coord}
+		newGrid := &gc.GridElement{Coord: activityParams[*gc.MoveParams](t, b).Destination.Coord}
 		assert.Less(t, gridDistance(newGrid, snap.LeaderGrid), gridDistance(snap.Grid, snap.LeaderGrid))
 	})
 
@@ -466,7 +466,7 @@ func TestPlanVanguardAction(t *testing.T) {
 		require.Equal(t, gc.BehaviorMove, b.BehaviorName)
 
 		field := query.GetCurrentStageField(world)
-		assert.True(t, field.ExploredTiles[moveParams(t, b).Destination], "探索済みの隣接マスへ移動する")
+		assert.True(t, field.ExploredTiles[activityParams[*gc.MoveParams](t, b).Destination], "探索済みの隣接マスへ移動する")
 	})
 }
 
@@ -500,7 +500,7 @@ func TestPlanSquadPatrolAction(t *testing.T) {
 		require.Equal(t, gc.BehaviorMove, b.BehaviorName)
 
 		field := query.GetCurrentStageField(world)
-		assert.True(t, field.ExploredTiles[moveParams(t, b).Destination], "探索済みの隣接マスへ移動する")
+		assert.True(t, field.ExploredTiles[activityParams[*gc.MoveParams](t, b).Destination], "探索済みの隣接マスへ移動する")
 	})
 }
 
@@ -519,7 +519,7 @@ func TestTryMoveToward(t *testing.T) {
 		b, ok := sp.tryMoveToward(world, member, from, target)
 		require.True(t, ok)
 		require.Equal(t, gc.BehaviorMove, b.BehaviorName)
-		newGrid := &gc.GridElement{Coord: moveParams(t, b).Destination.Coord}
+		newGrid := &gc.GridElement{Coord: activityParams[*gc.MoveParams](t, b).Destination.Coord}
 		assert.Less(t, gridDistance(newGrid, target), gridDistance(from, target))
 	})
 
@@ -549,6 +549,6 @@ func TestTryMoveAway(t *testing.T) {
 	b, ok := sp.tryMoveAway(world, member, from, threat)
 	require.True(t, ok)
 	require.Equal(t, gc.BehaviorMove, b.BehaviorName)
-	newGrid := &gc.GridElement{Coord: moveParams(t, b).Destination.Coord}
+	newGrid := &gc.GridElement{Coord: activityParams[*gc.MoveParams](t, b).Destination.Coord}
 	assert.Greater(t, gridDistance(newGrid, threat), gridDistance(from, threat))
 }

--- a/internal/aiinput/squad_processor_test.go
+++ b/internal/aiinput/squad_processor_test.go
@@ -3,7 +3,6 @@ package aiinput
 import (
 	"testing"
 
-	"github.com/kijimaD/ruins/internal/activity"
 	gc "github.com/kijimaD/ruins/internal/components"
 	"github.com/kijimaD/ruins/internal/consts"
 	"github.com/kijimaD/ruins/internal/testutil"
@@ -259,9 +258,8 @@ func TestPlanItemHandlingAction(t *testing.T) {
 		b, ok := sp.planItemHandlingAction(world, member, snap)
 		assert.True(t, ok, "転送アクションが返る")
 		assert.NotNil(t, b)
-		transfer, ok := b.(*activity.TransferBehavior)
-		require.True(t, ok, "型が *activity.TransferBehavior であるべき")
-		assert.NotZero(t, transfer.Target)
+		require.Equal(t, gc.BehaviorTransfer, b.BehaviorName)
+		require.NotNil(t, b.Target)
 	})
 
 	t.Run("PolicyKeepではアイテムがあっても転送しない", func(t *testing.T) {

--- a/internal/aiinput/squad_processor_test.go
+++ b/internal/aiinput/squad_processor_test.go
@@ -259,7 +259,7 @@ func TestPlanItemHandlingAction(t *testing.T) {
 		assert.True(t, ok, "転送アクションが返る")
 		assert.NotNil(t, b)
 		require.Equal(t, gc.BehaviorTransfer, b.BehaviorName)
-		require.NotZero(t, transferParams(t, b).Target)
+		require.NotZero(t, activityParams[*gc.TransferParams](t, b).Target)
 	})
 
 	t.Run("PolicyKeepではアイテムがあっても転送しない", func(t *testing.T) {

--- a/internal/aiinput/squad_processor_test.go
+++ b/internal/aiinput/squad_processor_test.go
@@ -259,7 +259,7 @@ func TestPlanItemHandlingAction(t *testing.T) {
 		assert.True(t, ok, "転送アクションが返る")
 		assert.NotNil(t, b)
 		require.Equal(t, gc.BehaviorTransfer, b.BehaviorName)
-		require.NotNil(t, b.Target)
+		require.NotZero(t, transferParams(t, b).Target)
 	})
 
 	t.Run("PolicyKeepではアイテムがあっても転送しない", func(t *testing.T) {

--- a/internal/aiinput/supply_test.go
+++ b/internal/aiinput/supply_test.go
@@ -90,7 +90,7 @@ func TestPlanSupplyAction(t *testing.T) {
 		b, ok := sp.planSupplyAction(world, member, snap)
 		require.True(t, ok)
 		require.Equal(t, gc.BehaviorUseItem, b.BehaviorName, "自分の食料は食べるべき")
-		assert.Equal(t, food, *b.Target)
+		assert.Equal(t, food, targetParams(t, b).Target)
 	})
 
 	t.Run("栄養価の低い食料を先に消費する", func(t *testing.T) {
@@ -112,7 +112,7 @@ func TestPlanSupplyAction(t *testing.T) {
 		b, ok := sp.planSupplyAction(world, member, snap)
 		require.True(t, ok)
 		require.Equal(t, gc.BehaviorUseItem, b.BehaviorName)
-		got := world.Components.ProvidesNutrition.Get(*b.Target).Amount
+		got := world.Components.ProvidesNutrition.Get(targetParams(t, b).Target).Amount
 		assert.LessOrEqual(t, got, lowN, "最も栄養価の低い食料を選ぶべき")
 	})
 
@@ -127,9 +127,9 @@ func TestPlanSupplyAction(t *testing.T) {
 		b, ok := sp.planSupplyAction(world, member, snap)
 		require.True(t, ok)
 		require.Equal(t, gc.BehaviorTransfer, b.BehaviorName, "隣接なら受け取りになるべき")
-		assert.Equal(t, poolFood, *b.Target)
-		assert.Equal(t, member, *b.Recipient)
-		assert.Equal(t, 1, b.Count, "共有プールからは1食ぶんだけ受け取る")
+		assert.Equal(t, poolFood, transferParams(t, b).Target)
+		assert.Equal(t, member, transferParams(t, b).Recipient)
+		assert.Equal(t, 1, transferParams(t, b).Count, "共有プールからは1食ぶんだけ受け取る")
 	})
 
 	t.Run("リーダーが遠ければ接近する", func(t *testing.T) {

--- a/internal/aiinput/supply_test.go
+++ b/internal/aiinput/supply_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/kijimaD/ruins/internal/activity"
 	w "github.com/kijimaD/ruins/internal/world"
 	"github.com/mlange-42/ark/ecs"
 )
@@ -90,9 +89,8 @@ func TestPlanSupplyAction(t *testing.T) {
 		sp := newSquadPlanner(newTestRNG())
 		b, ok := sp.planSupplyAction(world, member, snap)
 		require.True(t, ok)
-		use, isUse := b.(*activity.UseItemBehavior)
-		require.True(t, isUse, "自分の食料は食べるべき")
-		assert.Equal(t, food, use.Target)
+		require.Equal(t, gc.BehaviorUseItem, b.BehaviorName, "自分の食料は食べるべき")
+		assert.Equal(t, food, *b.Target)
 	})
 
 	t.Run("栄養価の低い食料を先に消費する", func(t *testing.T) {
@@ -113,9 +111,8 @@ func TestPlanSupplyAction(t *testing.T) {
 		sp := newSquadPlanner(newTestRNG())
 		b, ok := sp.planSupplyAction(world, member, snap)
 		require.True(t, ok)
-		use, isUse := b.(*activity.UseItemBehavior)
-		require.True(t, isUse)
-		got := world.Components.ProvidesNutrition.Get(use.Target).Amount
+		require.Equal(t, gc.BehaviorUseItem, b.BehaviorName)
+		got := world.Components.ProvidesNutrition.Get(*b.Target).Amount
 		assert.LessOrEqual(t, got, lowN, "最も栄養価の低い食料を選ぶべき")
 	})
 
@@ -129,11 +126,10 @@ func TestPlanSupplyAction(t *testing.T) {
 		sp := newSquadPlanner(newTestRNG())
 		b, ok := sp.planSupplyAction(world, member, snap)
 		require.True(t, ok)
-		tr, isTransfer := b.(*activity.TransferBehavior)
-		require.True(t, isTransfer, "隣接なら受け取りになるべき")
-		assert.Equal(t, poolFood, tr.Target)
-		assert.Equal(t, member, tr.Recipient)
-		assert.Equal(t, 1, tr.Count, "共有プールからは1食ぶんだけ受け取る")
+		require.Equal(t, gc.BehaviorTransfer, b.BehaviorName, "隣接なら受け取りになるべき")
+		assert.Equal(t, poolFood, *b.Target)
+		assert.Equal(t, member, *b.Recipient)
+		assert.Equal(t, 1, b.Count, "共有プールからは1食ぶんだけ受け取る")
 	})
 
 	t.Run("リーダーが遠ければ接近する", func(t *testing.T) {
@@ -151,8 +147,8 @@ func TestPlanSupplyAction(t *testing.T) {
 		sp := newSquadPlanner(newTestRNG())
 		b, ok := sp.planSupplyAction(world, member, snap)
 		require.True(t, ok)
-		_, isUse := b.(*activity.UseItemBehavior)
-		_, isTransfer := b.(*activity.TransferBehavior)
+		isUse := b.BehaviorName == gc.BehaviorUseItem
+		isTransfer := b.BehaviorName == gc.BehaviorTransfer
 		assert.False(t, isUse || isTransfer, "遠距離では移動行動になるべき")
 	})
 

--- a/internal/aiinput/supply_test.go
+++ b/internal/aiinput/supply_test.go
@@ -90,7 +90,7 @@ func TestPlanSupplyAction(t *testing.T) {
 		b, ok := sp.planSupplyAction(world, member, snap)
 		require.True(t, ok)
 		require.Equal(t, gc.BehaviorUseItem, b.BehaviorName, "自分の食料は食べるべき")
-		assert.Equal(t, food, targetParams(t, b).Target)
+		assert.Equal(t, food, activityParams[*gc.UseItemParams](t, b).Target)
 	})
 
 	t.Run("栄養価の低い食料を先に消費する", func(t *testing.T) {
@@ -112,7 +112,7 @@ func TestPlanSupplyAction(t *testing.T) {
 		b, ok := sp.planSupplyAction(world, member, snap)
 		require.True(t, ok)
 		require.Equal(t, gc.BehaviorUseItem, b.BehaviorName)
-		got := world.Components.ProvidesNutrition.Get(targetParams(t, b).Target).Amount
+		got := world.Components.ProvidesNutrition.Get(activityParams[*gc.UseItemParams](t, b).Target).Amount
 		assert.LessOrEqual(t, got, lowN, "最も栄養価の低い食料を選ぶべき")
 	})
 
@@ -127,9 +127,9 @@ func TestPlanSupplyAction(t *testing.T) {
 		b, ok := sp.planSupplyAction(world, member, snap)
 		require.True(t, ok)
 		require.Equal(t, gc.BehaviorTransfer, b.BehaviorName, "隣接なら受け取りになるべき")
-		assert.Equal(t, poolFood, transferParams(t, b).Target)
-		assert.Equal(t, member, transferParams(t, b).Recipient)
-		assert.Equal(t, 1, transferParams(t, b).Count, "共有プールからは1食ぶんだけ受け取る")
+		assert.Equal(t, poolFood, activityParams[*gc.TransferParams](t, b).Target)
+		assert.Equal(t, member, activityParams[*gc.TransferParams](t, b).Recipient)
+		assert.Equal(t, 1, activityParams[*gc.TransferParams](t, b).Count, "共有プールからは1食ぶんだけ受け取る")
 	})
 
 	t.Run("リーダーが遠ければ接近する", func(t *testing.T) {

--- a/internal/components/activity.go
+++ b/internal/components/activity.go
@@ -149,13 +149,22 @@ type DisassembleParams struct {
 
 func (*DisassembleParams) isActivityParams() {}
 
-// PlaceParams は対象と操作先を取るアクションのパラメータ。拾得・ドロップ・押し引きが使う。
+// PlaceParams は対象と操作先を取るアクションのパラメータ。ドロップ・押し引きが使う。
 type PlaceParams struct {
 	Target      ecs.Entity  // 操作対象のエンティティ
 	Destination GridElement // 操作先タイル
 }
 
 func (*PlaceParams) isActivityParams() {}
+
+// PickupParams は拾得アクションのパラメータ。拾う対象は呼び出し側が確定して渡す。
+// 単一のアイテムでも足元一掃でも、拾うエンティティの並びを Targets として同じ形で持つ。
+// タイル上の何を拾うかという決定は behavior でなく構築側にあり、標識に頼らない。
+type PickupParams struct {
+	Targets []ecs.Entity // 拾うエンティティ。空なら検証で弾く
+}
+
+func (*PickupParams) isActivityParams() {}
 
 // TransferParams はアイテム転送のパラメータ。Count が0以下なら在庫全量を渡す。
 type TransferParams struct {

--- a/internal/components/activity.go
+++ b/internal/components/activity.go
@@ -67,15 +67,52 @@ const (
 // Activity は実行中のアクティビティを保持するコンポーネント
 // 1エンティティにつき最大1つのアクティビティを持つ
 type Activity struct {
-	BehaviorName BehaviorName  // アクティビティの種類
-	State        ActivityState // 実行状態
-	Progress     IntPool       // Max=完了に必要な総量、Current=注ぎ込んだ総量。Current>=Max で完了。初回ステップで満ちれば即時アクションになる
-	Target       *ecs.Entity   // 操作対象のエンティティ
-	Recipient    *ecs.Entity   // 受取人エンティティ。アイテム転送の転送先など
-	Destination  *GridElement  // 操作先のタイル座標。何もない位置に配置するなどに使う
-	Count        int           // 個数パラメータ。アイテム転送で渡す個数など。0は全量を意味する
-	CancelReason string        // キャンセル理由
+	BehaviorName BehaviorName   // アクティビティの種類
+	State        ActivityState  // 実行状態
+	Progress     IntPool        // Max=完了に必要な総量、Current=注ぎ込んだ総量。Current>=Max で完了。初回ステップで満ちれば即時アクションになる
+	Params       ActivityParams // 各アクティビティ固有のパラメータ。無いアクションは nil
+	CancelReason string         // キャンセル理由
 }
+
+// ActivityParams は各アクティビティ固有のパラメータを表すマーカーインターフェース。
+// Activity は serde の skip 対象なので、interface を保持しても保存互換に影響しない。
+// VisualEffect と同じく、依存の無いデータだけを components 層の interface として持つ。
+// 実行ロジックを持つ Behavior は w.World に依存するため activity 層に置く。
+type ActivityParams interface {
+	isActivityParams()
+}
+
+// MoveParams は移動アクションのパラメータ。
+type MoveParams struct {
+	Destination GridElement // 移動先タイル
+}
+
+func (*MoveParams) isActivityParams() {}
+
+// TargetParams は単一の対象エンティティを取るアクションのパラメータ。
+// 攻撃・会話・扉開閉・射撃・アイテム使用・読書・分解などが使う。
+type TargetParams struct {
+	Target ecs.Entity // 操作対象のエンティティ
+}
+
+func (*TargetParams) isActivityParams() {}
+
+// PlaceParams は対象と操作先を取るアクションのパラメータ。拾得・ドロップ・押し引きが使う。
+type PlaceParams struct {
+	Target      ecs.Entity  // 操作対象のエンティティ
+	Destination GridElement // 操作先タイル
+}
+
+func (*PlaceParams) isActivityParams() {}
+
+// TransferParams はアイテム転送のパラメータ。Count が0以下なら在庫全量を渡す。
+type TransferParams struct {
+	Target    ecs.Entity // 渡すアイテム
+	Recipient ecs.Entity // 受取人エンティティ
+	Count     int        // 渡す個数。0以下は全量
+}
+
+func (*TransferParams) isActivityParams() {}
 
 // LastActivity は直近のアクティビティ実行結果を保持するコンポーネント
 type LastActivity struct {

--- a/internal/components/activity.go
+++ b/internal/components/activity.go
@@ -69,7 +69,7 @@ const (
 type Activity struct {
 	BehaviorName BehaviorName  // アクティビティの種類
 	State        ActivityState // 実行状態
-	Required     int           // 完了に必要な総量。AP や工数の単位。即時アクションは 0
+	Required     int           // 完了に必要な総量。AP や工数の単位。初回ステップで完了すれば即時アクションになる
 	Accumulated  int           // 注ぎ込んだ総量。Required に達したら完了
 	Target       *ecs.Entity   // 操作対象のエンティティ
 	Recipient    *ecs.Entity   // 受取人エンティティ。アイテム転送の転送先など

--- a/internal/components/activity.go
+++ b/internal/components/activity.go
@@ -69,8 +69,7 @@ const (
 type Activity struct {
 	BehaviorName BehaviorName  // アクティビティの種類
 	State        ActivityState // 実行状態
-	Required     int           // 完了に必要な総量。AP や工数の単位。初回ステップで完了すれば即時アクションになる
-	Accumulated  int           // 注ぎ込んだ総量。Required に達したら完了
+	Progress     IntPool       // Max=完了に必要な総量、Current=注ぎ込んだ総量。Current>=Max で完了。初回ステップで満ちれば即時アクションになる
 	Target       *ecs.Entity   // 操作対象のエンティティ
 	Recipient    *ecs.Entity   // 受取人エンティティ。アイテム転送の転送先など
 	Destination  *GridElement  // 操作先のタイル座標。何もない位置に配置するなどに使う

--- a/internal/components/activity.go
+++ b/internal/components/activity.go
@@ -89,13 +89,65 @@ type MoveParams struct {
 
 func (*MoveParams) isActivityParams() {}
 
-// TargetParams は単一の対象エンティティを取るアクションのパラメータ。
-// 攻撃・会話・扉開閉・射撃・アイテム使用・読書・分解などが使う。
-type TargetParams struct {
-	Target ecs.Entity // 操作対象のエンティティ
+// 単一の対象エンティティを取るアクションは behavior ごとに専用の Params 型を持つ。
+// 対象の意味が behavior ごとに違うため、共有せず型で区別する。共有ヘルパを介さないので
+// 分割してもコード共有を壊さない。
+
+// AttackParams は近接攻撃のパラメータ。
+type AttackParams struct {
+	Target ecs.Entity // 攻撃対象のエンティティ
 }
 
-func (*TargetParams) isActivityParams() {}
+func (*AttackParams) isActivityParams() {}
+
+// TalkParams は会話のパラメータ。
+type TalkParams struct {
+	Target ecs.Entity // 会話相手のエンティティ
+}
+
+func (*TalkParams) isActivityParams() {}
+
+// OpenDoorParams は扉を開くアクションのパラメータ。
+type OpenDoorParams struct {
+	Target ecs.Entity // 開く扉のエンティティ
+}
+
+func (*OpenDoorParams) isActivityParams() {}
+
+// CloseDoorParams は扉を閉じるアクションのパラメータ。
+type CloseDoorParams struct {
+	Target ecs.Entity // 閉じる扉のエンティティ
+}
+
+func (*CloseDoorParams) isActivityParams() {}
+
+// ShootParams は射撃のパラメータ。
+type ShootParams struct {
+	Target ecs.Entity // 射撃対象のエンティティ
+}
+
+func (*ShootParams) isActivityParams() {}
+
+// UseItemParams はアイテム使用のパラメータ。
+type UseItemParams struct {
+	Target ecs.Entity // 使用するアイテムのエンティティ
+}
+
+func (*UseItemParams) isActivityParams() {}
+
+// ReadParams は読書のパラメータ。
+type ReadParams struct {
+	Target ecs.Entity // 読む本のエンティティ
+}
+
+func (*ReadParams) isActivityParams() {}
+
+// DisassembleParams は分解のパラメータ。
+type DisassembleParams struct {
+	Target ecs.Entity // 分解するアイテムのエンティティ
+}
+
+func (*DisassembleParams) isActivityParams() {}
 
 // PlaceParams は対象と操作先を取るアクションのパラメータ。拾得・ドロップ・押し引きが使う。
 type PlaceParams struct {

--- a/internal/components/activity.go
+++ b/internal/components/activity.go
@@ -72,6 +72,7 @@ type Activity struct {
 	State        ActivityState // 実行状態
 	TurnsTotal   consts.Turn   // 総必要ターン数
 	TurnsLeft    consts.Turn   // 残りターン数
+	Accumulated  int           // 継続アクションの累積量。装填工数などターン数では表せない進捗を持つ Behavior が使う
 	Target       *ecs.Entity   // 操作対象のエンティティ
 	Recipient    *ecs.Entity   // 受取人エンティティ。アイテム転送の転送先など
 	Destination  *GridElement  // 操作先のタイル座標。何もない位置に配置するなどに使う

--- a/internal/components/activity.go
+++ b/internal/components/activity.go
@@ -73,6 +73,7 @@ type Activity struct {
 	Target       *ecs.Entity   // 操作対象のエンティティ
 	Recipient    *ecs.Entity   // 受取人エンティティ。アイテム転送の転送先など
 	Destination  *GridElement  // 操作先のタイル座標。何もない位置に配置するなどに使う
+	Count        int           // 個数パラメータ。アイテム転送で渡す個数など。0は全量を意味する
 	CancelReason string        // キャンセル理由
 }
 

--- a/internal/components/activity.go
+++ b/internal/components/activity.go
@@ -1,7 +1,6 @@
 package components
 
 import (
-	"github.com/kijimaD/ruins/internal/consts"
 	"github.com/mlange-42/ark/ecs"
 )
 
@@ -70,9 +69,8 @@ const (
 type Activity struct {
 	BehaviorName BehaviorName  // アクティビティの種類
 	State        ActivityState // 実行状態
-	TurnsTotal   consts.Turn   // 総必要ターン数
-	TurnsLeft    consts.Turn   // 残りターン数
-	Accumulated  int           // 継続アクションの累積量。装填工数などターン数では表せない進捗を持つ Behavior が使う
+	Required     int           // 完了に必要な総量。AP や工数の単位。即時アクションは 0
+	Accumulated  int           // 注ぎ込んだ総量。Required に達したら完了
 	Target       *ecs.Entity   // 操作対象のエンティティ
 	Recipient    *ecs.Entity   // 受取人エンティティ。アイテム転送の転送先など
 	Destination  *GridElement  // 操作先のタイル座標。何もない位置に配置するなどに使う

--- a/internal/components/activity.go
+++ b/internal/components/activity.go
@@ -78,6 +78,10 @@ type Activity struct {
 // Activity は serde の skip 対象なので、interface を保持しても保存互換に影響しない。
 // VisualEffect と同じく、依存の無いデータだけを components 層の interface として持つ。
 // 実行ロジックを持つ Behavior は w.World に依存するため activity 層に置く。
+//
+// 型の分け方: 対象が1エンティティでも意味が behavior ごとに違うものは共有せず専用型に分ける。
+// 攻撃対象と会話相手と分解対象は同じ ecs.Entity だが意味が違うので AttackParams などに分ける。
+// 一方 PlaceParams のように共有ヘルパを介して同じ形を使い回すものは共有型のままにする。
 type ActivityParams interface {
 	isActivityParams()
 }
@@ -88,10 +92,6 @@ type MoveParams struct {
 }
 
 func (*MoveParams) isActivityParams() {}
-
-// 単一の対象エンティティを取るアクションは behavior ごとに専用の Params 型を持つ。
-// 対象の意味が behavior ごとに違うため、共有せず型で区別する。共有ヘルパを介さないので
-// 分割してもコード共有を壊さない。
 
 // AttackParams は近接攻撃のパラメータ。
 type AttackParams struct {

--- a/internal/states/inventory_menu.go
+++ b/internal/states/inventory_menu.go
@@ -574,13 +574,8 @@ func (st *InventoryMenuState) executeActionItem(world w.World) error {
 			return err
 		}
 
-		// Durationは上限見積もり。実際の完了はDoTurn内のIsCompletedで判定する
-		book := world.Components.Book.Get(entity)
-		remaining := book.Effort.Max - book.Effort.Current
-		if remaining <= 0 {
-			remaining = 1
-		}
-		_, err = activity.Execute(&activity.ReadBehavior{Target: entity, Duration: consts.Turn(remaining)}, playerEntity, world)
+		// 読書の進捗は本の Effort に保持され、読了は DoTurn 内で判定する
+		_, err = activity.Execute(&activity.ReadBehavior{Target: entity}, playerEntity, world)
 		if err != nil {
 			st.subState = invSubStateMenu
 			return err

--- a/internal/states/inventory_menu.go
+++ b/internal/states/inventory_menu.go
@@ -560,7 +560,7 @@ func (st *InventoryMenuState) executeActionItem(world w.World) error {
 			return err
 		}
 
-		_, err = activity.Execute(&activity.UseItemBehavior{Target: entity}, playerEntity, world)
+		_, err = activity.Execute(activity.NewUseItemActivity(entity), playerEntity, world)
 		if err != nil {
 			st.subState = invSubStateMenu
 			return err
@@ -575,7 +575,12 @@ func (st *InventoryMenuState) executeActionItem(world w.World) error {
 		}
 
 		// 読書の進捗は本の Effort に保持され、読了は DoTurn 内で判定する
-		_, err = activity.Execute(&activity.ReadBehavior{Target: entity}, playerEntity, world)
+		comp, err := activity.NewReadActivity(entity, world)
+		if err != nil {
+			st.subState = invSubStateMenu
+			return err
+		}
+		_, err = activity.Execute(comp, playerEntity, world)
 		if err != nil {
 			st.subState = invSubStateMenu
 			return err
@@ -589,7 +594,12 @@ func (st *InventoryMenuState) executeActionItem(world w.World) error {
 			return err
 		}
 
-		_, err = activity.Execute(&activity.DisassembleBehavior{Target: entity}, playerEntity, world)
+		comp, err := activity.NewDisassembleActivity(entity, playerEntity, world)
+		if err != nil {
+			st.subState = invSubStateMenu
+			return err
+		}
+		_, err = activity.Execute(comp, playerEntity, world)
 		if err != nil {
 			st.subState = invSubStateMenu
 			return err
@@ -605,7 +615,7 @@ func (st *InventoryMenuState) executeActionItem(world w.World) error {
 
 		playerGrid := world.Components.GridElement.Get(playerEntity)
 		destination := gc.GridElement{Coord: playerGrid.Coord}
-		_, err = activity.Execute(&activity.DropBehavior{Target: entity, Destination: destination}, playerEntity, world)
+		_, err = activity.Execute(activity.NewDropActivity(entity, destination), playerEntity, world)
 		if err != nil {
 			st.subState = invSubStateMenu
 			return err

--- a/internal/states/pickup_state.go
+++ b/internal/states/pickup_state.go
@@ -136,12 +136,7 @@ func (st *PickupState) doAction(world w.World, action inputmapper.ActionID) (es.
 
 // refreshItems はカーソル位置のタイル上の拾得可能エンティティを更新する
 func (st *PickupState) refreshItems(world w.World) {
-	st.itemsAtTarget = nil
-	for _, entity := range query.GetEntitiesAt(world, st.cursor.X, st.cursor.Y) {
-		if query.IsPickable(entity, world) {
-			st.itemsAtTarget = append(st.itemsAtTarget, entity)
-		}
-	}
+	st.itemsAtTarget = query.PickablesAt(world, consts.Coord[consts.Tile]{X: st.cursor.X, Y: st.cursor.Y})
 }
 
 // executePickup は拾得アクションを実行する

--- a/internal/states/pickup_state.go
+++ b/internal/states/pickup_state.go
@@ -9,7 +9,6 @@ import (
 	"github.com/hajimehoshi/ebiten/v2"
 	"github.com/hajimehoshi/ebiten/v2/text/v2"
 	"github.com/kijimaD/ruins/internal/activity"
-	gc "github.com/kijimaD/ruins/internal/components"
 	"github.com/kijimaD/ruins/internal/consts"
 	es "github.com/kijimaD/ruins/internal/engine/states"
 	"github.com/kijimaD/ruins/internal/geometry"
@@ -152,7 +151,7 @@ func (st *PickupState) executePickup(world w.World) error {
 		return err
 	}
 
-	_, err = activity.Execute(activity.NewPickupActivity(nil, &gc.GridElement{Coord: consts.Coord[consts.Tile]{X: st.cursor.X, Y: st.cursor.Y}}), playerEntity, world)
+	_, err = activity.Execute(activity.NewPickupTileActivity(world, consts.Coord[consts.Tile]{X: st.cursor.X, Y: st.cursor.Y}), playerEntity, world)
 	return err
 }
 

--- a/internal/states/pickup_state.go
+++ b/internal/states/pickup_state.go
@@ -152,7 +152,7 @@ func (st *PickupState) executePickup(world w.World) error {
 		return err
 	}
 
-	_, err = activity.Execute(&activity.PickupBehavior{Destination: &gc.GridElement{Coord: consts.Coord[consts.Tile]{X: st.cursor.X, Y: st.cursor.Y}}}, playerEntity, world)
+	_, err = activity.Execute(activity.NewPickupActivity(nil, &gc.GridElement{Coord: consts.Coord[consts.Tile]{X: st.cursor.X, Y: st.cursor.Y}}), playerEntity, world)
 	return err
 }
 

--- a/internal/states/place_state.go
+++ b/internal/states/place_state.go
@@ -202,7 +202,7 @@ func (st *PlaceState) executeDrop(world w.World) error {
 
 	item := st.backpackItems[st.selectedIndex]
 	destination := gc.GridElement{Coord: consts.Coord[consts.Tile]{X: st.cursor.X, Y: st.cursor.Y}}
-	_, err = activity.Execute(&activity.DropBehavior{Target: item, Destination: destination}, playerEntity, world)
+	_, err = activity.Execute(activity.NewDropActivity(item, destination), playerEntity, world)
 	return err
 }
 

--- a/internal/states/stage_binding_test.go
+++ b/internal/states/stage_binding_test.go
@@ -36,10 +36,8 @@ func TestPlacedItemBindsToCurrentStage(t *testing.T) {
 	// バックパックのアイテムを実際の設置経路 DropBehavior で足元へ置く
 	item, err := lifecycle.SpawnBackpackItem(world, "木刀", 1)
 	require.NoError(t, err)
-	_, err = activity.Execute(&activity.DropBehavior{
-		Target:      item,
-		Destination: gc.GridElement{Coord: consts.Coord[consts.Tile]{X: 6, Y: 6}},
-	}, player, world)
+	dropComp := activity.NewDropActivity(item, gc.GridElement{Coord: consts.Coord[consts.Tile]{X: 6, Y: 6}})
+	_, err = activity.Execute(dropComp, player, world)
 	require.NoError(t, err)
 
 	// 置いた直後にフィールド座標を持ち、その場で現ステージAへ束縛される

--- a/internal/systems/dead_cleanup_test.go
+++ b/internal/systems/dead_cleanup_test.go
@@ -229,8 +229,7 @@ func TestDeadCleanupSystem_CancelsActivity(t *testing.T) {
 	world.Components.Name.Add(enemy, &gc.Name{Name: "テスト敵"})
 	world.Components.Dead.Add(enemy, &gc.Dead{})
 
-	aa := &activity.AttackBehavior{}
-	comp, err := activity.NewActivity(aa, 1)
+	comp, err := activity.NewActivity(gc.BehaviorAttack, 1)
 	require.NoError(t, err)
 	comp.State = gc.ActivityStateRunning
 	world.Components.Activity.Add(enemy, comp)

--- a/internal/systems/dead_cleanup_test.go
+++ b/internal/systems/dead_cleanup_test.go
@@ -229,8 +229,7 @@ func TestDeadCleanupSystem_CancelsActivity(t *testing.T) {
 	world.Components.Name.Add(enemy, &gc.Name{Name: "テスト敵"})
 	world.Components.Dead.Add(enemy, &gc.Dead{})
 
-	comp, err := activity.NewActivity(gc.BehaviorAttack, 1)
-	require.NoError(t, err)
+	comp := activity.NewActivity(gc.BehaviorAttack, 1)
 	comp.State = gc.ActivityStateRunning
 	world.Components.Activity.Add(enemy, comp)
 

--- a/internal/systems/disassemble_coordination_test.go
+++ b/internal/systems/disassemble_coordination_test.go
@@ -64,7 +64,9 @@ func TestTurnSystem_分解を完走してもAPが枯渇しない(t *testing.T) {
 	crate, err := lifecycle.SpawnProp(world, "crate", 6, 5)
 	require.NoError(t, err)
 
-	result, err := activity.Execute(&activity.DisassembleBehavior{Target: crate}, player, world)
+	disComp, err := activity.NewDisassembleActivity(crate, player, world)
+	require.NoError(t, err)
+	result, err := activity.Execute(disComp, player, world)
 	require.NoError(t, err)
 	require.True(t, result.Success)
 
@@ -105,7 +107,9 @@ func TestTurnSystem_分解中も隊員がターンごとに行動する(t *testi
 	crate, err := lifecycle.SpawnProp(world, "crate", 6, 5)
 	require.NoError(t, err)
 
-	_, err = activity.Execute(&activity.DisassembleBehavior{Target: crate}, player, world)
+	disComp, err := activity.NewDisassembleActivity(crate, player, world)
+	require.NoError(t, err)
+	_, err = activity.Execute(disComp, player, world)
 	require.NoError(t, err)
 
 	turnState := query.GetTurnState(world)
@@ -142,7 +146,9 @@ func TestTurnSystem_隊員が分解産出を拾いに来る(t *testing.T) {
 	crate, err := lifecycle.SpawnProp(world, "crate", 6, 5)
 	require.NoError(t, err)
 
-	_, err = activity.Execute(&activity.DisassembleBehavior{Target: crate}, player, world)
+	disComp, err := activity.NewDisassembleActivity(crate, player, world)
+	require.NoError(t, err)
+	_, err = activity.Execute(disComp, player, world)
 	require.NoError(t, err)
 
 	turnState := query.GetTurnState(world)

--- a/internal/systems/turn_system_test.go
+++ b/internal/systems/turn_system_test.go
@@ -52,7 +52,7 @@ func TestTurnSystem_Update(t *testing.T) {
 		world.Components.Activity.Add(player, &gc.Activity{
 			BehaviorName: gc.BehaviorWait,
 			State:        gc.ActivityStateRunning,
-			Required:     5,
+			Progress:     gc.IntPool{Max: 5},
 		})
 
 		turnState := query.GetTurnState(world)

--- a/internal/systems/turn_system_test.go
+++ b/internal/systems/turn_system_test.go
@@ -52,8 +52,7 @@ func TestTurnSystem_Update(t *testing.T) {
 		world.Components.Activity.Add(player, &gc.Activity{
 			BehaviorName: gc.BehaviorWait,
 			State:        gc.ActivityStateRunning,
-			TurnsTotal:   5,
-			TurnsLeft:    5,
+			Required:     5,
 		})
 
 		turnState := query.GetTurnState(world)

--- a/internal/world/query/activity_test.go
+++ b/internal/world/query/activity_test.go
@@ -29,8 +29,7 @@ func TestGetActivity(t *testing.T) {
 		activity := &gc.Activity{
 			BehaviorName: gc.BehaviorWait,
 			State:        gc.ActivityStateRunning,
-			TurnsTotal:   5,
-			TurnsLeft:    5,
+			Required:     5,
 		}
 		world.Components.Activity.Add(entity, activity)
 

--- a/internal/world/query/activity_test.go
+++ b/internal/world/query/activity_test.go
@@ -29,7 +29,7 @@ func TestGetActivity(t *testing.T) {
 		activity := &gc.Activity{
 			BehaviorName: gc.BehaviorWait,
 			State:        gc.ActivityStateRunning,
-			Required:     5,
+			Progress:     gc.IntPool{Max: 5},
 		}
 		world.Components.Activity.Add(entity, activity)
 

--- a/internal/world/query/query.go
+++ b/internal/world/query/query.go
@@ -59,15 +59,10 @@ func IsPickable(entity ecs.Entity, world w.World) bool {
 
 // PickablesAt は指定タイル上の拾得可能なエンティティを返す。拾得アクションの構築側が
 // 「どのタイルを拾うか」から「どのエンティティを拾うか」へ解決するのに使う。
+// タイル上のエンティティ列挙は空間索引を引く GetEntitiesAt に任せる。
 func PickablesAt(world w.World, tile consts.Coord[consts.Tile]) []ecs.Entity {
 	var result []ecs.Entity
-	q := ActiveFilter1[gc.GridElement](world).Query()
-	for q.Next() {
-		entity := q.Entity()
-		grid := world.Components.GridElement.Get(entity)
-		if grid.X != tile.X || grid.Y != tile.Y {
-			continue
-		}
+	for _, entity := range GetEntitiesAt(world, tile.X, tile.Y) {
 		if IsPickable(entity, world) {
 			result = append(result, entity)
 		}

--- a/internal/world/query/query.go
+++ b/internal/world/query/query.go
@@ -59,7 +59,7 @@ func IsPickable(entity ecs.Entity, world w.World) bool {
 
 // PickablesAt は指定タイル上の拾得可能なエンティティを返す。拾得アクションの構築側が
 // 「どのタイルを拾うか」から「どのエンティティを拾うか」へ解決するのに使う。
-// タイル上のエンティティ列挙は空間索引を引く GetEntitiesAt に任せる。
+// タイル上のエンティティ列挙は共通の GetEntitiesAt に委ね、拾得可否だけを重ねる。
 func PickablesAt(world w.World, tile consts.Coord[consts.Tile]) []ecs.Entity {
 	var result []ecs.Entity
 	for _, entity := range GetEntitiesAt(world, tile.X, tile.Y) {

--- a/internal/world/query/query.go
+++ b/internal/world/query/query.go
@@ -57,6 +57,24 @@ func IsPickable(entity ecs.Entity, world w.World) bool {
 	return true
 }
 
+// PickablesAt は指定タイル上の拾得可能なエンティティを返す。拾得アクションの構築側が
+// 「どのタイルを拾うか」から「どのエンティティを拾うか」へ解決するのに使う。
+func PickablesAt(world w.World, tile consts.Coord[consts.Tile]) []ecs.Entity {
+	var result []ecs.Entity
+	q := ActiveFilter1[gc.GridElement](world).Query()
+	for q.Next() {
+		entity := q.Entity()
+		grid := world.Components.GridElement.Get(entity)
+		if grid.X != tile.X || grid.Y != tile.Y {
+			continue
+		}
+		if IsPickable(entity, world) {
+			result = append(result, entity)
+		}
+	}
+	return result
+}
+
 // IsInActivationRange はプレイヤーがトリガーの発動範囲内にいるかを判定する
 func IsInActivationRange(playerGrid, triggerGrid *gc.GridElement, activationRange gc.ActivationRange) bool {
 	switch activationRange {

--- a/internal/world/query/spatial_index_test.go
+++ b/internal/world/query/spatial_index_test.go
@@ -145,7 +145,7 @@ func TestSpatialIndex_移動で再構築チャーンが起きない(t *testing.T
 	for range steps {
 		grid := world.Components.GridElement.Get(player)
 		dest := gc.GridElement{Coord: consts.Coord[consts.Tile]{X: grid.X + 1, Y: grid.Y}}
-		_, err := activity.Execute(&activity.MoveBehavior{Destination: dest}, player, world)
+		_, err := activity.Execute(activity.NewMoveActivity(dest), player, world)
 		require.NoError(t, err)
 	}
 


### PR DESCRIPTION
## 背景

即時アクションと継続アクションで処理経路が違い分かりにくかった。実体は `stepActivity` 一つで、差は「呼び出し側が同じ呼び出しで結果を必要とするか」だけである。掘ってみると、この非対称性が実害も生んでいた。

## 変更

### 1. 処理経路の一本化
着手後のライフサイクルは常に `behaviors` レジストリの共有シングルトンで回すよう揃えた。

- `stepActivity(entity, world)` は entity だけ受け取り、`gc.Activity.BehaviorName` から実装を解決する。呼び出し側インスタンスを使うのは着手時の `BuildActivity` だけになる
- `consumePassCost` も `behaviorName` からシングルトンを引く
- `ProcessContinuousActivities` の `GetBehavior` + 分岐を `stepActivity(entity, world)` へ集約
- `behaviors` マップ・`stepActivity`・即時分岐のコメントを、mental model と「per-アクティビティ状態は `gc.Activity` に置く」不変条件で書き直した

### 2. Reload の並行装填バグ修正
`ReloadBehavior` は進捗 `effortAccum` を共有シングルトンのフィールドに溜めており、プレイヤーと隊員が同ティックで装填すると累積が混ざるバグがあった。`gc.Activity` は serde の skip 対象なので実害はセーブ喪失ではなく **並行装填の衝突**。進捗を `gc.Activity.Accumulated` へ移し、per-アクティビティ状態はデータ側に持つ規律へ揃えた。`ReloadBehavior` は `struct{}` になる。

### 3. 回帰テスト
共有シングルトンで複数アクティビティを回しても進捗が混ざらないことを固定するテストを追加。進捗をインスタンスへ戻す変異テストで、テストが実際に落ちることを確認済み。

## 検証
`make check` 全緑（build・test・lint 0 issues・脆弱性なし）。

## 残す非対称性
1ターン/複数ターンの **同期性** の差だけは本質として残す。即時アクションは呼び出し側が同じ呼び出しで成否を必要とするため完全統一はできない。

🤖 Generated with [Claude Code](https://claude.com/claude-code)