### PR TITLE
test(raw): カバレッジ増強

### DIFF
--- a/internal/raw/disassembly_test.go
+++ b/internal/raw/disassembly_test.go
@@ -1,0 +1,196 @@
+package raw
+
+import (
+	"testing"
+
+	"github.com/kijimaD/ruins/internal/oapi"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFindDisassembly(t *testing.T) {
+	t.Parallel()
+
+	propDisassembly := &oapi.Disassembly{
+		ToolCategory: oapi.Prying,
+		BaseAP:       100,
+		Yields:       []oapi.DisassemblyYield{{Name: "鉄くず", Count: "1d1"}},
+	}
+	itemDisassembly := &oapi.Disassembly{
+		ToolCategory: oapi.Precision,
+		BaseAP:       200,
+		Yields:       []oapi.DisassemblyYield{{Name: "ネジ", Count: "1d2"}},
+	}
+	raws := oapi.Raws{
+		Props: &[]oapi.Prop{
+			{Name: "棚", Disassembly: propDisassembly},
+			{Name: "机"},
+		},
+		Items: &[]oapi.Item{
+			{Name: "廃品", Disassembly: itemDisassembly},
+			{Name: "回復薬"},
+		},
+	}
+
+	t.Run("propの分解定義を返す", func(t *testing.T) {
+		t.Parallel()
+		got, ok := FindDisassembly(raws, "棚")
+		require.True(t, ok)
+		assert.Equal(t, propDisassembly, got)
+	})
+
+	t.Run("itemの分解定義を返す", func(t *testing.T) {
+		t.Parallel()
+		got, ok := FindDisassembly(raws, "廃品")
+		require.True(t, ok)
+		assert.Equal(t, itemDisassembly, got)
+	})
+
+	t.Run("分解定義を持たないpropはfalseを返す", func(t *testing.T) {
+		t.Parallel()
+		got, ok := FindDisassembly(raws, "机")
+		assert.False(t, ok)
+		assert.Nil(t, got)
+	})
+
+	t.Run("分解定義を持たないitemはfalseを返す", func(t *testing.T) {
+		t.Parallel()
+		got, ok := FindDisassembly(raws, "回復薬")
+		assert.False(t, ok)
+		assert.Nil(t, got)
+	})
+
+	t.Run("存在しない名前はfalseを返す", func(t *testing.T) {
+		t.Parallel()
+		got, ok := FindDisassembly(raws, "存在しない名前")
+		assert.False(t, ok)
+		assert.Nil(t, got)
+	})
+}
+
+func TestFindDisassemblyTool(t *testing.T) {
+	t.Parallel()
+
+	tool := &oapi.DisassemblyTool{
+		Categories: []oapi.ToolCategory{oapi.Prying, oapi.Cutting},
+		Grade:      2,
+	}
+	raws := oapi.Raws{
+		Items: &[]oapi.Item{
+			{Name: "バール", DisassemblyTool: tool},
+			{Name: "回復薬"},
+		},
+	}
+
+	t.Run("アイテムの分解工具定義を返す", func(t *testing.T) {
+		t.Parallel()
+		got, ok := FindDisassemblyTool(raws, "バール")
+		require.True(t, ok)
+		assert.Equal(t, tool, got)
+	})
+
+	t.Run("分解工具定義を持たないアイテムはfalseを返す", func(t *testing.T) {
+		t.Parallel()
+		got, ok := FindDisassemblyTool(raws, "回復薬")
+		assert.False(t, ok)
+		assert.Nil(t, got)
+	})
+
+	t.Run("存在しないアイテム名はfalseを返す", func(t *testing.T) {
+		t.Parallel()
+		got, ok := FindDisassemblyTool(raws, "存在しないアイテム")
+		assert.False(t, ok)
+		assert.Nil(t, got)
+	})
+}
+
+func TestValidateReferences(t *testing.T) {
+	t.Parallel()
+
+	t.Run("空のRawsは成功する", func(t *testing.T) {
+		t.Parallel()
+		assert.NoError(t, ValidateReferences(oapi.Raws{}))
+	})
+
+	t.Run("全チェックを満たすRawsは成功する", func(t *testing.T) {
+		t.Parallel()
+		raws := oapi.Raws{
+			Items: &[]oapi.Item{
+				{Name: "鉄くず"},
+				{Name: "刀"},
+			},
+			Props: &[]oapi.Prop{{
+				Name: "棚",
+				Disassembly: &oapi.Disassembly{
+					ToolCategory: oapi.Prying,
+					BaseAP:       100,
+					Yields:       []oapi.DisassemblyYield{{Name: "鉄くず", Count: "1d1"}},
+				},
+			}},
+			DropTables: &[]oapi.DropTable{{
+				Name:    "廃墟",
+				Entries: []oapi.DropTableEntry{{Material: "鉄くず", Weight: 1}},
+			}},
+			EnemyTables: &[]oapi.EnemyTable{{
+				Name:    "通常",
+				Entries: []oapi.EnemyTableEntry{{EnemyName: "スライム", Pack: "1d3"}},
+			}},
+			CommandTables: &[]oapi.CommandTable{{
+				Name:    "剣術",
+				Entries: []oapi.CommandTableEntry{{Weapon: "刀"}},
+			}},
+			ItemGroups: &[]oapi.ItemGroup{{
+				Name:    "素材",
+				Entries: []oapi.ItemGroupEntry{{ItemName: "鉄くず", Pack: "1d1"}},
+			}},
+			ItemTables: &[]oapi.ItemTable{{
+				Name:    "宝箱",
+				Entries: []oapi.ItemTableEntry{{GroupName: "素材"}},
+			}},
+			Members: &[]oapi.Member{{
+				Name:             "スライム",
+				DropTableName:    new(oapi.EntityName("廃墟")),
+				CommandTableName: new(oapi.EntityName("剣術")),
+			}},
+		}
+		assert.NoError(t, ValidateReferences(raws))
+	})
+
+	t.Run("分解参照エラーが最初に検出される", func(t *testing.T) {
+		t.Parallel()
+		raws := oapi.Raws{
+			Items: &[]oapi.Item{{Name: "鉄くず"}},
+			Props: &[]oapi.Prop{{
+				Name: "棚",
+				Disassembly: &oapi.Disassembly{
+					ToolCategory: oapi.Prying,
+					BaseAP:       100,
+					Yields:       []oapi.DisassemblyYield{{Name: "存在しない素材", Count: "1d1"}},
+				},
+			}},
+			DropTables: &[]oapi.DropTable{{
+				Name:    "廃墟",
+				Entries: []oapi.DropTableEntry{{Material: "別の存在しない素材", Weight: 1}},
+			}},
+		}
+		err := ValidateReferences(raws)
+		require.Error(t, err)
+		require.ErrorContains(t, err, "分解産出")
+		require.ErrorContains(t, err, "存在しない素材")
+	})
+
+	t.Run("武器参照エラーが最後のチェックで検出される", func(t *testing.T) {
+		t.Parallel()
+		raws := oapi.Raws{
+			Items: &[]oapi.Item{{Name: "鉄くず"}},
+			CommandTables: &[]oapi.CommandTable{{
+				Name:    "剣術",
+				Entries: []oapi.CommandTableEntry{{Weapon: "未定義武器"}},
+			}},
+		}
+		err := ValidateReferences(raws)
+		require.Error(t, err)
+		require.ErrorContains(t, err, "未定義武器")
+		require.ErrorContains(t, err, "剣術")
+	})
+}


### PR DESCRIPTION
## 概要

`internal/raw` パッケージのテストを増強する。本体コードの変更はなし。

対象は次の3関数。いずれも純粋なロジックで表示環境に依存しない。

- `FindDisassembly`: prop・item から分解定義を検索する。カバレッジ 0% → 100%
- `FindDisassemblyTool`: item から分解工具定義を検索する。カバレッジ 0% → 100%
- `ValidateReferences`: 各種参照整合性チェックを順に呼ぶオーケストレータ。カバレッジ 53.3% → 検証順序も含めてカバー

## カバレッジ

`internal/raw`: 86.6% → 89.0%

## 狙った振る舞い

- `FindDisassembly` が prop・item どちらの分解定義も見つけられること、分解定義を持たない場合や存在しない名前で `false` を返すこと
- `FindDisassemblyTool` がアイテムの分解工具定義を見つけられること、定義を持たない場合や存在しないアイテム名で `false` を返すこと
- `ValidateReferences` が全チェックを満たす場合に成功すること、複数の検証が同時に失敗する場合は実装順どおり最初のチェック、分解参照が先に検出されること、最後のチェックである武器参照エラーも正しく検出されること

## 検証

- `make test`: 全パッケージ通過
- `make lint`: golangci-lint 0件、deadcode検出なし。govulncheck はサンドボックス環境のプロキシ制限で `vuln.go.dev` に到達できず未検証。コード変更とは無関係な環境制約

---
_Generated by [Claude Code](https://claude.ai/code/session_01H4NN48qiF1DpKKsCRb13WY)_