### PR TITLE
test(tabmenu): カバレッジ増強

### DIFF
--- a/internal/widgets/tabmenu/tabmenu_test.go
+++ b/internal/widgets/tabmenu/tabmenu_test.go
@@ -57,6 +57,18 @@ func TestGetVisibleItems(t *testing.T) {
 		assert.Empty(t, visible)
 		assert.Empty(t, indices)
 	})
+
+	t.Run("開始位置が総アイテム数以上の場合は空を返す", func(t *testing.T) {
+		t.Parallel()
+		config := Config{
+			Tabs:         []TabItem{{ID: "t1", Items: items}},
+			ItemsPerPage: 3,
+		}
+		state := ViewState{TabIndex: 0, ItemIndex: 100}
+		visible, indices := getVisibleItems(config, state)
+		assert.Empty(t, visible)
+		assert.Empty(t, indices)
+	})
 }
 
 func TestPageIndicatorText(t *testing.T) {
@@ -118,5 +130,33 @@ func TestTotalPages(t *testing.T) {
 		t.Parallel()
 		config := Config{Tabs: []TabItem{{ID: "t1", Items: make([]Item, 10)}}, ItemsPerPage: 3}
 		assert.Equal(t, 4, totalPages(config, ViewState{}))
+	})
+
+	t.Run("TabIndexがタブ数以上は1ページ", func(t *testing.T) {
+		t.Parallel()
+		config := Config{Tabs: []TabItem{{ID: "t1", Items: make([]Item, 10)}}, ItemsPerPage: 3}
+		assert.Equal(t, 1, totalPages(config, ViewState{TabIndex: 5}))
+	})
+}
+
+func TestCurrentPage(t *testing.T) {
+	t.Parallel()
+
+	t.Run("ItemsPerPageが0以下は0を返す", func(t *testing.T) {
+		t.Parallel()
+		config := Config{ItemsPerPage: 0}
+		assert.Equal(t, 0, currentPage(config, ViewState{ItemIndex: 5}))
+	})
+
+	t.Run("ItemIndexが負は0を返す", func(t *testing.T) {
+		t.Parallel()
+		config := Config{ItemsPerPage: 3}
+		assert.Equal(t, 0, currentPage(config, ViewState{ItemIndex: -1}))
+	})
+
+	t.Run("ItemIndexをItemsPerPageで割った値を返す", func(t *testing.T) {
+		t.Parallel()
+		config := Config{ItemsPerPage: 3}
+		assert.Equal(t, 2, currentPage(config, ViewState{ItemIndex: 7}))
 	})
 }

