### PR TITLE
chore(i18n): gosmopolitan で日本語リテラルを検知し states UI を段階英語化する

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -54,7 +54,7 @@ linters:
       # states は UI を能動移行する。ファイル単位で除外し、英語化した画面から1枚ずつ外す。
       # main_menu は英語化済みなので載せない。ここに無い states ファイルはリンターの監視下に入る
       - linters: [gosmopolitan]
-        path: '^internal/states/(action_handlers|character_equip_overlay|character_info|character_job|character_state|character_view|debug_menu|dungeon_input|factories|lib|look_around|shooting|tavern_menu)\.go$'
+        path: '^internal/states/(action_handlers|character_equip_overlay|character_info|character_job|character_state|debug_menu|dungeon_input|factories|lib|look_around|shooting|tavern_menu)\.go$'
 
   settings:
     gosmopolitan:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -54,7 +54,7 @@ linters:
       # states は UI を能動移行する。ファイル単位で除外し、英語化した画面から1枚ずつ外す。
       # main_menu は英語化済みなので載せない。ここに無い states ファイルはリンターの監視下に入る
       - linters: [gosmopolitan]
-        path: '^internal/states/(action_handlers|character_equip_overlay|character_info|character_job|character_naming|character_state|character_view|debug_menu|dungeon_input|factories|item_action_state|lib|look_around|settings_menu|shooting|shop_menu|storage_menu|tavern_menu)\.go$'
+        path: '^internal/states/(action_handlers|character_equip_overlay|character_info|character_job|character_naming|character_state|character_view|debug_menu|dungeon_input|factories|lib|look_around|settings_menu|shooting|tavern_menu)\.go$'
 
   settings:
     gosmopolitan:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -54,7 +54,7 @@ linters:
       # states は UI を能動移行する。ファイル単位で除外し、英語化した画面から1枚ずつ外す。
       # main_menu は英語化済みなので載せない。ここに無い states ファイルはリンターの監視下に入る
       - linters: [gosmopolitan]
-        path: '^internal/states/(action_handlers|character_equip_overlay|character_info|character_job|character_state|debug_menu|dungeon_input|factories|lib|look_around|shooting|tavern_menu)\.go$'
+        path: '^internal/states/(action_handlers|character_equip_overlay|character_info|character_job|character_state|debug_menu|dungeon_input|factories|lib|tavern_menu)\.go$'
 
   settings:
     gosmopolitan:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -54,7 +54,7 @@ linters:
       # states は UI を能動移行する。ファイル単位で除外し、英語化した画面から1枚ずつ外す。
       # main_menu は英語化済みなので載せない。ここに無い states ファイルはリンターの監視下に入る
       - linters: [gosmopolitan]
-        path: '^internal/states/(action_handlers|character_equip_overlay|character_info|character_job|character_naming|character_state|character_view|choice|component_debug_state|craft_menu|cube_panel|debug_menu|demo_start|dungeon_floor|dungeon_input|factories|item_action_state|lib|look_around|mapgen_visualizer|message|overworld_map|settings_menu|shooting|shop_menu|storage_menu|tavern_menu)\.go$'
+        path: '^internal/states/(action_handlers|character_equip_overlay|character_info|character_job|character_naming|character_state|character_view|craft_menu|debug_menu|dungeon_input|factories|item_action_state|lib|look_around|settings_menu|shooting|shop_menu|storage_menu|tavern_menu)\.go$'
 
   settings:
     gosmopolitan:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -54,7 +54,7 @@ linters:
       # states は UI を能動移行する。ファイル単位で除外し、英語化した画面から1枚ずつ外す。
       # main_menu は英語化済みなので載せない。ここに無い states ファイルはリンターの監視下に入る
       - linters: [gosmopolitan]
-        path: '^internal/states/(action_handlers|character_equip_overlay|character_info|character_job|character_naming|character_state|character_view|debug_menu|dungeon_input|factories|lib|look_around|settings_menu|shooting|tavern_menu)\.go$'
+        path: '^internal/states/(action_handlers|character_equip_overlay|character_info|character_job|character_state|character_view|debug_menu|dungeon_input|factories|lib|look_around|shooting|tavern_menu)\.go$'
 
   settings:
     gosmopolitan:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -37,13 +37,29 @@ linters:
     - bidichk        # 不可視の危険なUnicode（トロイソース攻撃）を検出
     - forbidigo      # t.Error/t.Fatal を禁止しtestifyの使用を強制する
     - forcetypeassert # 未チェックの型アサーションを禁止する
+    - gosmopolitan   # 文字列リテラルの日本語などを検出し、UIの源泉英語化を促す
     # - testpackage  # テストファイルの命名規約（テスト品質向上）
 
   exclusions:
     paths:
       - editor-ui/node_modules # npmパッケージ内のGoファイルを除外する
+    rules:
+      # gosmopolitan の源泉英語化 allowlist。移行が済んだ領域から外していく。
+      # テストの日本語リテラルはテスト名や assert メッセージであり、源泉英語化の対象外にする
+      - linters: [gosmopolitan]
+        path: '_test\.go$'
+      # 非UIパッケージ。errors/logs/data の日本語は後続で移行するため当面パッケージ単位で除外する
+      - linters: [gosmopolitan]
+        path: '^internal/(activity|aiinput|balance|cmd|components|config|consts|designdoc|dungeon|hooks|i18n|loader|logger|maingame|mapplanner|mapspawner|maptemplate|messagedata|overworld|raw|resources|save|screeneffect|systems|testutil|vrt|widgets|world|worldstream)/'
+      # states は UI を能動移行する。ファイル単位で除外し、英語化した画面から1枚ずつ外す。
+      # main_menu は英語化済みなので載せない。ここに無い states ファイルはリンターの監視下に入る
+      - linters: [gosmopolitan]
+        path: '^internal/states/(action_handlers|character_equip_overlay|character_info|character_job|character_naming|character_state|character_view|choice|component_debug_state|craft_menu|cube_panel|debug_menu|demo_start|dungeon_floor|dungeon_input|factories|item_action_state|lib|look_around|mapgen_visualizer|message|overworld_map|settings_menu|shooting|shop_menu|storage_menu|tavern_menu)\.go$'
 
   settings:
+    gosmopolitan:
+      # 日本語の3スクリプトを監視する。漢字・ひらがな・カタカナのリテラルを検出する
+      watch-for-scripts: [Han, Hiragana, Katakana]
     goconst:
       # テストは独立して読めることが重要で、フィクスチャ文字列の重複は許容する。
       # テストを数えないことで、テストとの合算で誤検知される本体側の指摘も消える。

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -54,7 +54,7 @@ linters:
       # states は UI を能動移行する。ファイル単位で除外し、英語化した画面から1枚ずつ外す。
       # main_menu は英語化済みなので載せない。ここに無い states ファイルはリンターの監視下に入る
       - linters: [gosmopolitan]
-        path: '^internal/states/(action_handlers|character_equip_overlay|character_info|character_job|character_naming|character_state|character_view|craft_menu|debug_menu|dungeon_input|factories|item_action_state|lib|look_around|settings_menu|shooting|shop_menu|storage_menu|tavern_menu)\.go$'
+        path: '^internal/states/(action_handlers|character_equip_overlay|character_info|character_job|character_naming|character_state|character_view|debug_menu|dungeon_input|factories|item_action_state|lib|look_around|settings_menu|shooting|shop_menu|storage_menu|tavern_menu)\.go$'
 
   settings:
     gosmopolitan:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -54,7 +54,7 @@ linters:
       # states は UI を能動移行する。ファイル単位で除外し、英語化した画面から1枚ずつ外す。
       # main_menu は英語化済みなので載せない。ここに無い states ファイルはリンターの監視下に入る
       - linters: [gosmopolitan]
-        path: '^internal/states/(action_handlers|character_equip_overlay|character_info|character_job|character_state|debug_menu|dungeon_input|factories|lib|tavern_menu)\.go$'
+        path: '^internal/states/(action_handlers|character_equip_overlay|character_job|character_state|debug_menu|dungeon_input|factories|lib|tavern_menu)\.go$'
 
   settings:
     gosmopolitan:

--- a/internal/i18n/i18n.go
+++ b/internal/i18n/i18n.go
@@ -44,14 +44,15 @@ func mustParse(path string) *gotext.Po {
 }
 
 // Translate は lang における msgid の訳を返す。未知の言語や未訳は原文の英語へフォールバックする。
+// args を渡すと訳を書式として printf 整形する。args が無ければ整形せずそのまま返す。
 //
