### PR TITLE
fix(lifecycle): 隊員配置の空き探索をマップ全体へ広げ密集で潰れないようにする

### DIFF
--- a/internal/world/lifecycle/location.go
+++ b/internal/world/lifecycle/location.go
@@ -263,8 +263,9 @@ func tileAvailable(si *gc.SpatialIndex, tile consts.Coord[consts.Tile], exclude 
 	return !exclude[gc.GridElement{Coord: tile}]
 }
 
-// findNearbyEmptyTile はcenterから近い順に空きタイルを探す。隣接(半径1)から外側へリングを
-// 広げ、maxRadius まで探す。密集地でも遠くの空きを拾えるようにするための拡張探索。
+// findNearbyEmptyTile はcenterに近いリングから順に空きタイルを探す。隣接(半径1)から外側へ
+// チェビシェフ距離のリングを広げ、maxRadius まで探す。内側リングが先に埋まるが、同一リング内の
+// 走査順はラスタースキャンで、厳密なユークリッド最短ではない。密集地でも遠くの空きを拾える。
 // 見つからなければ ok=false を返す。呼び出し側が最終手段の退避先を決める。
 func findNearbyEmptyTile(world w.World, center consts.Coord[consts.Tile], exclude map[gc.GridElement]bool, maxRadius int) (consts.Coord[consts.Tile], bool) {
 	si := query.GetSpatialIndex(world)
@@ -285,17 +286,16 @@ func findNearbyEmptyTile(world w.World, center consts.Coord[consts.Tile], exclud
 	return consts.Coord[consts.Tile]{}, false
 }
 
-// findPlacementTile は隊員の配置先を探す。center 近傍を優先しつつ、密集で近傍が埋まっていれば
-// マップ全体へ探索を広げて最寄りの空きを拾う。リング探索は近い順に走査するので、範囲を広げても
-// 最も近い空きから埋まり、近傍が空いていれば従来どおり隣接タイルへ収まる。地図全体が埋まっている
-// 極限だけ ok=false を返し、呼び出し側が最終手段の退避先を決める。
-// これで地図端や壁の密集で近傍6タイルが尽きても、全員が1タイルへ重なるのを防ぐ。
+// findPlacementTile は隊員の配置先を探す。center 近傍を優先しつつ、近傍が埋まっていれば
+// マップ全体へ探索を広げて空きを拾う。リング探索は内側のリングから走査するので、範囲を広げても
+// 近いリングから埋まり、近傍が空いていれば隣接タイルへ収まる。地図全体が埋まっている極限だけ
+// ok=false を返し、呼び出し側が最終手段の退避先を決める。
 func findPlacementTile(world w.World, center consts.Coord[consts.Tile], exclude map[gc.GridElement]bool) (consts.Coord[consts.Tile], bool) {
 	maxRadius := squadPlacementMaxRadius
 	// マップ寸法が引けるなら、地図全体を覆う半径まで探索を広げる。どのタイルを中心にしても
-	// 幅+高さぶんのリングでマップ全体を走査できる。近傍優先はリング探索の性質で保たれる。
+	// 幅と高さの大きい方ぶんのリングでマップ全体を走査できる。近傍優先はリング探索の性質で保たれる。
 	if si := query.GetSpatialIndex(world); si != nil {
-		if mapRadius := int(si.MapWidth) + int(si.MapHeight); mapRadius > maxRadius {
+		if mapRadius := max(int(si.MapWidth), int(si.MapHeight)); mapRadius > maxRadius {
 			maxRadius = mapRadius
 		}
 	}

--- a/internal/world/lifecycle/location.go
+++ b/internal/world/lifecycle/location.go
@@ -11,8 +11,10 @@ import (
 	"github.com/mlange-42/ark/ecs"
 )
 
-// squadPlacementMaxRadius はステージ遷移で隊員を再配置するときの空きタイル探索の最大半径。
-// 街や遺跡入口の密集地でも近くの空きを拾えるだけの広さを確保する。
+// squadPlacementMaxRadius は隊員配置の空きタイル探索で優先する近傍リングの半径。
+// 通常はこの範囲で隣接タイルへ収める。SpatialIndex が無くマップ寸法を引けない場面、
+// テストなどではこの半径を上限に使う。密集地でマップ寸法が引ける場面では
+// findPlacementTile がマップ全体まで探索を広げる。
 const squadPlacementMaxRadius = 6
 
 // MoveToBackpack はエンティティをバックパックに移動する。
@@ -283,6 +285,23 @@ func findNearbyEmptyTile(world w.World, center consts.Coord[consts.Tile], exclud
 	return consts.Coord[consts.Tile]{}, false
 }
 
+// findPlacementTile は隊員の配置先を探す。center 近傍を優先しつつ、密集で近傍が埋まっていれば
+// マップ全体へ探索を広げて最寄りの空きを拾う。リング探索は近い順に走査するので、範囲を広げても
+// 最も近い空きから埋まり、近傍が空いていれば従来どおり隣接タイルへ収まる。地図全体が埋まっている
+// 極限だけ ok=false を返し、呼び出し側が最終手段の退避先を決める。
+// これで地図端や壁の密集で近傍6タイルが尽きても、全員が1タイルへ重なるのを防ぐ。
+func findPlacementTile(world w.World, center consts.Coord[consts.Tile], exclude map[gc.GridElement]bool) (consts.Coord[consts.Tile], bool) {
+	maxRadius := squadPlacementMaxRadius
+	// マップ寸法が引けるなら、地図全体を覆う半径まで探索を広げる。どのタイルを中心にしても
+	// 幅+高さぶんのリングでマップ全体を走査できる。近傍優先はリング探索の性質で保たれる。
+	if si := query.GetSpatialIndex(world); si != nil {
+		if mapRadius := int(si.MapWidth) + int(si.MapHeight); mapRadius > maxRadius {
+			maxRadius = mapRadius
+		}
+	}
+	return findNearbyEmptyTile(world, center, exclude, maxRadius)
+}
+
 // MovePlayerToPosition は既存のプレイヤーエンティティを指定位置に移動させる
 func MovePlayerToPosition(world w.World, pos consts.Coord[consts.Tile]) error {
 	var playerEntity ecs.Entity
@@ -317,7 +336,7 @@ func MovePlayerToPosition(world w.World, pos consts.Coord[consts.Tile]) error {
 	exclude := map[gc.GridElement]bool{}
 	for _, member := range query.SquadMembers(world) {
 		memberGrid := world.Components.GridElement.Get(member)
-		dest, ok := findNearbyEmptyTile(world, pos, exclude, squadPlacementMaxRadius)
+		dest, ok := findPlacementTile(world, pos, exclude)
 		if !ok {
 			dest = pos
 		}

--- a/internal/world/lifecycle/location_test.go
+++ b/internal/world/lifecycle/location_test.go
@@ -152,8 +152,8 @@ func TestMovePlayerToPosition_地図端の密集でも隊員が重ならず散�
 		require.NoError(t, err)
 	}
 
-	// 地図端 (24,0) の近傍リング(squadPlacementMaxRadius)を壁で埋める。
-	// 近傍6タイル探索で打ち切る旧フォールバックでは、空きが尽きて全員が (24,0) へ潰れていた。
+	// 地図端 (24,0) の近傍リング(squadPlacementMaxRadius)を壁で埋め、近傍だけでは空きが尽きる
+	// 状況を作る。この密集でも全隊員が別タイルへ散ることを検証する。
 	target := consts.Coord[consts.Tile]{X: 24, Y: 0}
 	for dx := -squadPlacementMaxRadius; dx <= squadPlacementMaxRadius; dx++ {
 		for dy := -squadPlacementMaxRadius; dy <= squadPlacementMaxRadius; dy++ {
@@ -178,6 +178,32 @@ func TestMovePlayerToPosition_地図端の密集でも隊員が重ならず散�
 		seen[g] = true
 	}
 	assert.Len(t, seen, numMembers, "全隊員が別々のタイルに配置される")
+}
+
+// TestSpawnSquadMember_連続生成で重ならない は、隊員を続けて生成しても互いに重ならないことを固定する。
+// SpawnSquadMember は末尾で SpatialIndex を無効化するので、次の生成の findPlacementTile が索引を
+// 再構築し直前の隊員を占有として見る。ゲーム開始時などの連続生成で同一タイルへ重ならないことの回帰。
+func TestSpawnSquadMember_連続生成で重ならない(t *testing.T) {
+	t.Parallel()
+	world := testutil.InitTestWorld(t)
+
+	player, err := SpawnPlayer(world, consts.Coord[consts.Tile]{X: 10, Y: 10}, "Ash")
+	require.NoError(t, err)
+
+	const numMembers = 8
+	for range numMembers {
+		_, err := SpawnSquadMember(world, player, "隊員", testAbilities(), "player")
+		require.NoError(t, err)
+	}
+
+	seen := map[gc.GridElement]bool{}
+	seen[*world.Components.GridElement.Get(player)] = true
+	for _, m := range query.SquadMembers(world) {
+		g := *world.Components.GridElement.Get(m)
+		assert.Falsef(t, seen[g], "(%d,%d) に別キャラと重なった", g.X, g.Y)
+		seen[g] = true
+	}
+	assert.Len(t, seen, numMembers+1, "プレイヤーと全隊員が別タイルに配置される")
 }
 
 func TestUnequipAll(t *testing.T) {

--- a/internal/world/lifecycle/location_test.go
+++ b/internal/world/lifecycle/location_test.go
@@ -138,6 +138,48 @@ func TestMovePlayerToPosition_複数隊員が重複しない位置に配置さ�
 		"隊員同士は重複しない位置に配置される")
 }
 
+func TestMovePlayerToPosition_地図端の密集でも隊員が重ならず散る(t *testing.T) {
+	t.Parallel()
+	world := testutil.InitTestWorld(t)
+
+	player, err := SpawnPlayer(world, consts.Coord[consts.Tile]{X: 10, Y: 10}, "Ash")
+	require.NoError(t, err)
+
+	// 隊員を多数連れる。近傍リングだけでは全員を収めきれない数にする
+	const numMembers = 15
+	for range numMembers {
+		_, err := SpawnSquadMember(world, player, "隊員", testAbilities(), "player")
+		require.NoError(t, err)
+	}
+
+	// 地図端 (24,0) の近傍リング(squadPlacementMaxRadius)を壁で埋める。
+	// 近傍6タイル探索で打ち切る旧フォールバックでは、空きが尽きて全員が (24,0) へ潰れていた。
+	target := consts.Coord[consts.Tile]{X: 24, Y: 0}
+	for dx := -squadPlacementMaxRadius; dx <= squadPlacementMaxRadius; dx++ {
+		for dy := -squadPlacementMaxRadius; dy <= squadPlacementMaxRadius; dy++ {
+			x, y := int(target.X)+dx, int(target.Y)+dy
+			if x < 0 || y < 0 {
+				continue
+			}
+			wall := world.ECS.NewEntity()
+			world.Components.GridElement.Add(wall, &gc.GridElement{Coord: consts.Coord[consts.Tile]{X: consts.Tile(x), Y: consts.Tile(y)}})
+			world.Components.BlockPass.Add(wall, &gc.BlockPass{})
+		}
+	}
+	query.InvalidateSpatialIndex(world)
+
+	require.NoError(t, MovePlayerToPosition(world, target))
+
+	// マップ全体へ探索を広げるので、全隊員が別々のタイルへ散る。1タイルへ重ならない
+	seen := map[gc.GridElement]bool{}
+	for _, m := range query.SquadMembers(world) {
+		g := *world.Components.GridElement.Get(m)
+		assert.False(t, seen[g], "隊員が同じタイル (%d,%d) に重なっている", g.X, g.Y)
+		seen[g] = true
+	}
+	assert.Len(t, seen, numMembers, "全隊員が別々のタイルに配置される")
+}
+
 func TestUnequipAll(t *testing.T) {
 	t.Parallel()
 

--- a/internal/world/lifecycle/spawn.go
+++ b/internal/world/lifecycle/spawn.go
@@ -180,9 +180,9 @@ func SpawnSquadMember(world w.World, leader ecs.Entity, name string, abilities g
 	leaderGrid := world.Components.GridElement.Get(leader)
 
 	// リーダーの近くの空きタイルを探す。街や遺跡入口など密集地では隣接が埋まっていることが
-	// あるため、近い順に外側へ広げて探す。それでも無ければリーダーと同じタイルへ退避させ、
-	// 生成そのものは失敗させない。重なっても次の移動で追従処理が空きへ散らす。
-	spawnPos, ok := findNearbyEmptyTile(world, leaderGrid.Coord, nil, squadPlacementMaxRadius)
+	// あるため、近い順に外側へ広げ、必要ならマップ全体まで探す。それでも無ければリーダーと同じ
+	// タイルへ退避させ、生成そのものは失敗させない。重なっても次の移動で追従処理が空きへ散らす。
+	spawnPos, ok := findPlacementTile(world, leaderGrid.Coord, nil)
 	if !ok {
 		spawnPos = leaderGrid.Coord
 	}


### PR DESCRIPTION
## 概要

隊員が多いと新階層のスポーンで**全員が1タイルへ重なる**ことがあった。空きタイル探索を近傍6タイルで打ち切っていたため、地図端や壁の密集で近傍が尽きると、フォールバックで全隊員がプレイヤーのタイルへ退避して潰れていた。

## 修正

- `findPlacementTile` を追加。近傍を優先しつつ、密集で埋まっていれば `SpatialIndex` のマップ寸法から**地図全体を覆う半径**まで探索を広げ最寄りの空きを拾う。リング探索は近い順なので、範囲を広げても隣接から埋まり通常時の挙動は不変
- `MovePlayerToPosition`・`SpawnSquadMember` の探索を差し替え。地図が真に満杯の極限だけ従来の退避

バグの正体は新機能でなく `squadPlacementMaxRadius = 6` の不要な固定上限だった。

## 検証

- 回帰テスト追加。地図端の密集でも隊員15名が別タイルに配置されることを固定（修正前は1タイルに15名）
- `make check` 緑

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vtn5TDhyDS8DWhozMGpYck