--- a/internal/widgets/tabmenu/view_test.go
+++ b/internal/widgets/tabmenu/view_test.go
@@ -1,0 +1,44 @@
+package tabmenu
+
+import (
+	"testing"
+
+	w "github.com/kijimaD/ruins/internal/world"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestView_GetCurrentPage(t *testing.T) {
+	t.Parallel()
+
+	t.Run("1ページ目は1を返す", func(t *testing.T) {
+		t.Parallel()
+		view := NewView(Config{
+			Tabs:         []TabItem{{ID: "t1", Items: make([]Item, 10)}},
+			ItemsPerPage: 3,
+		}, w.World{})
+		view.SetState(ViewState{TabIndex: 0, ItemIndex: 0})
+		assert.Equal(t, 1, view.GetCurrentPage())
+	})
+
+	t.Run("2ページ目は2を返す", func(t *testing.T) {
+		t.Parallel()
+		view := NewView(Config{
+			Tabs:         []TabItem{{ID: "t1", Items: make([]Item, 10)}},
+			ItemsPerPage: 3,
+		}, w.World{})
+		view.SetState(ViewState{TabIndex: 0, ItemIndex: 4})
+		assert.Equal(t, 2, view.GetCurrentPage())
+	})
+}
+
+func TestView_UpdateTabs_タブを置き換える(t *testing.T) {
+	t.Parallel()
+	view := NewView(Config{
+		Tabs: []TabItem{{ID: "old", Label: "旧タブ"}},
+	}, w.World{})
+
+	newTabs := []TabItem{{ID: "new", Label: "新タブ"}}
+	view.UpdateTabs(newTabs)
+
+	assert.Equal(t, newTabs, view.config.Tabs)
+}

--- a/internal/widgets/tabmenu/view_test.go
+++ b/internal/widgets/tabmenu/view_test.go
@@ -40,5 +40,6 @@ func TestView_UpdateTabs_タブを置き換える(t *testing.T) {
 	newTabs := []TabItem{{ID: "new", Label: "新タブ"}}
 	view.UpdateTabs(newTabs)
 
+	// 公開APIでは置き換え後のタブを外部から取得できないため、同一パッケージの特権で内部状態を直接検証する
 	assert.Equal(t, newTabs, view.config.Tabs)
 }

--- a/internal/widgets/tabmenu/view_ui_test.go
+++ b/internal/widgets/tabmenu/view_ui_test.go
@@ -1,0 +1,124 @@
+package tabmenu_test
+
+import (
+	"testing"
+
+	"github.com/ebitenui/ebitenui/widget"
+	"github.com/kijimaD/ruins/internal/vrt"
+	"github.com/kijimaD/ruins/internal/widgets/tabmenu"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestView_UpdateTabDisplayContainer(t *testing.T) {
+	t.Parallel()
+	world := vrt.InitVRTWorld(t)
+
+	t.Run("ページネーションありならページインジケーターを先頭に加えた件数になる", func(t *testing.T) {
+		t.Parallel()
+		view := tabmenu.NewView(tabmenu.Config{
+			Tabs: []tabmenu.TabItem{
+				{ID: "tab", Items: []tabmenu.Item{
+					{ID: "i1", Label: "A"},
+					{ID: "i2", Label: "B"},
+					{ID: "i3", Label: "C"},
+					{ID: "i4", Label: "D"},
+				}},
+			},
+			ItemsPerPage: 2,
+		}, world)
+		view.SetState(tabmenu.ViewState{TabIndex: 0, ItemIndex: 0})
+
+		container := widget.NewContainer()
+		view.UpdateTabDisplayContainer(container)
+
+		// ページインジケーター1件 + 表示アイテム2件
+		assert.Len(t, container.Children(), 3)
+	})
+
+	t.Run("ページネーションなしならページインジケーターを加えない件数になる", func(t *testing.T) {
+		t.Parallel()
+		view := tabmenu.NewView(tabmenu.Config{
+			Tabs: []tabmenu.TabItem{
+				{ID: "tab", Items: []tabmenu.Item{
+					{ID: "i1", Label: "A"},
+					{ID: "i2", Label: "B"},
+				}},
+			},
+		}, world)
+		view.SetState(tabmenu.ViewState{TabIndex: 0, ItemIndex: 0})
+
+		container := widget.NewContainer()
+		view.UpdateTabDisplayContainer(container)
+
+		assert.Len(t, container.Children(), 2)
+	})
+
+	t.Run("アイテムが空なら空表示のテキストを1件加える", func(t *testing.T) {
+		t.Parallel()
+		view := tabmenu.NewView(tabmenu.Config{
+			Tabs: []tabmenu.TabItem{
+				{ID: "tab", Items: []tabmenu.Item{}},
+			},
+		}, world)
+		view.SetState(tabmenu.ViewState{TabIndex: 0, ItemIndex: 0})
+
+		container := widget.NewContainer()
+		view.UpdateTabDisplayContainer(container)
+
+		require.Len(t, container.Children(), 1)
+		_, ok := container.Children()[0].(*widget.Text)
+		assert.True(t, ok)
+	})
+
+	t.Run("呼び出すたびに既存の子を入れ替えて累積しない", func(t *testing.T) {
+		t.Parallel()
+		view := tabmenu.NewView(tabmenu.Config{
+			Tabs: []tabmenu.TabItem{
+				{ID: "tab", Items: []tabmenu.Item{{ID: "i1", Label: "A"}}},
+			},
+		}, world)
+		view.SetState(tabmenu.ViewState{TabIndex: 0, ItemIndex: 0})
+
+		container := widget.NewContainer()
+		view.UpdateTabDisplayContainer(container)
+		view.UpdateTabDisplayContainer(container)
+
+		assert.Len(t, container.Children(), 1)
+	})
+}
+
+func TestView_UpdateFocus(t *testing.T) {
+	t.Parallel()
+	world := vrt.InitVRTWorld(t)
+
+	t.Run("BuildUI前に呼んでもパニックしない", func(t *testing.T) {
+		t.Parallel()
+		view := tabmenu.NewView(tabmenu.Config{
+			Tabs: []tabmenu.TabItem{{ID: "tab", Items: []tabmenu.Item{{ID: "i1", Label: "A"}}}},
+		}, world)
+
+		assert.NotPanics(t, view.UpdateFocus)
+	})
+
+	t.Run("フォーカス移動後も子要素の構成は変わらない", func(t *testing.T) {
+		t.Parallel()
+		view := tabmenu.NewView(tabmenu.Config{
+			Tabs: []tabmenu.TabItem{
+				{ID: "tab", Items: []tabmenu.Item{
+					{ID: "i1", Label: "A"},
+					{ID: "i2", Label: "B"},
+					{ID: "i3", Label: "C"},
+				}},
+			},
+		}, world)
+		view.SetState(tabmenu.ViewState{TabIndex: 0, ItemIndex: 0})
+		container := view.BuildUI()
+		before := len(container.Children())
+
+		view.SetState(tabmenu.ViewState{TabIndex: 0, ItemIndex: 2})
+		require.NotPanics(t, view.UpdateFocus)
+
+		assert.Len(t, container.Children(), before)
+	})
+}

--- a/internal/widgets/tabmenu/view_ui_test.go
+++ b/internal/widgets/tabmenu/view_ui_test.go
@@ -67,8 +67,9 @@ func TestView_UpdateTabDisplayContainer(t *testing.T) {
 		view.UpdateTabDisplayContainer(container)
 
 		require.Len(t, container.Children(), 1)
-		_, ok := container.Children()[0].(*widget.Text)
-		assert.True(t, ok)
+		child := container.Children()[0]
+		_, ok := child.(*widget.Text)
+		assert.Truef(t, ok, "want *widget.Text, got %T", child)
 	})
 
 	t.Run("呼び出すたびに既存の子を入れ替えて累積しない", func(t *testing.T) {


### PR DESCRIPTION
## 概要

`internal/widgets/tabmenu` のテストカバレッジを増強する。本体コードの変更はなく、テストファイルのみ追加・変更している。

## カバレッジ

- 対象パッケージ全体: 54.8% → 96.2%
- `tabmenu.go` の `currentPage` / `totalPages` / `getVisibleItems`: 各66.7%〜94.4% → 100%
- `view.go` の `GetCurrentPage` / `UpdateTabs` / `UpdateFocus` / `UpdateTabDisplayContainer`: 0% → 100%
- `ui_builder.go` の `UpdateTabDisplayContainer`: 0% → 100%
- `ui_builder.go` の `UpdateFocus`: 0% → 84.6%（型アサーションの失敗経路は正常系のUI構築では到達しないため未カバー）

## 狙った振る舞い

- `currentPage`: `ItemsPerPage<=0` と `ItemIndex<0` それぞれで0を返す分岐、正常時の除算分岐
- `totalPages`: `TabIndex` がタブ数以上のときに1ページを返す分岐
- `getVisibleItems`: ページ先頭位置が総アイテム数以上になり空を返す分岐
- `View.GetCurrentPage` / `View.UpdateTabs`: UIリソース無しでも動く純粋なロジック部分
- `View.UpdateTabDisplayContainer`: ページネーション有無・アイテム空時のプレースホルダー表示・呼び出しごとの子要素入れ替えを子要素数で検証
- `View.UpdateFocus`: `BuildUI` 前に呼んでもパニックしないこと、フォーカス移動後も子要素構成が変わらないことを検証

## 検証

- `make test`
- `make lint`（`govulncheck` はサンドボックスのプロキシ制限で脆弱性DBに到達できず未実行。`golangci-lint run ./...` は0件）

---
_Generated by [Claude Code](https://claude.ai/code/session_01FmFFxfSa51Nv6Sc25j1NWB)_