-// gotext の Get は可変引数で printf 整形するため、直接呼ぶと go vet が非定数の書式文字列と誤検知する。
-// 整形しないのでメソッド値を介して呼び回避する。
-func (c Catalog) Translate(lang, msgid string) string {
+// gotext の Get は書式引数で printf 整形するため、直接呼ぶと go vet が非定数の書式文字列と誤検知する。
+// メソッド値を介して呼び回避する。
+func (c Catalog) Translate(lang, msgid string, args ...any) string {
 	po, ok := c.langs[lang]
 	if !ok {
 		po = c.langs[defaultLang]
 	}
 	get := po.Get
-	return get(msgid)
+	return get(msgid, args...)
 }

--- a/internal/i18n/i18n.go
+++ b/internal/i18n/i18n.go
@@ -36,7 +36,7 @@ func NewCatalog() Catalog {
 func mustParse(path string) *gotext.Po {
 	data, err := localeFS.ReadFile(path)
 	if err != nil {
-		panic(fmt.Sprintf("i18n: 埋め込み PO の読み込みに失敗した: %s: %v", path, err))
+		panic(fmt.Sprintf("i18n: failed to read embedded PO: %s: %v", path, err))
 	}
 	po := gotext.NewPo()
 	po.Parse(data)

--- a/internal/i18n/locale/ja.po
+++ b/internal/i18n/locale/ja.po
@@ -187,3 +187,225 @@ msgstr "命中率"
 
 msgid "Distance"
 msgstr "距離"
+
+msgid "Abilities"
+msgstr "能力"
+
+msgid "Skills"
+msgstr "スキル"
+
+msgid "Effects"
+msgstr "効果"
+
+msgid "Effect"
+msgstr "効果"
+
+msgid "Health"
+msgstr "健康"
+
+msgid "Basic"
+msgstr "基本"
+
+msgid "Profession"
+msgstr "職業"
+
+msgid "HP. You die at 0"
+msgstr "体力。0になると死亡する"
+
+msgid "Max weight"
+msgstr "最大重量"
+
+msgid "Maximum weight you can carry"
+msgstr "所持可能な最大重量"
+
+msgid "Hunger"
+msgstr "空腹度"
+
+msgid "Hunger. High hunger hinders actions"
+msgstr "空腹度。高いと行動に支障が出る"
+
+msgid "Ambient temperature"
+msgstr "環境気温"
+
+msgid "Temperature at current location"
+msgstr "現在地の気温"
+
+msgid "Time of day"
+msgstr "時間帯"
+
+msgid "Current time of day. Affects temperature outdoors"
+msgstr "現在の時間帯。屋外では気温に影響する"
+
+msgid "Vitality. Affects max HP and SP"
+msgstr "体力。HPとSPの最大値に影響する"
+
+msgid "Strength. Affects melee attack damage"
+msgstr "筋力。近接攻撃のダメージに影響する"
+
+msgid "Sensation. Affects ranged attack damage"
+msgstr "感覚。射撃攻撃のダメージに影響する"
+
+msgid "Dexterity. Affects accuracy"
+msgstr "器用さ。命中率に影響する"
+
+msgid "Agility. Affects evasion and action speed"
+msgstr "敏捷。回避率と行動速度に影響する"
+
+msgid "Defense. Reduces damage taken"
+msgstr "防御。被ダメージを軽減する"
+
+msgid "%s category skills"
+msgstr "%sカテゴリのスキル"
+
+msgid "Gained by"
+msgstr "獲得条件"
+
+msgid "Combat"
+msgstr "戦闘"
+
+msgid "Combat effects"
+msgstr "戦闘に関する効果"
+
+msgid "%s attack power"
+msgstr "%s攻撃力"
+
+msgid "%s weapon damage multiplier"
+msgstr "%s武器のダメージ倍率"
+
+msgid "%s accuracy"
+msgstr "%s命中"
+
+msgid "%s weapon accuracy multiplier"
+msgstr "%s武器の命中倍率"
+
+msgid "%s resistance"
+msgstr "%s耐性"
+
+msgid "%s element damage multiplier. Lower reduces more"
+msgstr "%s属性ダメージの倍率。低いほど軽減される"
+
+msgid "Survival"
+msgstr "生存"
+
+msgid "Survival effects"
+msgstr "生存に関する効果"
+
+msgid "Hypothermia progress"
+msgstr "低体温進行"
+
+msgid "Hypothermia progress rate. Lower is slower"
+msgstr "低体温の進行速度。低いほど遅くなる"
+
+msgid "Hyperthermia progress"
+msgstr "高体温進行"
+
+msgid "Hyperthermia progress rate. Lower is slower"
+msgstr "高体温の進行速度。低いほど遅くなる"
+
+msgid "Hunger progress"
+msgstr "空腹進行"
+
+msgid "Hunger progress rate. Lower is slower"
+msgstr "空腹の進行速度。低いほど遅くなる"
+
+msgid "Healing effect"
+msgstr "回復効果"
+
+msgid "Healing item effect multiplier. Higher heals more"
+msgstr "回復アイテムの効果倍率。高いほど多く回復する"
+
+msgid "Action"
+msgstr "行動"
+
+msgid "Action effects"
+msgstr "行動に関する効果"
+
+msgid "Move speed"
+msgstr "移動速度"
+
+msgid "AP cost multiplier when moving. Lower moves with less AP"
+msgstr "移動時のAPコスト倍率。低いほど少ないAPで移動できる"
+
+msgid "Discovery"
+msgstr "発見"
+
+msgid "Item discovery rate multiplier. Higher finds more"
+msgstr "アイテム発見率の倍率。高いほど見つけやすい"
+
+msgid "Detection"
+msgstr "被発見"
+
+msgid "Enemy detection distance multiplier. Lower is harder to find"
+msgstr "敵に発見される距離の倍率。低いほど見つかりにくい"
+
+msgid "Night vision"
+msgstr "暗所視界"
+
+msgid "Vision multiplier in dark. Higher sees more"
+msgstr "暗所での視界の倍率。高いほど見える"
+
+msgid "Production"
+msgstr "生産"
+
+msgid "Production and trade effects"
+msgstr "生産・取引に関する効果"
+
+msgid "Material cost"
+msgstr "素材消費"
+
+msgid "Material consumption multiplier when crafting. Lower saves materials"
+msgstr "合成時の素材消費量倍率。低いほど素材が節約できる"
+
+msgid "Craft quality"
+msgstr "合成品質"
+
+msgid "Quality multiplier when crafting. Higher makes better goods"
+msgstr "調合時の品質倍率。高いほど良い品ができる"
+
+msgid "Buy price"
+msgstr "買値"
+
+msgid "Purchase price multiplier. Lower buys cheaper"
+msgstr "買い物の価格倍率。低いほど安く買える"
+
+msgid "Sell price"
+msgstr "売値"
+
+msgid "Sell price multiplier. Higher sells higher"
+msgstr "売却の価格倍率。高いほど高く売れる"
+
+msgid "Max carry weight multiplier"
+msgstr "所持可能な最大重量の倍率"
+
+msgid "Max load"
+msgstr "最大荷重"
+
+msgid "Max load multiplier"
+msgstr "最大荷重倍率"
+
+msgid "Normal"
+msgstr "正常"
+
+msgid "Torso"
+msgstr "胴体"
+
+msgid "Head"
+msgstr "頭部"
+
+msgid "Arms"
+msgstr "腕"
+
+msgid "Hands"
+msgstr "手"
+
+msgid "Legs"
+msgstr "脚"
+
+msgid "Feet"
+msgstr "足"
+
+msgid "Whole body"
+msgstr "全身"
+
+msgid "No entries"
+msgstr "(項目なし)"

--- a/internal/i18n/locale/ja.po
+++ b/internal/i18n/locale/ja.po
@@ -88,3 +88,27 @@ msgstr "戻る"
 
 msgid "Japanese"
 msgstr "日本語"
+
+msgid "Confirm"
+msgstr "決定"
+
+msgid "Name"
+msgstr "名前"
+
+msgid "Enter a name of 1 to 10 characters"
+msgstr "名前は1〜10文字で入力してください"
+
+msgid ", . Switch"
+msgstr ", . 切替"
+
+msgid "No equipment slots"
+msgstr "装備スロットがありません"
+
+msgid "No formation orders"
+msgstr "この対象に隊列指示はない"
+
+msgid "Choose equipment"
+msgstr "装備を選ぶ"
+
+msgid "Nothing to equip"
+msgstr "装備できるものがない"

--- a/internal/i18n/locale/ja.po
+++ b/internal/i18n/locale/ja.po
@@ -40,3 +40,42 @@ msgstr "x 詳細"
 
 msgid "No recipes"
 msgstr "(レシピなし)"
+
+msgid "Buy"
+msgstr "購入"
+
+msgid "Sell"
+msgstr "売却"
+
+msgid "No goods"
+msgstr "(商品なし)"
+
+msgid "No items to sell"
+msgstr "売却可能なアイテムがありません"
+
+msgid "Retrieve"
+msgstr "取得"
+
+msgid "Store"
+msgstr "収納"
+
+msgid "No items"
+msgstr "(アイテムなし)"
+
+msgid "Inspect"
+msgstr "調べる"
+
+msgid "Drop"
+msgstr "置く"
+
+msgid "Eat"
+msgstr "食べる"
+
+msgid "Read"
+msgstr "読む"
+
+msgid "Use"
+msgstr "使う"
+
+msgid "No matching items"
+msgstr "該当するアイテムがありません"

--- a/internal/i18n/locale/ja.po
+++ b/internal/i18n/locale/ja.po
@@ -112,3 +112,78 @@ msgstr "装備を選ぶ"
 
 msgid "Nothing to equip"
 msgstr "装備できるものがない"
+
+msgid "Coord"
+msgstr "座標"
+
+msgid "Darkness"
+msgstr "暗闇"
+
+msgid "Nothing here"
+msgstr "何もありません"
+
+msgid "WASD/Arrows: Move  X/Esc: Close"
+msgstr "WASD/矢印: 移動  X/Esc: 閉じる"
+
+msgid "Durability"
+msgstr "耐久"
+
+msgid "Move cost"
+msgstr "移動コスト"
+
+msgid "Impassable"
+msgstr "不可"
+
+msgid "Temperature modifier"
+msgstr "気温修正"
+
+msgid "Indoor"
+msgstr "屋内"
+
+msgid "Waterside"
+msgstr "水辺"
+
+msgid "Foliage"
+msgstr "植生"
+
+msgid "No ranged weapon equipped"
+msgstr "射撃武器が装備されていません"
+
+msgid "Not loaded"
+msgstr "装填されていません"
+
+msgid "== Shooting Mode =="
+msgstr "== 射撃モード =="
+
+msgid "Error: player not found"
+msgstr "エラー: プレイヤーが見つかりません"
+
+msgid "No shooting target"
+msgstr "射撃対象がいません"
+
+msgid "Tab: Switch  Enter: Fire  R: Reload  Esc: Back"
+msgstr "Tab:切替 Enter:射撃 R:装填 Esc:戻る"
+
+msgid "Weapon slot: invalid"
+msgstr "武器スロット: 無効"
+
+msgid "Weapon: none"
+msgstr "武器: なし"
+
+msgid "Weapon"
+msgstr "武器"
+
+msgid "Ammo"
+msgstr "残弾"
+
+msgid "Melee weapon"
+msgstr "近接武器"
+
+msgid "Target"
+msgstr "対象"
+
+msgid "Hit rate"
+msgstr "命中率"
+
+msgid "Distance"
+msgstr "距離"

--- a/internal/i18n/locale/ja.po
+++ b/internal/i18n/locale/ja.po
@@ -79,3 +79,12 @@ msgstr "使う"
 
 msgid "No matching items"
 msgstr "該当するアイテムがありません"
+
+msgid "Language"
+msgstr "言語"
+
+msgid "Back"
+msgstr "戻る"
+
+msgid "Japanese"
+msgstr "日本語"

--- a/internal/i18n/locale/ja.po
+++ b/internal/i18n/locale/ja.po
@@ -22,3 +22,21 @@ msgstr "設定"
 
 msgid "Quit"
 msgstr "終了"
+
+msgid "Consumables"
+msgstr "道具"
+
+msgid "Weapons"
+msgstr "武器"
+
+msgid "Armor"
+msgstr "防具"
+
+msgid "Materials"
+msgstr "材料"
+
+msgid "x Details"
+msgstr "x 詳細"
+
+msgid "No recipes"
+msgstr "(レシピなし)"

--- a/internal/states/character_info.go
+++ b/internal/states/character_info.go
@@ -68,11 +68,11 @@ func (st *CharacterState) fetchInfoTabs(world w.World, player ecs.Entity) []stat
 	}
 
 	return []statusTabData{
-		{ID: tabAbilities, Label: "能力", Items: st.createAbilityItems(world, player)},
-		{ID: tabSkills, Label: "スキル", Items: st.createSkillItems(world, player)},
-		{ID: tabEffects, Label: "効果", Items: st.createEffectItems(world, player)},
-		{ID: tabHealth, Label: "健康", Items: st.createHealthItems(world, player)},
-		{ID: tabBasic, Label: "基本", Items: st.createBasicItems(world, player, envTemp, professionName)},
+		{ID: tabAbilities, Label: query.T(world, "Abilities"), Items: st.createAbilityItems(world, player)},
+		{ID: tabSkills, Label: query.T(world, "Skills"), Items: st.createSkillItems(world, player)},
+		{ID: tabEffects, Label: query.T(world, "Effects"), Items: st.createEffectItems(world, player)},
+		{ID: tabHealth, Label: query.T(world, "Health"), Items: st.createHealthItems(world, player)},
+		{ID: tabBasic, Label: query.T(world, "Basic"), Items: st.createBasicItems(world, player, envTemp, professionName)},
 	}
 }
 
@@ -80,23 +80,23 @@ func (st *CharacterState) createBasicItems(world w.World, playerEntity ecs.Entit
 	items := []statusItemData{}
 
 	if professionName != "" {
-		items = append(items, statusItemData{Label: "職業", Value: professionName, Description: "職業"})
+		items = append(items, statusItemData{Label: query.T(world, "Profession"), Value: professionName, Description: query.T(world, "Profession")})
 	}
 	if query.AliveHas(world, world.Components.HP, playerEntity) {
 		hp := world.Components.HP.Get(playerEntity)
-		items = append(items, statusItemData{Label: "HP", Value: fmt.Sprintf("%d", hp.Max), Description: "体力。0になると死亡する"})
+		items = append(items, statusItemData{Label: "HP", Value: fmt.Sprintf("%d", hp.Max), Description: query.T(world, "HP. You die at 0")})
 	}
 	if query.AliveHas(world, world.Components.WeightCapacity, playerEntity) {
 		cw := world.Components.WeightCapacity.Get(playerEntity)
-		items = append(items, statusItemData{Label: "最大重量", Value: cw.Max.KgString(), Description: "所持可能な最大重量"})
+		items = append(items, statusItemData{Label: query.T(world, "Max weight"), Value: cw.Max.KgString(), Description: query.T(world, "Maximum weight you can carry")})
 	}
 	if query.AliveHas(world, world.Components.Hunger, playerEntity) {
 		hunger := world.Components.Hunger.Get(playerEntity)
-		items = append(items, statusItemData{Label: "空腹度", Value: hunger.GetLevel().String(), Description: "空腹度。高いと行動に支障が出る"})
+		items = append(items, statusItemData{Label: query.T(world, "Hunger"), Value: hunger.GetLevel().String(), Description: query.T(world, "Hunger. High hunger hinders actions")})
 	}
 	items = append(items,
-		statusItemData{Label: "環境気温", Value: fmt.Sprintf("%d%s", envTemp, consts.IconDegree), Description: "現在地の気温"},
-		statusItemData{Label: "時間帯", Value: query.GetGameTime(world).GetTimeOfDay().String(), Description: "現在の時間帯。屋外では気温に影響する"},
+		statusItemData{Label: query.T(world, "Ambient temperature"), Value: fmt.Sprintf("%d%s", envTemp, consts.IconDegree), Description: query.T(world, "Temperature at current location")},
+		statusItemData{Label: query.T(world, "Time of day"), Value: query.GetGameTime(world).GetTimeOfDay().String(), Description: query.T(world, "Current time of day. Affects temperature outdoors")},
 	)
 	return items
 }
@@ -106,12 +106,12 @@ func (st *CharacterState) createAbilityItems(world w.World, playerEntity ecs.Ent
 	if query.AliveHas(world, world.Components.Abilities, playerEntity) {
 		abils := world.Components.Abilities.Get(playerEntity)
 		items = append(items,
-			statusItemData{Label: consts.VitalityLabel, Value: fmt.Sprintf("%d", abils.Vitality.Total), Modifier: fmt.Sprintf("(%+d)", abils.Vitality.Modifier), Description: "体力。HPとSPの最大値に影響する"},
-			statusItemData{Label: consts.StrengthLabel, Value: fmt.Sprintf("%d", abils.Strength.Total), Modifier: fmt.Sprintf("(%+d)", abils.Strength.Modifier), Description: "筋力。近接攻撃のダメージに影響する"},
-			statusItemData{Label: consts.SensationLabel, Value: fmt.Sprintf("%d", abils.Sensation.Total), Modifier: fmt.Sprintf("(%+d)", abils.Sensation.Modifier), Description: "感覚。射撃攻撃のダメージに影響する"},
-			statusItemData{Label: consts.DexterityLabel, Value: fmt.Sprintf("%d", abils.Dexterity.Total), Modifier: fmt.Sprintf("(%+d)", abils.Dexterity.Modifier), Description: "器用さ。命中率に影響する"},
-			statusItemData{Label: consts.AgilityLabel, Value: fmt.Sprintf("%d", abils.Agility.Total), Modifier: fmt.Sprintf("(%+d)", abils.Agility.Modifier), Description: "敏捷。回避率と行動速度に影響する"},
-			statusItemData{Label: consts.DefenseLabel, Value: fmt.Sprintf("%d", abils.Defense.Total), Modifier: fmt.Sprintf("(%+d)", abils.Defense.Modifier), Description: "防御。被ダメージを軽減する"},
+			statusItemData{Label: consts.VitalityLabel, Value: fmt.Sprintf("%d", abils.Vitality.Total), Modifier: fmt.Sprintf("(%+d)", abils.Vitality.Modifier), Description: query.T(world, "Vitality. Affects max HP and SP")},
+			statusItemData{Label: consts.StrengthLabel, Value: fmt.Sprintf("%d", abils.Strength.Total), Modifier: fmt.Sprintf("(%+d)", abils.Strength.Modifier), Description: query.T(world, "Strength. Affects melee attack damage")},
+			statusItemData{Label: consts.SensationLabel, Value: fmt.Sprintf("%d", abils.Sensation.Total), Modifier: fmt.Sprintf("(%+d)", abils.Sensation.Modifier), Description: query.T(world, "Sensation. Affects ranged attack damage")},
+			statusItemData{Label: consts.DexterityLabel, Value: fmt.Sprintf("%d", abils.Dexterity.Total), Modifier: fmt.Sprintf("(%+d)", abils.Dexterity.Modifier), Description: query.T(world, "Dexterity. Affects accuracy")},
+			statusItemData{Label: consts.AgilityLabel, Value: fmt.Sprintf("%d", abils.Agility.Total), Modifier: fmt.Sprintf("(%+d)", abils.Agility.Modifier), Description: query.T(world, "Agility. Affects evasion and action speed")},
+			statusItemData{Label: consts.DefenseLabel, Value: fmt.Sprintf("%d", abils.Defense.Total), Modifier: fmt.Sprintf("(%+d)", abils.Defense.Modifier), Description: query.T(world, "Defense. Reduces damage taken")},
 		)
 	}
 	return items
@@ -124,7 +124,7 @@ func (st *CharacterState) createSkillItems(world w.World, playerEntity ecs.Entit
 	}
 	skills := world.Components.Skills.Get(playerEntity)
 	for _, cat := range gc.SkillCategories {
-		items = append(items, statusItemData{Label: cat.Name, IsHeader: true, Description: fmt.Sprintf("%sカテゴリのスキル", cat.Name)})
+		items = append(items, statusItemData{Label: cat.Name, IsHeader: true, Description: query.T(world, "%s category skills", cat.Name)})
 		for _, id := range cat.IDs {
 			s := skills.Get(id)
 			expFrac := 0
@@ -137,8 +137,8 @@ func (st *CharacterState) createSkillItems(world w.World, playerEntity ecs.Entit
 				Value:       fmt.Sprintf("%d.%03d", s.Value, expFrac),
 				Description: info.Summary,
 				Details: []statusDetailRow{
-					{Label: "獲得条件", Value: info.GainedBy},
-					{Label: "効果", Value: info.Effect},
+					{Label: query.T(world, "Gained by"), Value: info.GainedBy},
+					{Label: query.T(world, "Effect"), Value: info.Effect},
 				},
 			})
 		}
@@ -153,49 +153,49 @@ func (st *CharacterState) createEffectItems(world w.World, playerEntity ecs.Enti
 	}
 	e := world.Components.CharModifiers.Get(playerEntity)
 
-	items = append(items, statusItemData{Label: "戦闘", IsHeader: true, Description: "戦闘に関する効果"})
+	items = append(items, statusItemData{Label: query.T(world, "Combat"), IsHeader: true, Description: query.T(world, "Combat effects")})
 	for _, id := range gc.AllSkillIDs {
 		if mult, ok := e.WeaponDamage[id]; ok {
 			name := gc.SkillName(id)
-			items = append(items, statusItemData{Label: name + "攻撃力", Value: fmt.Sprintf("%d%%", mult), Description: fmt.Sprintf("%s武器のダメージ倍率", name), Details: sourceToDetails(e.Sources, gc.WeaponDamageKey(id))})
+			items = append(items, statusItemData{Label: query.T(world, "%s attack power", name), Value: fmt.Sprintf("%d%%", mult), Description: query.T(world, "%s weapon damage multiplier", name), Details: sourceToDetails(e.Sources, gc.WeaponDamageKey(id))})
 		}
 	}
 	for _, id := range gc.AllSkillIDs {
 		if mult, ok := e.WeaponAccuracy[id]; ok {
 			name := gc.SkillName(id)
-			items = append(items, statusItemData{Label: name + "命中", Value: fmt.Sprintf("%d%%", mult), Description: fmt.Sprintf("%s武器の命中倍率", name), Details: sourceToDetails(e.Sources, gc.WeaponAccuracyKey(id))})
+			items = append(items, statusItemData{Label: query.T(world, "%s accuracy", name), Value: fmt.Sprintf("%d%%", mult), Description: query.T(world, "%s weapon accuracy multiplier", name), Details: sourceToDetails(e.Sources, gc.WeaponAccuracyKey(id))})
 		}
 	}
 	for _, elem := range []gc.ElementType{gc.ElementTypeFire, gc.ElementTypeThunder, gc.ElementTypeChill, gc.ElementTypePhoton} {
 		if mult, ok := e.ElementResist[elem]; ok {
-			items = append(items, statusItemData{Label: elem.String() + "耐性", Value: fmt.Sprintf("%d%%", mult), Description: fmt.Sprintf("%s属性ダメージの倍率。低いほど軽減される", elem.String()), Details: sourceToDetails(e.Sources, gc.ElementResistKey(elem))})
+			items = append(items, statusItemData{Label: query.T(world, "%s resistance", elem.String()), Value: fmt.Sprintf("%d%%", mult), Description: query.T(world, "%s element damage multiplier. Lower reduces more", elem.String()), Details: sourceToDetails(e.Sources, gc.ElementResistKey(elem))})
 		}
 	}
 
-	items = append(items, statusItemData{Label: "生存", IsHeader: true, Description: "生存に関する効果"})
+	items = append(items, statusItemData{Label: query.T(world, "Survival"), IsHeader: true, Description: query.T(world, "Survival effects")})
 	items = append(items,
-		statusItemData{Label: "低体温進行", Value: fmt.Sprintf("%d%%", e.ColdProgress), Description: "低体温の進行速度。低いほど遅くなる", Details: sourceToDetails(e.Sources, gc.ModColdProgress)},
-		statusItemData{Label: "高体温進行", Value: fmt.Sprintf("%d%%", e.HeatProgress), Description: "高体温の進行速度。低いほど遅くなる", Details: sourceToDetails(e.Sources, gc.ModHeatProgress)},
-		statusItemData{Label: "空腹進行", Value: fmt.Sprintf("%d%%", e.HungerProgress), Description: "空腹の進行速度。低いほど遅くなる", Details: sourceToDetails(e.Sources, gc.ModHungerProgress)},
-		statusItemData{Label: "回復効果", Value: fmt.Sprintf("%d%%", e.HealingEffect), Description: "回復アイテムの効果倍率。高いほど多く回復する", Details: sourceToDetails(e.Sources, gc.ModHealingEffect)},
+		statusItemData{Label: query.T(world, "Hypothermia progress"), Value: fmt.Sprintf("%d%%", e.ColdProgress), Description: query.T(world, "Hypothermia progress rate. Lower is slower"), Details: sourceToDetails(e.Sources, gc.ModColdProgress)},
+		statusItemData{Label: query.T(world, "Hyperthermia progress"), Value: fmt.Sprintf("%d%%", e.HeatProgress), Description: query.T(world, "Hyperthermia progress rate. Lower is slower"), Details: sourceToDetails(e.Sources, gc.ModHeatProgress)},
+		statusItemData{Label: query.T(world, "Hunger progress"), Value: fmt.Sprintf("%d%%", e.HungerProgress), Description: query.T(world, "Hunger progress rate. Lower is slower"), Details: sourceToDetails(e.Sources, gc.ModHungerProgress)},
+		statusItemData{Label: query.T(world, "Healing effect"), Value: fmt.Sprintf("%d%%", e.HealingEffect), Description: query.T(world, "Healing item effect multiplier. Higher heals more"), Details: sourceToDetails(e.Sources, gc.ModHealingEffect)},
 	)
 
-	items = append(items, statusItemData{Label: "行動", IsHeader: true, Description: "行動に関する効果"})
+	items = append(items, statusItemData{Label: query.T(world, "Action"), IsHeader: true, Description: query.T(world, "Action effects")})
 	items = append(items,
-		statusItemData{Label: "移動速度", Value: fmt.Sprintf("%d%%", e.MoveCost), Description: "移動時のAPコスト倍率。低いほど少ないAPで移動できる", Details: sourceToDetails(e.Sources, gc.ModMoveCost)},
-		statusItemData{Label: "発見", Value: fmt.Sprintf("%d%%", e.Exploration), Description: "アイテム発見率の倍率。高いほど見つけやすい", Details: sourceToDetails(e.Sources, gc.ModExploration)},
-		statusItemData{Label: "被発見", Value: fmt.Sprintf("%d%%", e.EnemyVision), Description: "敵に発見される距離の倍率。低いほど見つかりにくい", Details: sourceToDetails(e.Sources, gc.ModEnemyVision)},
-		statusItemData{Label: "暗所視界", Value: fmt.Sprintf("%d%%", e.NightVision), Description: "暗所での視界の倍率。高いほど見える", Details: sourceToDetails(e.Sources, gc.ModNightVision)},
+		statusItemData{Label: query.T(world, "Move speed"), Value: fmt.Sprintf("%d%%", e.MoveCost), Description: query.T(world, "AP cost multiplier when moving. Lower moves with less AP"), Details: sourceToDetails(e.Sources, gc.ModMoveCost)},
+		statusItemData{Label: query.T(world, "Discovery"), Value: fmt.Sprintf("%d%%", e.Exploration), Description: query.T(world, "Item discovery rate multiplier. Higher finds more"), Details: sourceToDetails(e.Sources, gc.ModExploration)},
+		statusItemData{Label: query.T(world, "Detection"), Value: fmt.Sprintf("%d%%", e.EnemyVision), Description: query.T(world, "Enemy detection distance multiplier. Lower is harder to find"), Details: sourceToDetails(e.Sources, gc.ModEnemyVision)},
+		statusItemData{Label: query.T(world, "Night vision"), Value: fmt.Sprintf("%d%%", e.NightVision), Description: query.T(world, "Vision multiplier in dark. Higher sees more"), Details: sourceToDetails(e.Sources, gc.ModNightVision)},
 	)
 
-	items = append(items, statusItemData{Label: "生産", IsHeader: true, Description: "生産・取引に関する効果"})
+	items = append(items, statusItemData{Label: query.T(world, "Production"), IsHeader: true, Description: query.T(world, "Production and trade effects")})
 	items = append(items,
-		statusItemData{Label: "素材消費", Value: fmt.Sprintf("%d%%", e.CraftCost), Description: "合成時の素材消費量倍率。低いほど素材が節約できる", Details: sourceToDetails(e.Sources, gc.ModCraftCost)},
-		statusItemData{Label: "合成品質", Value: fmt.Sprintf("%d%%", e.SmithQuality), Description: "調合時の品質倍率。高いほど良い品ができる", Details: sourceToDetails(e.Sources, gc.ModSmithQuality)},
-		statusItemData{Label: "買値", Value: fmt.Sprintf("%d%%", e.BuyPrice), Description: "買い物の価格倍率。低いほど安く買える", Details: sourceToDetails(e.Sources, gc.ModBuyPrice)},
-		statusItemData{Label: "売値", Value: fmt.Sprintf("%d%%", e.SellPrice), Description: "売却の価格倍率。高いほど高く売れる", Details: sourceToDetails(e.Sources, gc.ModSellPrice)},
-		statusItemData{Label: "最大重量", Value: fmt.Sprintf("%d%%", e.MaxWeight), Description: "所持可能な最大重量の倍率", Details: sourceToDetails(e.Sources, gc.ModMaxWeight)},
-		statusItemData{Label: "最大荷重", Value: fmt.Sprintf("%d%%", e.HeavyArmor), Description: "最大荷重倍率", Details: sourceToDetails(e.Sources, gc.ModHeavyArmor)},
+		statusItemData{Label: query.T(world, "Material cost"), Value: fmt.Sprintf("%d%%", e.CraftCost), Description: query.T(world, "Material consumption multiplier when crafting. Lower saves materials"), Details: sourceToDetails(e.Sources, gc.ModCraftCost)},
+		statusItemData{Label: query.T(world, "Craft quality"), Value: fmt.Sprintf("%d%%", e.SmithQuality), Description: query.T(world, "Quality multiplier when crafting. Higher makes better goods"), Details: sourceToDetails(e.Sources, gc.ModSmithQuality)},
+		statusItemData{Label: query.T(world, "Buy price"), Value: fmt.Sprintf("%d%%", e.BuyPrice), Description: query.T(world, "Purchase price multiplier. Lower buys cheaper"), Details: sourceToDetails(e.Sources, gc.ModBuyPrice)},
+		statusItemData{Label: query.T(world, "Sell price"), Value: fmt.Sprintf("%d%%", e.SellPrice), Description: query.T(world, "Sell price multiplier. Higher sells higher"), Details: sourceToDetails(e.Sources, gc.ModSellPrice)},
+		statusItemData{Label: query.T(world, "Max weight"), Value: fmt.Sprintf("%d%%", e.MaxWeight), Description: query.T(world, "Max carry weight multiplier"), Details: sourceToDetails(e.Sources, gc.ModMaxWeight)},
+		statusItemData{Label: query.T(world, "Max load"), Value: fmt.Sprintf("%d%%", e.HeavyArmor), Description: query.T(world, "Max load multiplier"), Details: sourceToDetails(e.Sources, gc.ModHeavyArmor)},
 	)
 	return items
 }
@@ -220,9 +220,9 @@ func (st *CharacterState) createHealthItems(world w.World, playerEntity ecs.Enti
 		}
 		value := conditionStr.String()
 		if value == "" {
-			value = "正常"
+			value = query.T(world, "Normal")
 		}
-		items = append(items, statusItemData{Label: part.String(), Value: value, Description: getHealthPartDescription(part), BodyPart: part})
+		items = append(items, statusItemData{Label: part.String(), Value: value, Description: query.T(world, getHealthPartDescription(part)), BodyPart: part})
 	}
 	return items
 }
