### PR TITLE
test(save): 読めば自明な冗長コメントを削除する

### DIFF
--- a/internal/save/manager_test.go
+++ b/internal/save/manager_test.go
@@ -449,17 +449,14 @@ func TestRestoreWorldFromJSON_PreservesWorldOnFailure(t *testing.T) {
 	badJSON, err := manager.LoadWorldJSON("bad_slot")
 	require.NoError(t, err)
 
-	// 現行ワールドに識別可能な内容を入れておく
 	world := testutil.InitTestWorld(t)
 	player := world.ECS.NewEntity()
 	world.Components.Player.Add(player, &gc.Player{})
 	world.Components.Name.Add(player, &gc.Name{Name: "生存確認プレイヤー"})
 
-	// 復元は失敗する
 	err = manager.RestoreWorldFromJSON(world, badJSON)
 	require.Error(t, err)
 
-	// 失敗しても現行ワールドのプレイヤーは消えていない
 	survived := false
 	q := ecs.NewFilter1[gc.Player](world.ECS).Query()
 	for q.Next() {


### PR DESCRIPTION
## 概要

#584 マージ後の追随。`manager_test.go` の `TestRestoreWorldFromJSON_PreservesWorldOnFailure` にあった、`require.Error` や assert メッセージと重複する自明なインラインコメント3行を削除する。失敗機構の非自明な説明は残している。

#584 の作業中に依頼を受けたが、コミットが landする前に #584 がマージされたため、独立した追随 PR として切り出した。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vtn5TDhyDS8DWhozMGpYck