### PR TITLE
fix(vision): 光源からタイルへの遮蔽判定を追加し壁の裏への光漏れを直す

### DIFF
--- a/internal/systems/vision.go
+++ b/internal/systems/vision.go
@@ -96,7 +96,7 @@ func (sys *VisionSystem) Update(world w.World) error {
 			continue
 		}
 
-		vs.LightSourceCache[gridElement] = calculateLightSourceDarkness(world, consts.Coord[int]{X: tileData.Col, Y: tileData.Row})
+		vs.LightSourceCache[gridElement] = calculateLightSourceDarkness(world, consts.Coord[int]{X: tileData.Col, Y: tileData.Row}, blockViewIndex)
 		field.ExploredTiles[gridElement] = true
 		visibleTiles[gridElement] = true
 	}
@@ -284,8 +284,9 @@ func bresenhamLineOfSight(x0, y0, x1, y1 int, blockIndex map[gc.GridElement]bool
 	}
 }
 
-// calculateLightSourceDarkness は光源からの距離に応じた暗闇レベルと色を計算する
-func calculateLightSourceDarkness(world w.World, tile consts.Coord[int]) gc.LightInfo {
+// calculateLightSourceDarkness は光源からの距離に応じた暗闇レベルと色を計算する。
+// 光源からタイルへの視線が壁で遮られている光源は寄与しない。壁の裏へ光が漏れるのを防ぐ。
+func calculateLightSourceDarkness(world w.World, tile consts.Coord[int], blockIndex map[gc.GridElement]bool) gc.LightInfo {
 	minDarkness := 1.0 // 完全に暗い状態からスタート
 
 	// 加重平均用の累積値
@@ -310,6 +311,12 @@ func calculateLightSourceDarkness(world w.World, tile consts.Coord[int]) gc.Ligh
 
 		// 光源範囲内かチェック
 		if distance <= float64(lightSource.Radius) {
+			// 光源からタイルまでの視線が壁で遮られているなら、この光は届かない。
+			// プレイヤー視界と同じ遮蔽判定を光源起点で行い、壁の裏へ光が漏れるのを防ぐ。
+			if !bresenhamLineOfSight(int(lightGrid.X), int(lightGrid.Y), tile.X, tile.Y, blockIndex) {
+				continue
+			}
+
 			// 光源中心（距離0-1タイル）も周囲と同じ明るさにする
 			if distance < 1.0 {
 				distance = 1.0

--- a/internal/systems/vision_test.go
+++ b/internal/systems/vision_test.go
@@ -7,6 +7,7 @@ import (
 	gc "github.com/kijimaD/ruins/internal/components"
 	"github.com/kijimaD/ruins/internal/consts"
 	"github.com/kijimaD/ruins/internal/testutil"
+	w "github.com/kijimaD/ruins/internal/world"
 
 	"github.com/kijimaD/ruins/internal/world/query"
 	"github.com/stretchr/testify/assert"
@@ -342,5 +343,53 @@ func TestBresenhamLineOfSight(t *testing.T) {
 
 		assert.True(t, bresenhamLineOfSight(5, 5, 6, 5, blockIndex))
 		assert.True(t, bresenhamLineOfSight(5, 5, 5, 6, blockIndex))
+	})
+}
+
+func TestCalculateLightSourceDarkness_壁が光を遮る(t *testing.T) {
+	t.Parallel()
+
+	// 光源を (5,5) に置き Radius 10 とする。(7,5) に壁を立て、壁の手前 (6,5) は照らされ、
+	// 壁の裏 (9,5) は照らされないことを固定する。光の伝播が視界と同じ遮蔽判定を通す回帰テスト。
+	setup := func(t *testing.T) w.World {
+		t.Helper()
+		world := testutil.InitTestWorld(t)
+		lightGrid := gc.GridElement{Coord: consts.Coord[consts.Tile]{X: 5, Y: 5}}
+		lightEntity := world.ECS.NewEntity()
+		world.Components.GridElement.Add(lightEntity, &lightGrid)
+		world.Components.LightSource.Add(lightEntity, &gc.LightSource{
+			Radius:  10,
+			Color:   color.RGBA{R: 255, G: 220, B: 150, A: 255},
+			Enabled: true,
+		})
+		return world
+	}
+	wall := map[gc.GridElement]bool{
+		{Coord: consts.Coord[consts.Tile]{X: 7, Y: 5}}: true,
+	}
+
+	t.Run("壁の手前のタイルは照らされる", func(t *testing.T) {
+		t.Parallel()
+		world := setup(t)
+		info := calculateLightSourceDarkness(world, consts.Coord[int]{X: 6, Y: 5}, wall)
+		assert.Less(t, info.Darkness, 1.0, "手前のタイルは光が届き暗闇が解消される")
+	})
+
+	t.Run("壁の裏のタイルは照らされない", func(t *testing.T) {
+		t.Parallel()
+		world := setup(t)
+		info := calculateLightSourceDarkness(world, consts.Coord[int]{X: 9, Y: 5}, wall)
+		assert.Equal(t, 1.0, info.Darkness, "壁の裏は光が遮られ完全に暗いまま")
+		// 光が寄与しないと RGB は 0 のまま。A は常に 255 が入るので RGB だけを見る。
+		// Darkness=1.0 なら描画側が色を無視するため、この色は実効に影響しない
+		assert.Equal(t, color.RGBA{A: 255}, info.Color, "光が届かないので色は乗らない。RGBは0")
+	})
+
+	t.Run("遮蔽が無ければ同じタイルが照らされる", func(t *testing.T) {
+		t.Parallel()
+		world := setup(t)
+		// 壁を除いた同座標で照らされることを示し、暗いのは距離でなく遮蔽が原因だと確定する
+		info := calculateLightSourceDarkness(world, consts.Coord[int]{X: 9, Y: 5}, map[gc.GridElement]bool{})
+		assert.Less(t, info.Darkness, 1.0, "壁が無ければ壁の裏と同じ位置でも照らされる")
 	})
 }


### PR DESCRIPTION
## 概要

明かりが壁の向こう側の不可視タイルまで漏れて照らしていたのを直す。壁の裏にあるタイルが、光源との間に壁があっても照らされてしまっていた。

## 原因

`calculateLightSourceDarkness`（`internal/systems/vision.go`）が光源からタイルへの**距離だけ**で採光を判定し、間の壁を考慮していなかった。視界判定は `bresenhamLineOfSight` で壁を遮蔽物として扱うのに、光の伝播だけが同じ判定を通っておらず、プレイヤーが見通せるタイルは光源との間に壁があっても照らされていた。光と視界で壁の扱いが食い違っていたのが本質。

## 修正

- `calculateLightSourceDarkness` に `blockIndex` を渡し、**光源を起点にした** `bresenhamLineOfSight` で視線が壁に遮られる光源は寄与させない。視界と光で同じ遮蔽モデルを共有する
- 呼び出し側は構築済みの `blockViewIndex` をそのまま渡すだけ

新しい遮蔽アルゴリズムは足さず、既に壁を正しく扱う既存関数を再利用した。別実装のシャドウキャストを書くと視界と光で壁の扱いがズレる第2のバグを生みかねないため。

## 設計判断

光源を持つ prop は `bed_lamp`・`bonfire` のみでいずれも `blockView=false`、members も壁ではないため、光源が壁タイル上に載って自分の光を遮る事象は構造的に起きない。よって始点タイルの遮蔽を特別扱いせず `bresenhamLineOfSight` をそのまま再利用している。

なお視界の「隣接は必ず見える」補正は光には適用していない。壁の隣の光源が角を回り込んで光るのを防ぐため、LOS の芯だけを共有し隣接補正は意図的に分けている。

## テスト

回帰テスト `TestCalculateLightSourceDarkness_壁が光を遮る` を追加。光源(5,5)・壁(7,5)の構成で以下を固定する。

- 壁の手前 (6,5) は照らされる
- 壁の裏 (9,5) は照らされない（`Darkness=1.0` のまま）
- 壁を除けば同座標 (9,5) が照らされる。暗いのは距離でなく遮蔽が原因だと確定する

## 検証

- `make check` 全緑（lint 0 issues・脆弱性なし）
- 新テスト3件パス、既存の golden も無変更

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vtn5TDhyDS8DWhozMGpYck
