### PR TITLE
ci: xvfb 起動レースで稀に落ちる test を check.yml の限定リトライで吸収する

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -84,8 +84,24 @@ jobs:
       - uses: ./.github/actions/setup-go-with-x
       - name: test
         # カバレッジは make test が coverage.out に出力し octocov が読む。
-        # テストの別実行を挟まないことで xvfb セッションを1本に保つ
-        run: make test
+        # テストの別実行を挟まないことで xvfb セッションを1本に保つ。
+        # xvfb-run の X サーバ起動が go test の並列パッケージ init に間に合わず
+        # ebiten が稀に panic する。Makefile を触らず、この起動レースのときだけ
+        # 数回リトライして transient な失敗を吸収する。それ以外の失敗は即座に落とす。
+        run: |
+          for attempt in 1 2 3; do
+            if make test 2>&1 | tee test-output.log; then
+              exit 0
+            fi
+            if grep -q "GLFW library is not initialized" test-output.log; then
+              echo "::warning::xvfb 起動レースを検出 (attempt ${attempt})。再試行する"
+              continue
+            fi
+            echo "::error::テストが失敗した。xvfb 起動レース以外の失敗"
+            exit 1
+          done
+          echo "::error::xvfb 起動レースが 3 回連続で発生した"
+          exit 1
       - uses: k1LoW/octocov-action@v1
 
   flaky-check:
@@ -97,7 +113,22 @@ jobs:
       - uses: ./.github/actions/setup-go-with-x
       - name: Flaky check
         # race検出付きで繰り返し実行し、データ競合とフレークを検出する。
-        run: make test RACE=-race COUNT=10
+        # test ジョブと同じ xvfb 起動レースのときだけリトライする。
+        # データ競合など本来検出したい失敗は即座に落とす。
+        run: |
+          for attempt in 1 2 3; do
+            if make test RACE=-race COUNT=10 2>&1 | tee test-output.log; then
+              exit 0
+            fi
+            if grep -q "GLFW library is not initialized" test-output.log; then
+              echo "::warning::xvfb 起動レースを検出 (attempt ${attempt})。再試行する"
+              continue
+            fi
+            echo "::error::flaky-check が失敗した。xvfb 起動レース以外の失敗"
+            exit 1
+          done
+          echo "::error::xvfb 起動レースが 3 回連続で発生した"
+          exit 1
 
   bench-compare:
     # mainとPRでベンチを比較し、結果を sticky コメント表示、sec/opが2倍以上悪化したら失敗させる。


### PR DESCRIPTION
## 背景

CI の test がたまに失敗する。原因はテスト内容ではなく Xvfb の起動レース。

- 失敗パッケージ例: `internal/components`(テストではなく**パッケージ init 時**の panic)
- 症状: `glfw: X11: Failed to open display :99` → `ebiten/internal/ui.init.0()` で panic
- 仕組み: `make test` は `xvfb-run -a go test -shuffle=on ...` で回す。`xvfb-run` はXサーバ起動直後にコマンドを実行するが、`go test` はパッケージごとに別バイナリを並列起動する。ebiten を import するバイナリの `init()` が、Xvfb が接続受付可能になる前に走ると panic する。純ロジックの `internal/components` も ebiten の画像型を使うため踏む。

## 修正方針

`xvfb-run -a` は Makefile 内で自前のXサーバを起動するため、check.yml で事前に Xvfb を立てても xvfb-run は別サーバを起動してしまい効かない。よって Makefile は変更せず、**workflow 側で GLFW 初期化 panic のシグネチャを検出したときだけ最大3回リトライ**する。

- `test` / `flaky-check` の両ステップに適用
- `GLFW library is not initialized` を検出したときのみ再試行。データ競合など本来検出したい失敗は即座に落とす

これで起動レース由来の transient な失敗だけを吸収し、実際のテスト失敗は隠さない。

🤖 Generated with [Claude Code](https://claude.com/claude-code)