### PR TITLE
test(config): カバレッジ増強

### DIFF
--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -74,6 +74,36 @@ func TestLoad(t *testing.T) {
 	assert.Positive(t, cfg.User.WindowHeight)
 	assert.Positive(t, cfg.TargetFPS)
 }
+func TestLoad_RUINS_PROFILEを指定するとそのプロファイルになる(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", dir)
+	t.Setenv("RUINS_PROFILE", "development")
+
+	cfg, err := Load()
+	require.NoError(t, err)
+	assert.Equal(t, ProfileDevelopment, cfg.Profile)
+}
+
+func TestLoad_環境変数の値が不正だとエラーを返す(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", dir)
+	t.Setenv("RUINS_TARGET_FPS", "invalid")
+
+	cfg, err := Load()
+	assert.Nil(t, cfg)
+	assert.ErrorContains(t, err, "設定の読み込みに失敗しました")
+}
+
+func TestLoad_検証に失敗する設定はエラーを返す(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", dir)
+	t.Setenv("RUINS_WINDOW_WIDTH", "100")
+
+	cfg, err := Load()
+	assert.Nil(t, cfg)
+	assert.ErrorIs(t, err, errWindowWidthTooSmall)
+}
+
 func TestValidate(t *testing.T) {
 	t.Parallel()
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -74,6 +74,10 @@ func TestLoad(t *testing.T) {
 	assert.Positive(t, cfg.User.WindowHeight)
 	assert.Positive(t, cfg.TargetFPS)
 }
+
+// 以下は環境変数を書き換えて Load の挙動を検証するため、
+// t.Setenv の制約上 t.Parallel は呼ばない。
+
 func TestLoad_RUINS_PROFILEを指定するとそのプロファイルになる(t *testing.T) {
 	dir := t.TempDir()
 	t.Setenv("XDG_CONFIG_HOME", dir)
@@ -101,6 +105,9 @@ func TestLoad_検証に失敗する設定はエラーを返す(t *testing.T) {
 
 	cfg, err := Load()
 	assert.Nil(t, cfg)
+	// Load は Validate のエラーを「設定の検証に失敗しました」でラップして返すため、
+	// ラップの事実と検証エラーの種類の両方をアサートする。
+	assert.ErrorContains(t, err, "設定の検証に失敗しました")
 	assert.ErrorIs(t, err, errWindowWidthTooSmall)
 }
 

--- a/internal/config/store_desktop_test.go
+++ b/internal/config/store_desktop_test.go
@@ -3,6 +3,7 @@
 package config
 
 import (
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -56,6 +57,59 @@ func TestSettingsExistAt(t *testing.T) {
 	assert.True(t, ok)
 }
 
+func TestWriteSettingsTo_親ディレクトリがファイルだとエラー(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	blocker := filepath.Join(dir, "blocker")
+	require.NoError(t, os.WriteFile(blocker, []byte("x"), 0o644))
+
+	err := writeSettingsTo(filepath.Join(blocker, "subdir", "settings.toml"), []byte("x"))
+	assert.ErrorContains(t, err, "設定ディレクトリの作成に失敗しました")
+}
+
+func TestWriteSettingsTo_一時ファイル用パスがディレクトリだとエラー(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "settings.toml")
+	require.NoError(t, os.Mkdir(path+".tmp", 0o755))
+
+	err := writeSettingsTo(path, []byte("x"))
+	assert.ErrorContains(t, err, "設定ファイルの書き込みに失敗しました")
+}
+
+func TestWriteSettingsTo_書き込み先がディレクトリだとエラー(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "settings.toml")
+	require.NoError(t, os.Mkdir(path, 0o755))
+
+	err := writeSettingsTo(path, []byte("x"))
+	assert.ErrorContains(t, err, "設定ファイルの置き換えに失敗しました")
+}
+
+func TestReadSettingsFrom_ディレクトリを指定するとエラー(t *testing.T) {
+	t.Parallel()
+
+	_, ok, err := readSettingsFrom(t.TempDir())
+	assert.False(t, ok)
+	assert.ErrorContains(t, err, "設定ファイルの読み込みに失敗しました")
+}
+
+func TestSettingsExistAt_親ディレクトリがファイルだとエラー(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	blocker := filepath.Join(dir, "blocker")
+	require.NoError(t, os.WriteFile(blocker, []byte("x"), 0o644))
+
+	ok, err := settingsExistAt(filepath.Join(blocker, "x"))
+	assert.False(t, ok)
+	assert.ErrorContains(t, err, "設定ファイルの存在確認に失敗しました")
+}
+
 // 以下は XDG_CONFIG_HOME を書き換えてパス解決を検証するため、
 // t.Setenv の制約上 t.Parallel は呼ばない。
 
@@ -66,6 +120,45 @@ func TestUserConfigPath_XDG_CONFIG_HOME配下にruinsディレクトリを作る
 	path, err := userConfigPath()
 	require.NoError(t, err)
 	assert.Equal(t, filepath.Join(dir, "ruins", "settings.toml"), path)
+}
+
+func TestUserConfigPath_XDG_CONFIG_HOMEもHOMEも未設定だとエラー(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", "")
+	t.Setenv("HOME", "")
+
+	_, err := userConfigPath()
+	assert.ErrorContains(t, err, "設定ディレクトリの取得に失敗しました")
+}
+
+func TestReadSettings_WriteSettings_SettingsExist_パス解決に失敗するとエラーを返す(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", "")
+	t.Setenv("HOME", "")
+
+	_, _, err := readSettings()
+	require.ErrorContains(t, err, "設定ディレクトリの取得に失敗しました")
+
+	err = writeSettings([]byte("x"))
+	require.ErrorContains(t, err, "設定ディレクトリの取得に失敗しました")
+
+	_, err = settingsExist()
+	require.ErrorContains(t, err, "設定ディレクトリの取得に失敗しました")
+}
+
+func TestSaveUserConfig_パス解決に失敗するとエラーを返す(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", "")
+	t.Setenv("HOME", "")
+
+	c := &Config{User: DefaultUserConfig()}
+	err := c.SaveUserConfig()
+	assert.ErrorContains(t, err, "設定ディレクトリの取得に失敗しました")
+}
+
+func TestEnsureUserConfigFile_存在確認に失敗するとエラーを返す(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", "")
+	t.Setenv("HOME", "")
+
+	err := EnsureUserConfigFile()
+	assert.ErrorContains(t, err, "設定ディレクトリの取得に失敗しました")
 }
 
 func TestWriteSettings_ReadSettings_SettingsExist_ラウンドトリップ(t *testing.T) {
@@ -156,6 +249,15 @@ func TestLoadUserConfig_保存済み設定を読み込んで上書きする(t *t
 	require.NoError(t, c.loadUserConfig())
 	assert.Equal(t, 1280, c.User.WindowWidth)
 	assert.Equal(t, 720, c.User.WindowHeight) // 保存に無いフィールドはデフォルトが残る
+}
+
+func TestLoadUserConfig_パス解決に失敗するとエラーを返す(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", "")
+	t.Setenv("HOME", "")
+
+	c := &Config{User: DefaultUserConfig()}
+	err := c.loadUserConfig()
+	assert.ErrorContains(t, err, "設定ディレクトリの取得に失敗しました")
 }
 
 func TestLoadUserConfig_不正なTOMLはエラーを返す(t *testing.T) {


### PR DESCRIPTION
## 概要

`internal/config` パッケージのテストカバレッジを増強する。本体コードの変更はなし。

- カバレッジ: 84.5% → 98.7%

## 狙った振る舞い

主にエラーパスの分岐を狙った。

- `userConfigPath`: `XDG_CONFIG_HOME` と `HOME` がともに未設定のときのエラー
- `readSettingsFrom` / `settingsExistAt`: ファイルの代わりにディレクトリを渡したときの読み取り・存在確認エラー
- `writeSettingsTo`: 親ディレクトリがファイルで `MkdirAll` が失敗するケース、一時ファイル用パスが既にディレクトリで `WriteFile` が失敗するケース、書き込み先が既にディレクトリで `Rename` が失敗するケース
- `readSettings` / `writeSettings` / `settingsExist` / `SaveUserConfig` / `EnsureUserConfigFile` / `loadUserConfig`: パス解決失敗がラッパー経由でエラー伝播すること
- `Load`: `RUINS_PROFILE` を明示指定したときの分岐、環境変数の型不正で `env.Parse` が失敗するケース、`Validate` が失敗する設定値を渡したケース

残り約1.3%は `encodeUserConfig` の TOML エンコード失敗パスで、現状の `UserConfig` の構造上テストから現実的に再現できないため対象外とした。

## 検証

- `make test`: 全体テスト成功
- `golangci-lint run ./...`: 0 issues
- `go tool deadcode`: 到達不能関数なし
- `go build ./...`: 成功

---
_Generated by [Claude Code](https://claude.ai/code/session_014qRpzNGqR5LQzyFfRHm5Sc)_