@@ -230,19 +230,19 @@ func (st *CharacterState) createHealthItems(world w.World, playerEntity ecs.Enti
 func getHealthPartDescription(part gc.BodyPart) string {
 	switch part {
 	case gc.BodyPartTorso:
-		return "胴体"
+		return "Torso"
 	case gc.BodyPartHead:
-		return "頭部"
+		return "Head"
 	case gc.BodyPartArms:
-		return "腕"
+		return "Arms"
 	case gc.BodyPartHands:
-		return "手"
+		return "Hands"
 	case gc.BodyPartLegs:
-		return "脚"
+		return "Legs"
 	case gc.BodyPartFeet:
-		return "足"
+		return "Feet"
 	case gc.BodyPartWholeBody:
-		return "全身"
+		return "Whole body"
 	default:
 		return ""
 	}
@@ -266,7 +266,7 @@ func sourceToDetails(sources map[gc.ModifierKey][]gc.ModifierSource, key gc.Modi
 
 // buildInfoTable は読み取り専用タブのアイテム一覧をテーブルで組み立てる
 // buildInfoTable は情報タブの一覧を組み立てる。能力タブは補正列を加える
-func buildInfoTable(tab statusTabData, itemIndex int, res resources.UIResources) *widget.Container {
+func buildInfoTable(world w.World, tab statusTabData, itemIndex int, res resources.UIResources) *widget.Container {
 	hasModifier := tab.ID == tabAbilities
 	var columnWidths []int
 	var aligns []styled.TextAlign
@@ -290,5 +290,5 @@ func buildInfoTable(tab statusTabData, itemIndex int, res resources.UIResources)
 		}
 		rows[i] = menuRow{Cells: cells, Header: it.IsHeader}
 	}
-	return renderMenuList(itemIndex, rows, columnWidths, aligns, menuListOpts{AlwaysIndicator: true, EmptyText: "(項目なし)"}, res)
+	return renderMenuList(itemIndex, rows, columnWidths, aligns, menuListOpts{AlwaysIndicator: true, EmptyText: query.T(world, "No entries")}, res)
 }

--- a/internal/states/character_naming.go
+++ b/internal/states/character_naming.go
@@ -144,7 +144,7 @@ func (st *CharacterNamingState) DoAction(world w.World, action inputmapper.Actio
 	case inputmapper.ActionMenuSelect:
 		return st.confirmName(world), nil
 	default:
-		return es.Transition[w.World]{}, fmt.Errorf("characterNaming: 未対応のアクション: %s", action)
+		return es.Transition[w.World]{}, fmt.Errorf("characterNaming: unsupported action: %s", action)
 	}
 }
 
@@ -167,7 +167,7 @@ func (st *CharacterNamingState) confirmName(world w.World) es.Transition[w.World
 	if nameLen < nameMinLength || nameLen > nameMaxLength {
 		st.mount.SetProps(namingProps{
 			CurrentName:  props.CurrentName,
-			ErrorMessage: "名前は1〜10文字で入力してください",
+			ErrorMessage: query.T(world, "Enter a name of 1 to 10 characters"),
 		})
 		_, startTimer, _ := hooks.UseTimer(st.mount.Store(), "errorTimer", errorDisplayTime)
 		startTimer()
@@ -228,7 +228,7 @@ func (st *CharacterNamingState) buildUI(world w.World) *ebitenui.UI {
 	)
 
 	titleLabel := widget.NewText(
-		widget.TextOpts.Text("名前", &res.Text.TitleFontFace, theme.TextPrimary),
+		widget.TextOpts.Text(query.T(world, "Name"), &res.Text.TitleFontFace, theme.TextPrimary),
 		widget.TextOpts.WidgetOpts(
 			widget.WidgetOpts.LayoutData(widget.RowLayoutData{
 				Position: widget.RowLayoutPositionCenter,
@@ -250,7 +250,7 @@ func (st *CharacterNamingState) buildUI(world w.World) *ebitenui.UI {
 			widget.TextInputOpts.Face(&res.TextInput.Face),
 			widget.TextInputOpts.Color(res.TextInput.Color),
 			widget.TextInputOpts.Padding(&res.TextInput.Padding),
-			widget.TextInputOpts.Placeholder("名前"),
+			widget.TextInputOpts.Placeholder(query.T(world, "Name")),
 		)
 		ti.SetText(props.CurrentName)
 		ti.Focus(true)
@@ -269,7 +269,7 @@ func (st *CharacterNamingState) buildUI(world w.World) *ebitenui.UI {
 
 	// 操作ヒント
 	hintLabel := widget.NewText(
-		widget.TextOpts.Text(consts.IconKeyEnter+" 決定 / "+consts.IconKeyEsc+" 戻る", &res.Text.SmallFace, theme.TextAccent),
+		widget.TextOpts.Text(consts.IconKeyEnter+" "+query.T(world, "Confirm")+" / "+consts.IconKeyEsc+" "+query.T(world, "Back"), &res.Text.SmallFace, theme.TextAccent),
 		widget.TextOpts.WidgetOpts(
 			widget.WidgetOpts.LayoutData(widget.RowLayoutData{
 				Position: widget.RowLayoutPositionCenter,

--- a/internal/states/character_view.go
+++ b/internal/states/character_view.go
@@ -12,11 +12,12 @@ import (
 	"github.com/kijimaD/ruins/internal/widgets/styled"
 	"github.com/kijimaD/ruins/internal/widgets/theme"
 	w "github.com/kijimaD/ruins/internal/world"
+	"github.com/kijimaD/ruins/internal/world/query"
 )
 
-// View は人物画面のタブ本体を props と選択位置だけから組み立てる純粋描画。world には触れず、
+// View は人物画面のタブ本体を props と選択位置から組み立てる描画。ラベルの訳のみ world から引く。
 // 詳細や装備選択のオーバーレイ窓は Screen が重ねる。menurt.Model の View 部にあたる
-func (st *CharacterState) View(_ w.World, props CharacterProps, cursor menurt.Selection, res resources.UIResources) *ebitenui.UI {
+func (st *CharacterState) View(world w.World, props CharacterProps, cursor menurt.Selection, res resources.UIResources) *ebitenui.UI {
 	// 見出しは対象キャラ名。仲間がいれば左右矢印で切替可能を示す。
 	// 矢印は素の記号だとフォントに無く文字化けするため FontAwesome のアイコンを使う
 	header := props.TargetName
@@ -27,18 +28,18 @@ func (st *CharacterState) View(_ w.World, props CharacterProps, cursor menurt.Se
 	// コンテンツは現在タブの中身。装備は編集可能、以降は読み取り専用の情報タブ
 	var content *widget.Container
 	if charTabAt(cursor.TabIndex) == charTabEquip {
-		content = buildEquipList(props.EquipSlots, cursor.ItemIndex, res)
+		content = buildEquipList(world, props.EquipSlots, cursor.ItemIndex, res)
 	} else if charTabAt(cursor.TabIndex) == charTabCommand {
-		content = buildCommandTable(props.Commands, cursor.ItemIndex, res)
+		content = buildCommandTable(world, props.Commands, cursor.ItemIndex, res)
 	} else if infoIdx := cursor.TabIndex - charFirstInfoTab; infoIdx >= 0 && infoIdx < len(props.InfoTabs) {
 		content = buildInfoTable(props.InfoTabs[infoIdx], cursor.ItemIndex, res)
 	} else {
 		content = widget.NewContainer()
 	}
 
-	extras := []string{"x 詳細"}
+	extras := []string{query.T(world, "x Details")}
 	if props.HasMultiple {
-		extras = []string{", . 切替", "x 詳細"}
+		extras = []string{query.T(world, ", . Switch"), query.T(world, "x Details")}
 	}
 
 	return newTabScreenUI(res, tabScreen{
@@ -51,35 +52,35 @@ func (st *CharacterState) View(_ w.World, props CharacterProps, cursor menurt.Se
 }
 
 // buildEquipList は装備タブの一覧を組み立てる。左にスロット名、右に装備名を並べ、未装備は空欄にする
-func buildEquipList(slots []equipItemData, itemIndex int, res resources.UIResources) *widget.Container {
+func buildEquipList(world w.World, slots []equipItemData, itemIndex int, res resources.UIResources) *widget.Container {
 	columnWidths := []int{120, 220}
 	aligns := []styled.TextAlign{styled.AlignLeft, styled.AlignLeft}
 	rows := make([]menuRow, len(slots))
 	for i, slot := range slots {
 		rows[i] = menuRow{Cells: []string{slot.SlotLabel, slot.ItemName}}
 	}
-	return renderMenuList(itemIndex, rows, columnWidths, aligns, menuListOpts{AlwaysIndicator: true, EmptyText: "装備スロットがありません"}, res)
+	return renderMenuList(itemIndex, rows, columnWidths, aligns, menuListOpts{AlwaysIndicator: true, EmptyText: query.T(world, "No equipment slots")}, res)
 }
 
 // buildCommandTable は命令タブの一覧を組み立てる。左に指示名、右に現在の値を並べる
-func buildCommandTable(cmdRows []commandRow, itemIndex int, res resources.UIResources) *widget.Container {
+func buildCommandTable(world w.World, cmdRows []commandRow, itemIndex int, res resources.UIResources) *widget.Container {
 	columnWidths := []int{180, 160}
 	aligns := []styled.TextAlign{styled.AlignLeft, styled.AlignLeft}
 	rows := make([]menuRow, len(cmdRows))
 	for i, row := range cmdRows {
 		rows[i] = menuRow{Cells: []string{string(row.Kind), row.Value}}
 	}
-	return renderMenuList(itemIndex, rows, columnWidths, aligns, menuListOpts{AlwaysIndicator: true, EmptyText: "この対象に隊列指示はない"}, res)
+	return renderMenuList(itemIndex, rows, columnWidths, aligns, menuListOpts{AlwaysIndicator: true, EmptyText: query.T(world, "No formation orders")}, res)
 }
 
 // buildEquipSelectWindow は装備選択のサブウィンドウを rect の位置へ組み立てる。
 // 候補名は world から引くため world を受け取るが、選択状態は selectedIndex で明示的に渡す
 func buildEquipSelectWindow(world w.World, props charEquipProps, selectedIndex int, rect image.Rectangle, res resources.UIResources) *widget.Window {
 	content := styled.NewWindowContainer(res)
-	title := styled.NewWindowHeaderContainer("装備を選ぶ", res)
+	title := styled.NewWindowHeaderContainer(query.T(world, "Choose equipment"), res)
 	win := styled.NewSmallWindow(title, content)
 	if len(props.Items) == 0 {
-		content.AddChild(styled.NewDescriptionText("装備できるものがない", res))
+		content.AddChild(styled.NewDescriptionText(query.T(world, "Nothing to equip"), res))
 	}
 	for i, entity := range props.Items {
 		name := world.Components.Name.Get(entity).Name

--- a/internal/states/character_view.go
+++ b/internal/states/character_view.go
@@ -32,7 +32,7 @@ func (st *CharacterState) View(world w.World, props CharacterProps, cursor menur
 	} else if charTabAt(cursor.TabIndex) == charTabCommand {
 		content = buildCommandTable(world, props.Commands, cursor.ItemIndex, res)
 	} else if infoIdx := cursor.TabIndex - charFirstInfoTab; infoIdx >= 0 && infoIdx < len(props.InfoTabs) {
-		content = buildInfoTable(props.InfoTabs[infoIdx], cursor.ItemIndex, res)
+		content = buildInfoTable(world, props.InfoTabs[infoIdx], cursor.ItemIndex, res)
 	} else {
 		content = widget.NewContainer()
 	}

--- a/internal/states/choice.go
+++ b/internal/states/choice.go
@@ -76,7 +76,7 @@ func (st *ChoiceMenuState) DoAction(world w.World, action inputmapper.ActionID) 
 	case inputmapper.ActionMenuUp, inputmapper.ActionMenuDown, inputmapper.ActionMenuLeft, inputmapper.ActionMenuRight, inputmapper.ActionMenuTabNext, inputmapper.ActionMenuTabPrev:
 		// Dispatch で処理される
 	default:
-		return es.Transition[w.World]{}, fmt.Errorf("choiceMenu: 未対応のアクション: %s", action)
+		return es.Transition[w.World]{}, fmt.Errorf("choiceMenu: unsupported action: %s", action)
 	}
 	return es.Transition[w.World]{Type: es.TransNone}, nil
 }

--- a/internal/states/component_debug_state.go
+++ b/internal/states/component_debug_state.go
@@ -49,7 +49,7 @@ func (st *ComponentDebugState) DoAction(_ w.World, action inputmapper.ActionID) 
 	case inputmapper.ActionMenuUp, inputmapper.ActionMenuDown, inputmapper.ActionMenuSelect:
 		return es.Transition[w.World]{Type: es.TransNone}, nil
 	default:
-		return es.Transition[w.World]{}, fmt.Errorf("未知のアクション: %s", action)
+		return es.Transition[w.World]{}, fmt.Errorf("unknown action: %s", action)
 	}
 }
 
@@ -126,7 +126,7 @@ func (st *ComponentDebugState) View(_ w.World, props ComponentDebugProps, cursor
 
 	// in-game モーダルの共通骨組みに揃える。見出しは合計数、下部にキー案内を常設する
 	return newTabScreenUI(res, tabScreen{
-		Header:  fmt.Sprintf("コンポーネント (合計: %d)", props.Total),
+		Header:  fmt.Sprintf("Components total: %d", props.Total),
 		Content: container,
 		Footer:  menuNavHint(false),
 	})

--- a/internal/states/craft_menu.go
+++ b/internal/states/craft_menu.go
@@ -84,7 +84,7 @@ func (st *CraftMenuState) DoAction(world w.World, action inputmapper.ActionID) (
 	case inputmapper.ActionMenuUp, inputmapper.ActionMenuDown, inputmapper.ActionMenuLeft, inputmapper.ActionMenuRight, inputmapper.ActionMenuTabNext, inputmapper.ActionMenuTabPrev:
 		// Dispatchで処理される
 	default:
-		return es.Transition[w.World]{}, fmt.Errorf("craftMenu: 未対応のアクション: %s", action)
+		return es.Transition[w.World]{}, fmt.Errorf("craftMenu: unsupported action: %s", action)
 	}
 	return es.Transition[w.World]{Type: es.TransNone}, nil
 }
@@ -127,9 +127,9 @@ func (st *CraftMenuState) Menu(props CraftProps) menurt.MenuConfig {
 
 func (st *CraftMenuState) createTabs(world w.World) []craftTabData {
 	return []craftTabData{
-		{ID: "consumables", Label: "道具", Items: st.createMenuItems(world, st.queryMenuConsumable(world))},
-		{ID: "weapons", Label: "武器", Items: st.createMenuItems(world, st.queryMenuWeapon(world))},
-		{ID: "wearables", Label: "防具", Items: st.createMenuItems(world, st.queryMenuWearable(world))},
+		{ID: "consumables", Label: query.T(world, "Consumables"), Items: st.createMenuItems(world, st.queryMenuConsumable(world))},
+		{ID: "weapons", Label: query.T(world, "Weapons"), Items: st.createMenuItems(world, st.queryMenuWeapon(world))},
+		{ID: "wearables", Label: query.T(world, "Armor"), Items: st.createMenuItems(world, st.queryMenuWearable(world))},
 	}
 }
 
@@ -212,7 +212,7 @@ func (st *CraftMenuState) craftSelected(world w.World) error {
 	}
 	resultEntity, err := gameaction.Craft(world, item.RecipeName)
 	if err != nil {
-		return fmt.Errorf("合成に失敗: %w", err)
+		return fmt.Errorf("failed to craft: %w", err)
 	}
 	st.resultEntity = resultEntity
 	st.result.Open()
@@ -246,7 +246,7 @@ func (st *CraftMenuState) resultDetailContent(world w.World) (menuscreen.DetailC
 // ================
 
 // View は props を UI へ組む純粋な描画。menurt.Model の View 部にあたる
-func (st *CraftMenuState) View(_ w.World, props CraftProps, cursor menurt.Selection, res resources.UIResources) *ebitenui.UI {
+func (st *CraftMenuState) View(world w.World, props CraftProps, cursor menurt.Selection, res resources.UIResources) *ebitenui.UI {
 	// カテゴリはタブ帯に寄せ、本体は名前のみの1カラム一覧にする。性能・材料・説明は x の詳細モーダルで見る
 	labels := make([]string, len(props.Tabs))
 	for i, tab := range props.Tabs {
@@ -255,12 +255,12 @@ func (st *CraftMenuState) View(_ w.World, props CraftProps, cursor menurt.Select
 	return newTabScreenUI(res, tabScreen{
 		TabLabels: labels,
 		TabIndex:  cursor.TabIndex,
-		Content:   st.buildItemContainer(props.Tabs, cursor.TabIndex, cursor.ItemIndex, res),
-		Footer:    menuNavHint(true, "x 詳細"),
+		Content:   st.buildItemContainer(world, props.Tabs, cursor.TabIndex, cursor.ItemIndex, res),
+		Footer:    menuNavHint(true, query.T(world, "x Details")),
 	})
 }
 
-func (st *CraftMenuState) buildItemContainer(tabs []craftTabData, tabIndex, itemIndex int, res resources.UIResources) *widget.Container {
+func (st *CraftMenuState) buildItemContainer(world w.World, tabs []craftTabData, tabIndex, itemIndex int, res resources.UIResources) *widget.Container {
 	if tabIndex >= len(tabs) {
 		return styled.NewVerticalContainer()
 	}
@@ -277,7 +277,7 @@ func (st *CraftMenuState) buildItemContainer(tabs []craftTabData, tabIndex, item
 		}
 		rows[i] = menuRow{Cells: []string{mark, it.RecipeName}}
 	}
-	return renderMenuList(itemIndex, rows, columnWidths, aligns, menuListOpts{AlwaysIndicator: true, EmptyText: "(レシピなし)"}, res)
+	return renderMenuList(itemIndex, rows, columnWidths, aligns, menuListOpts{AlwaysIndicator: true, EmptyText: query.T(world, "No recipes")}, res)
 }
 
 // detailContent は現在カーソルが当たっているレシピの性能・材料・説明を返す。詳細モーダルの唯一の定義点
@@ -295,7 +295,7 @@ func (st *CraftMenuState) detailContent(world w.World) (menuscreen.DetailContent
 	// その後ろに生成物の性能行を続ける
 	var rows []menuscreen.SpecRow
 	if spec.Recipe != nil {
-		rows = append(rows, menuscreen.SpecRow{Label: "材料", Header: true})
+		rows = append(rows, menuscreen.SpecRow{Label: query.T(world, "Materials"), Header: true})
 		for _, in := range spec.Recipe.Inputs {
 			owned := 0
 			if entity, found := query.FindStackableInInventory(world, in.Name); found {

--- a/internal/states/cube_panel.go
+++ b/internal/states/cube_panel.go
@@ -68,10 +68,10 @@ func (st *CubePanelState) Draw(world w.World, screen *ebiten.Image) error {
 		y += 28
 	}
 
-	line("コントロールパネル", theme.TextPrimary)
+	line("Control Panel", theme.TextPrimary)
 	y += 8
-	line(fmt.Sprintf("総重量: %s", st.totalWeight.KgString()), theme.TextPrimary)
+	line(fmt.Sprintf("Total Weight: %s", st.totalWeight.KgString()), theme.TextPrimary)
 	y += 8
-	line("Esc で閉じる", theme.TextAccent)
+	line("Esc to close", theme.TextAccent)
 	return nil
 }

--- a/internal/states/demo_start.go
+++ b/internal/states/demo_start.go
@@ -24,18 +24,18 @@ type DemoStartState struct {
 func (st *DemoStartState) OnStart(world w.World) error {
 	player, err := lifecycle.SpawnPlayer(world, consts.Coord[consts.Tile]{X: 5, Y: 5}, "Ash")
 	if err != nil {
-		return fmt.Errorf("プレイヤーの生成に失敗: %w", err)
+		return fmt.Errorf("failed to spawn player: %w", err)
 	}
 
 	professions := raw.PtrSlice(world.Resources.RawMaster.Professions)
 	if len(professions) > 0 {
 		if err := gameaction.ApplyProfession(world, player, professions[0]); err != nil {
-			return fmt.Errorf("職業の適用に失敗: %w", err)
+			return fmt.Errorf("failed to apply profession: %w", err)
 		}
 	}
 
 	if _, err := lifecycle.SpawnDefaultSquadMember(world, player); err != nil {
-		return fmt.Errorf("初期隊員の生成に失敗: %w", err)
+		return fmt.Errorf("failed to spawn initial members: %w", err)
 	}
 
 	st.SetTransition(es.Transition[w.World]{

--- a/internal/states/dungeon_floor.go
+++ b/internal/states/dungeon_floor.go
@@ -25,11 +25,11 @@ import (
 func resolveDungeonDefinition(defName string) (*dungeon.DungeonDefinition, error) {
 	def, found := dungeon.GetStageDefinition(defName)
 	if !found {
-		return nil, fmt.Errorf("ステージ定義が見つかりません: %s", defName)
+		return nil, fmt.Errorf("stage definition not found: %s", defName)
 	}
 	dk, ok := def.(*dungeon.DungeonDefinition)
 	if !ok {
-		return nil, fmt.Errorf("フロア生成できないステージ定義です: %s", defName)
+		return nil, fmt.Errorf("stage definition cannot generate a floor: %s", defName)
 	}
 	return dk, nil
 }
@@ -159,7 +159,7 @@ func (st *DungeonState) descend(world w.World) error {
 	if !ok {
 		// 訪問済みの階には必ず上り階段があるはず。無ければステージ切替済みで
 		// プレイヤーが元座標に取り残されるので、silent にせず error にする
-		return fmt.Errorf("再訪した階に上り階段が見つかりません: 深度%d", nextDepth)
+		return fmt.Errorf("no up stairs found on revisited floor: depth %d", nextDepth)
 	}
 	return lifecycle.MovePlayerToPosition(world, pos)
 }
@@ -171,7 +171,7 @@ func (st *DungeonState) descend(world w.World) error {
 // フロア遷移と違い state を使わないので DungeonState のメソッドでなく自由関数にする。
 func enterCube(world w.World, cube ecs.Entity) error {
 	if !world.Components.GridElement.Has(cube) {
-		return fmt.Errorf("キューブに位置がありません")
+		return fmt.Errorf("cube has no position")
 	}
 	player, err := query.GetPlayerEntity(world)
 	if err != nil {
@@ -187,7 +187,7 @@ func enterCube(world w.World, cube ecs.Entity) error {
 	// 出口 prop の位置が入場点。戻り先をプレイヤーの元タイルへ貼り直す
 	exitProp, exitPos, ok := findPortal(world, gc.InteractionExitCube)
 	if !ok {
-		return fmt.Errorf("キューブ内部に出口が見つかりません")
+		return fmt.Errorf("no exit found inside cube")
 	}
 	if err := setPortalConnection(world, exitProp, gc.NewOverworldStage(), returnPos); err != nil {
 		return err
@@ -200,16 +200,16 @@ func enterCube(world w.World, cube ecs.Entity) error {
 func exitCube(world w.World) error {
 	exitProp, _, ok := findPortal(world, gc.InteractionExitCube)
 	if !ok {
-		return fmt.Errorf("キューブ内部に出口が見つかりません")
+		return fmt.Errorf("no exit found inside cube")
 	}
 	if !world.Components.PortalConnection.Has(exitProp) {
-		return fmt.Errorf("出口に戻り先が結線されていません")
+		return fmt.Errorf("exit has no return destination wired")
 	}
 	conn := world.Components.PortalConnection.Get(exitProp)
 	target := conn.Stage
 	returnPos := conn.Coord
 	if err := stage.SwapTo(world, target, func(w.World, gc.StageKey) error {
-		return fmt.Errorf("戻り先のオーバーワールドが存在しません")
+		return fmt.Errorf("return destination overworld does not exist")
 	}); err != nil {
 		return err
 	}
@@ -292,7 +292,7 @@ func (st *DungeonState) ascend(world w.World) (bool, error) {
 
 	// 上り先は訪問済み前提。未訪問なら生成でなくエラーにする
 	if err := stage.SwapTo(world, target, func(_ w.World, _ gc.StageKey) error {
-		return fmt.Errorf("上り先の階が存在しません: %+v", target)
+		return fmt.Errorf("destination floor above does not exist: %+v", target)
 	}); err != nil {
 		return false, err
 	}
@@ -372,7 +372,7 @@ func (st *DungeonState) enterDungeonWith(world w.World, defName string, builderT
 	// 無ければプレイヤーが元座標に取り残されるので silent にせず error にする
 	pos, ok := findPortalPosition(world, gc.InteractionPortalPrev)
 	if !ok {
-		return fmt.Errorf("再訪した遺跡に上り階段が見つかりません: %s", defName)
+		return fmt.Errorf("no up stairs found in revisited ruins: %s", defName)
 	}
 	return lifecycle.MovePlayerToPosition(world, pos)
 }

--- a/internal/states/item_action_state.go
+++ b/internal/states/item_action_state.go
@@ -56,7 +56,7 @@ type itemVerb struct {
 var verbList = []itemVerb{
 	{
 		ID:      verbExamine,
-		Label:   "調べる",
+		Label:   "Inspect",
 		KeyHint: "X",
 		Key:     ebiten.KeyX,
 		Shift:   true,
@@ -66,7 +66,7 @@ var verbList = []itemVerb{
 	},
 	{
 		ID:      verbPlace,
-		Label:   "置く",
+		Label:   "Drop",
 		KeyHint: "d",
 		Key:     ebiten.KeyD,
 		Action:  inputmapper.ActionVerbPlace,
@@ -75,7 +75,7 @@ var verbList = []itemVerb{
 	},
 	{
 		ID:      verbConsume,
-		Label:   "食べる",
+		Label:   "Eat",
 		KeyHint: "e",
 		Key:     ebiten.KeyE,
 		Action:  inputmapper.ActionVerbConsume,
@@ -84,7 +84,7 @@ var verbList = []itemVerb{
 	},
 	{
 		ID:      verbRead,
-		Label:   "読む",
+		Label:   "Read",
 		KeyHint: "r",
 		Key:     ebiten.KeyR,
 		Action:  inputmapper.ActionVerbRead,
@@ -93,7 +93,7 @@ var verbList = []itemVerb{
 	},
 	{
 		ID:      verbUse,
-		Label:   "使う",
+		Label:   "Use",
 		KeyHint: "t",
 		Key:     ebiten.KeyT,
 		Action:  inputmapper.ActionVerbUse,
@@ -254,7 +254,7 @@ func (st *ItemActionState) DoAction(world w.World, action inputmapper.ActionID) 
 			st.jumpToTab(v)
 			return es.Transition[w.World]{Type: es.TransNone}, nil
 		}
-		return es.Transition[w.World]{}, fmt.Errorf("未知のアクション: %s", action)
+		return es.Transition[w.World]{}, fmt.Errorf("unknown action: %s", action)
 	}
 }
 
@@ -325,7 +325,7 @@ func (st *ItemActionState) Fetch(world w.World) ItemActionProps {
 			}
 			items = append(items, newItemActionEntry(world, entity))
 		}
-		tabs[i] = verbTabData{ID: verb.ID, Label: verb.Label, Key: verb.KeyHint, Items: items}
+		tabs[i] = verbTabData{ID: verb.ID, Label: query.T(world, verb.Label), Key: verb.KeyHint, Items: items}
 	}
 	return ItemActionProps{Tabs: tabs}
 }
@@ -364,7 +364,7 @@ func newItemActionEntry(world w.World, entity ecs.Entity) itemActionEntry {
 // ================
 
 // View は props を UI へ組む純粋な描画。menurt.Model の View 部にあたる
-func (st *ItemActionState) View(_ w.World, props ItemActionProps, cursor menurt.Selection, res resources.UIResources) *ebitenui.UI {
+func (st *ItemActionState) View(world w.World, props ItemActionProps, cursor menurt.Selection, res resources.UIResources) *ebitenui.UI {
 	// タブ見出しに直達ショートカットを添える。調べる(X) 置く(d) の形
 	labels := make([]string, len(props.Tabs))
 	for i, tab := range props.Tabs {
@@ -378,8 +378,8 @@ func (st *ItemActionState) View(_ w.World, props ItemActionProps, cursor menurt.
 	return newTabScreenUI(res, tabScreen{
 		TabLabels: labels,
 		TabIndex:  cursor.TabIndex,
-		Content:   st.buildItemList(props, cursor.TabIndex, cursor.ItemIndex, res),
-		Footer:    menuNavHint(true, "x 詳細"),
+		Content:   st.buildItemList(world, props, cursor.TabIndex, cursor.ItemIndex, res),
+		Footer:    menuNavHint(true, query.T(world, "x Details")),
 	})
 }
 
@@ -392,7 +392,7 @@ func (st *ItemActionState) Menu(props ItemActionProps) menurt.MenuConfig {
 	return menurt.MenuConfig{Key: itemActionMenuKey, TabCount: len(props.Tabs), ItemCounts: itemCounts, ItemsPerPage: menuItemsPerPage, InitialTab: verbTabIndex(st.initialVerb)}
 }
 
-func (st *ItemActionState) buildItemList(props ItemActionProps, tabIndex, itemIndex int, res resources.UIResources) *widget.Container {
+func (st *ItemActionState) buildItemList(world w.World, props ItemActionProps, tabIndex, itemIndex int, res resources.UIResources) *widget.Container {
 	if tabIndex >= len(props.Tabs) {
 		return styled.NewVerticalContainer()
 	}
@@ -403,7 +403,7 @@ func (st *ItemActionState) buildItemList(props ItemActionProps, tabIndex, itemIn
 	for i, it := range items {
 		rows[i] = menuRow{Cells: []string{nameWithCount(it.Name, it.Count), it.Weight}}
 	}
-	return renderMenuList(itemIndex, rows, columnWidths, aligns, menuListOpts{AlwaysIndicator: true, EmptyText: "該当するアイテムがありません"}, res)
+	return renderMenuList(itemIndex, rows, columnWidths, aligns, menuListOpts{AlwaysIndicator: true, EmptyText: query.T(world, "No matching items")}, res)
 }
 
 // detailContent は現在カーソルが当たっているアイテムの詳細内容を返す。詳細モーダルの唯一の定義点

--- a/internal/states/look_around.go
+++ b/internal/states/look_around.go
@@ -45,7 +45,7 @@ func (st *LookAroundState) OnStart(world w.World) error {
 	}
 
 	if !world.Components.GridElement.Has(playerEntity) {
-		return fmt.Errorf("プレイヤーがGridElementを持っていません")
+		return fmt.Errorf("player does not have GridElement")
 	}
 
 	playerGrid := world.Components.GridElement.Get(playerEntity)
@@ -106,7 +106,7 @@ func (st *LookAroundState) doAction(world w.World, action inputmapper.ActionID) 
 	case inputmapper.ActionMoveEast:
 		st.moveCursor(world, 1, 0)
 	default:
-		return es.Transition[w.World]{}, fmt.Errorf("未対応のアクション: %s", action)
+		return es.Transition[w.World]{}, fmt.Errorf("unsupported action: %s", action)
 	}
 
 	return st.ConsumeTransition(), nil
@@ -223,7 +223,7 @@ func (st *LookAroundState) drawInfoPanel(world w.World, screen *ebiten.Image) er
 	}
 
 	// 座標表示
-	drawText(fmt.Sprintf("座標: %s", st.cursor))
+	drawText(fmt.Sprintf("%s: %s", query.T(world, "Coord"), st.cursor))
 	y += 5
 
 	// 視界内かどうかをチェック
@@ -235,7 +235,7 @@ func (st *LookAroundState) drawInfoPanel(world w.World, screen *ebiten.Image) er
 	inVision := query.IsInVision(world, playerGrid.Coord, st.cursor)
 
 	if !inVision {
-		drawText("暗闇")
+		drawText(query.T(world, "Darkness"))
 		return nil
 	}
 
@@ -243,7 +243,7 @@ func (st *LookAroundState) drawInfoPanel(world w.World, screen *ebiten.Image) er
 	entities := query.GetEntitiesAt(world, st.cursor.X, st.cursor.Y)
 
 	if len(entities) == 0 {
-		drawText("何もありません")
+		drawText(query.T(world, "Nothing here"))
 	} else {
 		for _, entity := range entities {
 			st.drawEntityInfo(world, entity, drawText)
@@ -258,7 +258,7 @@ func (st *LookAroundState) drawInfoPanel(world w.World, screen *ebiten.Image) er
 
 	// 操作説明
 	y = panelY + panelHeight - 30
-	drawText("WASD/矢印: 移動  X/Esc: 閉じる")
+	drawText(query.T(world, "WASD/Arrows: Move  X/Esc: Close"))
 
 	return nil
 }
@@ -288,7 +288,7 @@ func (st *LookAroundState) drawEntityInfo(world w.World, entity ecs.Entity, draw
 		hp := world.Components.HP.Get(entity)
 		label := "HP"
 		if world.Components.Fixed.Has(entity) {
-			label = "耐久"
+			label = query.T(world, "Durability")
 		}
 		drawText(fmt.Sprintf("  %s: %d/%d", label, hp.Current, hp.Max))
 	}
@@ -309,10 +309,10 @@ func (st *LookAroundState) drawPassCost(world w.World, entities []ecs.Entity, y 
 	}
 	*y += 5
 	if blocked {
-		drawText("移動コスト: 不可")
+		drawText(query.T(world, "Move cost") + ": " + query.T(world, "Impassable"))
 	} else {
 		cost := consts.StandardActionCost + totalAdd
-		drawText(fmt.Sprintf("移動コスト: %d", cost))
+		drawText(fmt.Sprintf("%s: %d", query.T(world, "Move cost"), cost))
 	}
 }
 
@@ -322,15 +322,15 @@ func (st *LookAroundState) drawTileTemperature(world w.World, entities []ecs.Ent
 		if world.Components.TileTemperature.Has(entity) {
 			temp := world.Components.TileTemperature.Get(entity)
 			*y += 5
-			drawText(fmt.Sprintf("気温修正: %+d", temp.Total()))
+			drawText(fmt.Sprintf("%s: %+d", query.T(world, "Temperature modifier"), temp.Total()))
 			if temp.Shelter != 0 {
-				drawText(fmt.Sprintf("  屋内: %+d", temp.Shelter))
+				drawText(fmt.Sprintf("  %s: %+d", query.T(world, "Indoor"), temp.Shelter))
 			}
 			if temp.Water != 0 {
-				drawText(fmt.Sprintf("  水辺: %+d", temp.Water))
+				drawText(fmt.Sprintf("  %s: %+d", query.T(world, "Waterside"), temp.Water))
 			}
 			if temp.Foliage != 0 {
-				drawText(fmt.Sprintf("  植生: %+d", temp.Foliage))
+				drawText(fmt.Sprintf("  %s: %+d", query.T(world, "Foliage"), temp.Foliage))
 			}
 			return
 		}

--- a/internal/states/main_menu.go
+++ b/internal/states/main_menu.go
@@ -75,7 +75,7 @@ func (st *MainMenuState) DoAction(_ w.World, action inputmapper.ActionID) (es.Tr
 	case inputmapper.ActionMenuUp, inputmapper.ActionMenuDown, inputmapper.ActionMenuLeft, inputmapper.ActionMenuRight, inputmapper.ActionMenuTabNext, inputmapper.ActionMenuTabPrev:
 		// Dispatchで処理される
 	default:
-		return es.Transition[w.World]{}, fmt.Errorf("mainMenu: 未対応のアクション: %s", action)
+		return es.Transition[w.World]{}, fmt.Errorf("mainMenu: unsupported action: %s", action)
 	}
 	return es.Transition[w.World]{Type: es.TransNone}, nil
 }

--- a/internal/states/mapgen_visualizer.go
+++ b/internal/states/mapgen_visualizer.go
@@ -50,12 +50,12 @@ func (st *MapGenVisualizerState) OnStart(world w.World) error {
 
 	chain, err := mapplanner.BuildChain(world, consts.MapTileWidth, consts.MapTileHeight, seed, st.PlannerType)
 	if err != nil {
-		return fmt.Errorf("PlannerChain作成失敗: %w", err)
+		return fmt.Errorf("failed to create PlannerChain: %w", err)
 	}
 	chain.Recording = true
 
 	if err := chain.Plan(); err != nil {
-		return fmt.Errorf("plan実行失敗: %w", err)
+		return fmt.Errorf("failed to execute plan: %w", err)
 	}
 
 	// チェーン実行後の実際のマップサイズを使用する。テンプレートベースのPlannerは引数のwidth/heightを無視するため
@@ -64,7 +64,7 @@ func (st *MapGenVisualizerState) OnStart(world w.World) error {
 
 	st.snapshots = chain.Snapshots
 	if st.SnapshotIndex < 0 || st.SnapshotIndex >= len(st.snapshots) {
-		return fmt.Errorf("SnapshotIndex %d が範囲外です（スナップショット数: %d）", st.SnapshotIndex, len(st.snapshots))
+		return fmt.Errorf("SnapshotIndex %d out of range, snapshot count %d", st.SnapshotIndex, len(st.snapshots))
 	}
 
 	// カメラをマップ全体が見えるように設定する
@@ -173,7 +173,7 @@ func (st *MapGenVisualizerState) spawnSnapshot(world w.World) error {
 	}
 
 	if _, err := mapspawner.Spawn(world, plan); err != nil {
-		return fmt.Errorf("スナップショット%dのスポーン失敗: %w", st.SnapshotIndex, err)
+		return fmt.Errorf("failed to spawn snapshot %d: %w", st.SnapshotIndex, err)
 	}
 
 	// 全タイルを可視にする

--- a/internal/states/message.go
+++ b/internal/states/message.go
@@ -52,11 +52,11 @@ func (st *MessageState) OnStop(_ w.World) error { return nil }
 func loadBackgroundImage(world w.World, spriteKey string) (*ebiten.Image, error) {
 	sheet, sheetOK := world.Resources.SpriteSheets["bg"]
 	if !sheetOK {
-		return nil, fmt.Errorf("bgスプライトシートが存在しない")
+		return nil, fmt.Errorf("bg sprite sheet does not exist")
 	}
 	sprite, ok := sheet.Sprites[spriteKey]
 	if !ok {
-		return nil, fmt.Errorf("無効なBackgroundKey: %q がbgスプライトシートに存在しない", spriteKey)
+		return nil, fmt.Errorf("invalid BackgroundKey: %q not found in bg sprite sheet", spriteKey)
 	}
 	rect := image.Rect(
 		sprite.X,

--- a/internal/states/overworld_map.go
+++ b/internal/states/overworld_map.go
@@ -52,7 +52,7 @@ const (
 func (st *OverworldMapState) OnStart(world w.World) error {
 	sb := query.GetSeamlessBand(world)
 	if sb == nil || !sb.Active {
-		return fmt.Errorf("オーバーワールド帯が有効でない")
+		return fmt.Errorf("overworld band is not valid")
 	}
 	rows := max(sb.Rows, 1)
 
@@ -129,7 +129,7 @@ func (st *OverworldMapState) Draw(world w.World, screen *ebiten.Image) error {
 		text.Draw(screen, str, face, op)
 	}
 
-	drawText(fmt.Sprintf("オーバーワールド地図  現在地 チャンク(%d, %d)", st.playerAbs.X, st.playerAbs.Y), 16, 12, theme.TextPrimary)
+	drawText(fmt.Sprintf("Overworld Map  Current Chunk %d, %d", st.playerAbs.X, st.playerAbs.Y), 16, 12, theme.TextPrimary)
 
 	const originX, originY consts.ScreenPixel = 16, 44
 	// cellCenter はセル (col,row) の中央座標を返す。セルの塗りは一辺 mapCellPx-1
@@ -181,7 +181,7 @@ func (st *OverworldMapState) drawLegend(screen *ebiten.Image, drawText func(stri
 			x, y = 16, y+22
 		}
 	}
-	drawText("N / Esc で閉じる", 16, y+26, theme.TextPrimary)
+	drawText("N / Esc to close", 16, y+26, theme.TextPrimary)
 }
 
 // glyphColorTable は文字から色への対応。色は overworld の GlyphInfo が記号と同居して持つので、

--- a/internal/states/settings_menu.go
+++ b/internal/states/settings_menu.go
@@ -61,7 +61,7 @@ func (st *SettingsMenuState) DoAction(_ w.World, action inputmapper.ActionID) (e
 	case inputmapper.ActionMenuUp, inputmapper.ActionMenuDown, inputmapper.ActionMenuLeft, inputmapper.ActionMenuRight, inputmapper.ActionMenuTabNext, inputmapper.ActionMenuTabPrev:
 		// Dispatchで処理される
 	default:
-		return es.Transition[w.World]{}, fmt.Errorf("settingsMenu: 未対応のアクション: %s", action)
+		return es.Transition[w.World]{}, fmt.Errorf("settingsMenu: unsupported action: %s", action)
 	}
 	return es.Transition[w.World]{Type: es.TransNone}, nil
 }
@@ -96,8 +96,8 @@ type settingsMenuItem struct {
 func (st *SettingsMenuState) Fetch(world w.World) SettingsMenuProps {
 	return SettingsMenuProps{
 		Items: []settingsMenuItem{
-			{Kind: settingsItemLanguage, Label: "言語", Value: currentLanguageLabel(query.GetUserSettings(world).Language)},
-			{Kind: settingsItemBack, Label: "戻る"},
+			{Kind: settingsItemLanguage, Label: query.T(world, "Language"), Value: query.T(world, currentLanguageLabel(query.GetUserSettings(world).Language))},
+			{Kind: settingsItemBack, Label: query.T(world, "Back")},
 		},
 	}
 }
@@ -138,13 +138,13 @@ func (st *SettingsMenuState) handleSelection() es.Transition[w.World] {
 
 // language は選択できる表示言語を表す
 type language struct {
-	Code  string // 言語コード（"ja" / "en"）
-	Label string // 表示名（"日本語" / "English"）
+	Code  string // 言語コード。"ja" / "en"
+	Label string // 表示名の msgid。query.T で現在言語の訳を引く
 }
 
 // languagePresets は選択できる言語の一覧を保持する
 var languagePresets = []language{
-	{Code: "ja", Label: "日本語"},
+	{Code: "ja", Label: "Japanese"},
 	{Code: "en", Label: "English"},
 }
 
@@ -165,17 +165,17 @@ func NewLanguageMenuState() (es.State[w.World], error) {
 }
 
 // languageChoices は選択できる表示言語を選択肢にする。選ぶとシングルトンへ反映し設定を保存して閉じる
-func languageChoices(_ w.World) (string, []Choice) {
+func languageChoices(world w.World) (string, []Choice) {
 	choices := make([]Choice, 0, len(languagePresets))
 	for _, l := range languagePresets {
-		choices = append(choices, Choice{Label: l.Label, Run: func(world w.World) (es.Transition[w.World], error) {
+		choices = append(choices, Choice{Label: query.T(world, l.Label), Run: func(world w.World) (es.Transition[w.World], error) {
 			// シングルトンの設定言語を書き換える。Fetch が毎フレーム query.T 経由で引き直すので、再起動なしで表示が変わる。
 			if s := query.GetUserSettings(world); s != nil {
 				s.Language = l.Code
 			}
 			world.Config.User.Language = l.Code
 			if err := world.Config.SaveUserConfig(); err != nil {
-				logger.New(logger.CategorySave).Warn("言語設定の保存に失敗しました", "error", err)
+				logger.New(logger.CategorySave).Warn("failed to save language setting", "error", err)
 			}
 			return es.Transition[w.World]{Type: es.TransPop}, nil
 		}})
@@ -188,7 +188,7 @@ func languageChoices(_ w.World) (string, []Choice) {
 // ================
 
 // View は props を UI へ組む純粋な描画。menurt.Model の View 部にあたる
-func (st *SettingsMenuState) View(_ w.World, props SettingsMenuProps, cursor menurt.Selection, res resources.UIResources) *ebitenui.UI {
+func (st *SettingsMenuState) View(world w.World, props SettingsMenuProps, cursor menurt.Selection, res resources.UIResources) *ebitenui.UI {
 	// 項目リストは他メニューと同じテーブル描画に揃える。現在値は右列に表示し、変更は Enter で開くモーダルから行う
 	rows := make([]menuRow, len(props.Items))
 	for i, item := range props.Items {
@@ -208,7 +208,7 @@ func (st *SettingsMenuState) View(_ w.World, props SettingsMenuProps, cursor men
 	)
 
 	titleText := widget.NewText(
-		widget.TextOpts.Text("設定", &res.Text.BodyFace, theme.TextPrimary),
+		widget.TextOpts.Text(query.T(world, "Settings"), &res.Text.BodyFace, theme.TextPrimary),
 	)
 	menuContainer.AddChild(titleText)
 	menuContainer.AddChild(table)

--- a/internal/states/settings_menu_test.go
+++ b/internal/states/settings_menu_test.go
@@ -69,7 +69,8 @@ func TestLanguageChoices_選択で実行中シングルトンと設定を更新�
 func TestCurrentLanguageLabel(t *testing.T) {
 	t.Parallel()
 
-	assert.Equal(t, "日本語", currentLanguageLabel("ja"))
+	// 表示名の msgid を返す。実際の訳は query.T が引く
+	assert.Equal(t, "Japanese", currentLanguageLabel("ja"))
 	assert.Equal(t, "English", currentLanguageLabel("en"))
 	// 一覧に無いコードはそのまま返す
 	assert.Equal(t, "fr", currentLanguageLabel("fr"))

--- a/internal/states/shooting.go
+++ b/internal/states/shooting.go
@@ -129,7 +129,7 @@ func (st *ShootingState) doAction(world w.World, action inputmapper.ActionID) (e
 		return es.Transition[w.World]{Type: es.TransPop}, nil
 
 	default:
-		return es.Transition[w.World]{}, fmt.Errorf("未対応のアクション: %s", action)
+		return es.Transition[w.World]{}, fmt.Errorf("unsupported action: %s", action)
 	}
 
 	return st.ConsumeTransition(), nil
@@ -146,14 +146,14 @@ func (st *ShootingState) checkFireWeaponStatus(world w.World) string {
 	weapons := query.GetWeapons(world, playerEntity)
 	weaponIndex := selectedSlot - 1
 	if weaponIndex < 0 || weaponIndex >= len(weapons) || weapons[weaponIndex] == nil {
-		return "射撃武器が装備されていません"
+		return query.T(world, "No ranged weapon equipped")
 	}
 	fire := world.Components.Fire.Get(*weapons[weaponIndex])
 	if fire == nil {
-		return "射撃武器が装備されていません"
+		return query.T(world, "No ranged weapon equipped")
 	}
 	if fire.Magazine <= 0 {
-		return "装填されていません"
+		return query.T(world, "Not loaded")
 	}
 	return ""
 }
@@ -299,13 +299,13 @@ func (st *ShootingState) drawShootingPanel(world w.World, screen *ebiten.Image) 
 		y += lineHeight
 	}
 
-	drawText("== 射撃モード ==")
+	drawText(query.T(world, "== Shooting Mode =="))
 	y += 5
 
 	// 武器・残弾情報
 	playerEntity, err := query.GetPlayerEntity(world)
 	if err != nil {
-		drawText("エラー: プレイヤーが見つかりません")
+		drawText(query.T(world, "Error: player not found"))
 		return err
 	}
 
@@ -316,7 +316,7 @@ func (st *ShootingState) drawShootingPanel(world w.World, screen *ebiten.Image) 
 	if msg := st.checkFireWeaponStatus(world); msg != "" {
 		drawText(msg)
 	} else if len(st.enemies) == 0 {
-		drawText("射撃対象がいません")
+		drawText(query.T(world, "No shooting target"))
 	} else {
 		target := st.enemies[st.targetIndex]
 		st.drawTargetInfo(world, target, drawText)
@@ -324,7 +324,7 @@ func (st *ShootingState) drawShootingPanel(world w.World, screen *ebiten.Image) 
 
 	// 操作説明
 	y = panelY + panelHeight - 30
-	drawText("Tab:切替 Enter:射撃 R:装填 Esc:戻る")
+	drawText(query.T(world, "Tab: Switch  Enter: Fire  R: Reload  Esc: Back"))
 
 	return nil
 }
@@ -335,32 +335,32 @@ func (st *ShootingState) drawWeaponInfo(world w.World, playerEntity ecs.Entity, 
 	weapons := query.GetWeapons(world, playerEntity)
 	weaponIndex := selectedSlot - 1
 	if weaponIndex < 0 || weaponIndex >= len(weapons) {
-		drawText("武器スロット: 無効")
+		drawText(query.T(world, "Weapon slot: invalid"))
 		return
 	}
 
 	weaponEntity := weapons[weaponIndex]
 	if weaponEntity == nil {
-		drawText("武器: なし")
+		drawText(query.T(world, "Weapon: none"))
 		return
 	}
 
 	// 武器名
 	weaponName := query.GetEntityName(*weaponEntity, world)
-	drawText(fmt.Sprintf("武器: %s", weaponName))
+	drawText(fmt.Sprintf("%s: %s", query.T(world, "Weapon"), weaponName))
 
 	// 残弾表示
 	fireComp := world.Components.Fire.Get(*weaponEntity)
 	if fireComp != nil {
-		drawText(fmt.Sprintf("残弾: %d/%d", fireComp.Magazine, fireComp.MagazineSize))
+		drawText(fmt.Sprintf("%s: %d/%d", query.T(world, "Ammo"), fireComp.Magazine, fireComp.MagazineSize))
 	} else {
-		drawText("近接武器")
+		drawText(query.T(world, "Melee weapon"))
 	}
 }
 
 // drawTargetInfo はターゲット情報を描画する。キャッシュ済みの値を使用する
 func (st *ShootingState) drawTargetInfo(world w.World, target ecs.Entity, drawText func(string)) {
-	drawText(fmt.Sprintf("対象: %s (%d/%d)",
+	drawText(fmt.Sprintf("%s: %s (%d/%d)", query.T(world, "Target"),
 		query.GetEntityName(target, world),
 		st.targetIndex+1, len(st.enemies)))
 
@@ -370,6 +370,6 @@ func (st *ShootingState) drawTargetInfo(world w.World, target ecs.Entity, drawTe
 		drawText(fmt.Sprintf("HP: %d/%d", hp.Current, hp.Max))
 	}
 
-	drawText(fmt.Sprintf("命中率: %d%%", st.cachedHitRate))
-	drawText(fmt.Sprintf("距離: %.1f", st.cachedDistance))
+	drawText(fmt.Sprintf("%s: %d%%", query.T(world, "Hit rate"), st.cachedHitRate))
+	drawText(fmt.Sprintf("%s: %.1f", query.T(world, "Distance"), st.cachedDistance))
 }

--- a/internal/states/shop_menu.go
+++ b/internal/states/shop_menu.go
@@ -76,7 +76,7 @@ func (st *ShopMenuState) DoAction(world w.World, action inputmapper.ActionID) (e
 	case inputmapper.ActionMenuUp, inputmapper.ActionMenuDown, inputmapper.ActionMenuLeft, inputmapper.ActionMenuRight, inputmapper.ActionMenuTabNext, inputmapper.ActionMenuTabPrev:
 		// Dispatchで処理される
 	default:
-		return es.Transition[w.World]{}, fmt.Errorf("shopMenu: 未対応のアクション: %s", action)
+		return es.Transition[w.World]{}, fmt.Errorf("shopMenu: unsupported action: %s", action)
 	}
 	return es.Transition[w.World]{Type: es.TransNone}, nil
 }
@@ -135,8 +135,8 @@ func (st *ShopMenuState) Menu(props ShopProps) menurt.MenuConfig {
 
 func (st *ShopMenuState) createTabs(world w.World, currency int, buyPriceMod, sellPriceMod consts.Percent) []shopTabData {
 	return []shopTabData{
-		{ID: "buy", Label: "購入", Items: st.createBuyItems(world, currency, buyPriceMod)},
-		{ID: "sell", Label: "売却", Items: st.createSellItems(world, sellPriceMod)},
+		{ID: "buy", Label: query.T(world, "Buy"), Items: st.createBuyItems(world, currency, buyPriceMod)},
+		{ID: "sell", Label: query.T(world, "Sell"), Items: st.createSellItems(world, sellPriceMod)},
 	}
 }
 
@@ -230,14 +230,14 @@ func (st *ShopMenuState) buySellSelected(world w.World) error {
 		var err error
 		query.Player(world, func(p ecs.Entity) { err = gameaction.BuyItem(world, p, item.Label) })
 		if err != nil {
-			return fmt.Errorf("購入に失敗: %w", err)
+			return fmt.Errorf("failed to buy: %w", err)
 		}
 		return nil
 	}
 	var err error
 	query.Player(world, func(p ecs.Entity) { err = gameaction.SellItem(world, p, item.Entity) })
 	if err != nil {
-		return fmt.Errorf("売却に失敗: %w", err)
+		return fmt.Errorf("failed to sell: %w", err)
 	}
 	return nil
 }
@@ -261,7 +261,7 @@ func (st *ShopMenuState) selectedShopItem() (shopItemData, bool) {
 // ================
 
 // View は props を UI へ組む純粋な描画。menurt.Model の View 部にあたる
-func (st *ShopMenuState) View(_ w.World, props ShopProps, cursor menurt.Selection, res resources.UIResources) *ebitenui.UI {
+func (st *ShopMenuState) View(world w.World, props ShopProps, cursor menurt.Selection, res resources.UIResources) *ebitenui.UI {
 	// 購入と売却をタブ帯に寄せ、本体は1カラムの一覧にする。性能は x の詳細モーダルで見る
 	labels := make([]string, len(props.Tabs))
 	for i, tab := range props.Tabs {
@@ -270,8 +270,8 @@ func (st *ShopMenuState) View(_ w.World, props ShopProps, cursor menurt.Selectio
 	return newTabScreenUI(res, tabScreen{
 		TabLabels: labels,
 		TabIndex:  cursor.TabIndex,
-		Content:   st.buildItemContainer(props.Tabs, cursor.TabIndex, cursor.ItemIndex, res),
-		Footer:    menuNavHint(true, "x 詳細"),
+		Content:   st.buildItemContainer(world, props.Tabs, cursor.TabIndex, cursor.ItemIndex, res),
+		Footer:    menuNavHint(true, query.T(world, "x Details")),
 	})
 }
 
@@ -308,7 +308,7 @@ func (st *ShopMenuState) selectedDetail(world w.World) (shopItemData, gc.EntityS
 	return item, s, true
 }
 
-func (st *ShopMenuState) buildItemContainer(tabs []shopTabData, tabIndex, itemIndex int, res resources.UIResources) *widget.Container {
+func (st *ShopMenuState) buildItemContainer(world w.World, tabs []shopTabData, tabIndex, itemIndex int, res resources.UIResources) *widget.Container {
 	if tabIndex >= len(tabs) {
 		return styled.NewVerticalContainer()
 	}
@@ -323,9 +323,9 @@ func (st *ShopMenuState) buildItemContainer(tabs []shopTabData, tabIndex, itemIn
 	for i, it := range currentTab.Items {
 		rows[i] = menuRow{Cells: []string{nameWithCount(it.Label, it.Count), query.FormatCurrency(it.Price), it.Weight}}
 	}
-	emptyText := "(商品なし)"
+	emptyText := query.T(world, "No goods")
 	if currentTab.ID == "sell" {
-		emptyText = "売却可能なアイテムがありません"
+		emptyText = query.T(world, "No items to sell")
 	}
 	return renderMenuList(itemIndex, rows, columnWidths, aligns, menuListOpts{AlwaysIndicator: true, EmptyText: emptyText}, res)
 }

--- a/internal/states/storage_menu.go
+++ b/internal/states/storage_menu.go
@@ -86,7 +86,7 @@ func (st *StorageMenuState) DoAction(world w.World, action inputmapper.ActionID)
 	case inputmapper.ActionMenuUp, inputmapper.ActionMenuDown, inputmapper.ActionMenuLeft, inputmapper.ActionMenuRight, inputmapper.ActionMenuTabNext, inputmapper.ActionMenuTabPrev:
 		// Dispatchで処理される
 	default:
-		return es.Transition[w.World]{}, fmt.Errorf("storageMenu: 未対応のアクション: %s", action)
+		return es.Transition[w.World]{}, fmt.Errorf("storageMenu: unsupported action: %s", action)
 	}
 	return es.Transition[w.World]{Type: es.TransNone}, nil
 }
@@ -117,8 +117,8 @@ type storageItemData struct {
 func (st *StorageMenuState) Fetch(world w.World) StorageProps {
 	return StorageProps{
 		Tabs: []storageTabData{
-			{ID: tabIDRetrieve, Label: "取得", Items: st.createStorageItemData(world)},
-			{ID: tabIDStore, Label: "収納", Items: st.createBackpackItemData(world)},
+			{ID: tabIDRetrieve, Label: query.T(world, "Retrieve"), Items: st.createStorageItemData(world)},
+			{ID: tabIDStore, Label: query.T(world, "Store"), Items: st.createBackpackItemData(world)},
 		},
 	}
 }
@@ -215,7 +215,7 @@ func (st *StorageMenuState) executeTransfer(world w.World) error {
 // ================
 
 // View は props を UI へ組む純粋な描画。menurt.Model の View 部にあたる
-func (st *StorageMenuState) View(_ w.World, props StorageProps, cursor menurt.Selection, res resources.UIResources) *ebitenui.UI {
+func (st *StorageMenuState) View(world w.World, props StorageProps, cursor menurt.Selection, res resources.UIResources) *ebitenui.UI {
 	// カテゴリをタブ帯に寄せ、本体は1カラムの一覧にする。性能は x の詳細モーダルで見る
 	labels := make([]string, len(props.Tabs))
 	for i, tab := range props.Tabs {
@@ -224,8 +224,8 @@ func (st *StorageMenuState) View(_ w.World, props StorageProps, cursor menurt.Se
 	return newTabScreenUI(res, tabScreen{
 		TabLabels: labels,
 		TabIndex:  cursor.TabIndex,
-		Content:   st.buildActiveListContainer(props, cursor.TabIndex, cursor.ItemIndex, res),
-		Footer:    menuNavHint(true, "x 詳細"),
+		Content:   st.buildActiveListContainer(world, props, cursor.TabIndex, cursor.ItemIndex, res),
+		Footer:    menuNavHint(true, query.T(world, "x Details")),
 	})
 }
 
@@ -256,7 +256,7 @@ func (st *StorageMenuState) selectedEntity() (ecs.Entity, bool) {
 	return items[cursor.ItemIndex].Entity, true
 }
 
-func (st *StorageMenuState) buildActiveListContainer(props StorageProps, tabIndex, itemIndex int, res resources.UIResources) *widget.Container {
+func (st *StorageMenuState) buildActiveListContainer(world w.World, props StorageProps, tabIndex, itemIndex int, res resources.UIResources) *widget.Container {
 	if tabIndex >= len(props.Tabs) {
 		return styled.NewVerticalContainer()
 	}
@@ -268,5 +268,5 @@ func (st *StorageMenuState) buildActiveListContainer(props StorageProps, tabInde
 	for i, it := range currentTab.Items {
 		rows[i] = menuRow{Cells: []string{nameWithCount(it.Name, it.Count), it.Weight}}
 	}
-	return renderMenuList(itemIndex, rows, columnWidths, aligns, menuListOpts{AlwaysIndicator: true, EmptyText: "(アイテムなし)"}, res)
+	return renderMenuList(itemIndex, rows, columnWidths, aligns, menuListOpts{AlwaysIndicator: true, EmptyText: query.T(world, "No items")}, res)
 }

--- a/internal/world/query/singleton.go
+++ b/internal/world/query/singleton.go
@@ -53,12 +53,13 @@ func GetUserSettings(world w.World) *gc.UserSettings {
 }
 
 // T は現在の設定言語での msgid の訳を返す。現在言語は UserSettings、マスタは Resources.I18N から引く。
-func T(world w.World, msgid string) string {
+// args を渡すと訳を書式として整形する。"%s攻撃力" のようにデータ値を差し込む訳に使う。
+func T(world w.World, msgid string, args ...any) string {
 	var lang string
 	if s := GetUserSettings(world); s != nil {
 		lang = s.Language
 	}
-	return world.Resources.I18N.Translate(lang, msgid)
+	return world.Resources.I18N.Translate(lang, msgid, args...)
 }
 
 // stageFieldEntity は key に束縛された StageField エンティティを返す。


### PR DESCRIPTION
## 概要

doc 90 の i18n 源泉英語化を「機械検知 + 段階移行」で進める。golangci-lint 同梱の `gosmopolitan` を有効化し、日本語文字列リテラルを検出する。全体で 6900 件超あるため、除外ルールを allowlist として1画面ずつ外していく。今回は states の clean な UI ラベルファイルを移行する。

## 変更

**gosmopolitan 導入**
- `gosmopolitan` を有効化。漢字・ひらがな・カタカナのリテラルを検出する。カスタム linter は作らない
- 除外ルールを allowlist にする。テストは恒久除外、非UIパッケージはパッケージ単位、states はファイル単位で除外し、英語化した画面から外す

**states UI の i18n.T + ja.po 移行（18ファイル）**
- UIラベルは `query.T(world, "English")` で引き、`ja.po` の msgstr を元の日本語そのままにする。既定 ja では表示不変で、既存テストと golden が安全網になる
- エラー・ログ・デバッグ文字列は直接英語化する
- View の world を使い、一覧構築ヘルパへ world を渡す。const 初期化ラベルは表示時に訳す
- `query.T` / `i18n.Translate` を可変長引数対応にし、`"%s攻撃力"` のようにデータ値を差し込む訳を扱う。gotext の Get はメソッド値経由で呼び go vet 誤検知を避ける

移行済み: main_menu, choice, message, demo_start, component_debug_state, cube_panel, overworld_map, mapgen_visualizer, dungeon_floor, craft_menu, shop_menu, storage_menu, item_action_state, settings_menu, character_naming, character_view, look_around, shooting, character_info

## allowlist の残り

states は 27 → 9 に減った。残り9は別フェーズの作業になる。

- データキー結合で states 外に依存: `debug_menu` のアイテム名、`tavern_menu` の隊員名
- states 内で解決可能だが会話・ログ方針や追加リファクタで保留: `factories` のナラティブ、`character_job` などの gamelog、`character_state` の const タブ、`action_handlers` の変数連結ラベル、`lib` のパッケージ const

## 検証

- `make check` 緑（lint 0 issues・脆弱性なし）
- 各ファイルの移行ごとに `make check` を通してコミットした

🤖 Generated with [Claude Code](https://claude.com/claude-code)