### PR TITLE
ポータルと同居する NPC の会話が発動しないのを直す

### DIFF
--- a/internal/activity/player_actions.go
+++ b/internal/activity/player_actions.go
@@ -29,11 +29,11 @@ func ExecuteMoveAction(world w.World, direction gc.Direction) error {
 
 	next := current.Add(direction.GetDelta())
 
-	// 移動先にOnCollision方式のInteractableがある場合は自動実行
+	// 移動先の同居 Interactable を全て見て、OnCollision 方式のものを自動実行する。ポータルのような
+	// Manual 単独の Interactable が同じタイルに同居しても、NPC の会話などの OnCollision を取りこぼさない。
 	targetGrid := &gc.GridElement{Coord: next}
-	interactable, interactableEntity := getInteractableAtSameTile(world, targetGrid)
-
-	if interactable != nil {
+	for _, interactableEntity := range interactablesAtSameTile(world, targetGrid) {
+		interactable := world.Components.Interactable.Get(interactableEntity)
 		for _, interaction := range interactable.Interactions {
 			if interaction.Config().ActivationWay != gc.ActivationWayOnCollision {
 				continue
@@ -122,27 +122,20 @@ func ExecuteWaitAction(world w.World) error {
 	return err
 }
 
-// getInteractableAtSameTile は指定タイルのInteractableとエンティティを取得する。
-// 複数ある場合は最初に見つかったものを返す。
-// 見つからない場合は interactable が nil になる。interactable != nil のときのみ entity は有効値。
-func getInteractableAtSameTile(world w.World, targetGrid *gc.GridElement) (*gc.Interactable, ecs.Entity) {
-	var found *gc.Interactable
-	var foundEntity ecs.Entity
+// interactablesAtSameTile は指定タイルにある生存 Interactable を全て返す。同一タイルにポータルと
+// NPC のように複数の Interactable が同居しうるため、先着1件でなく全件を返して取りこぼしを防ぐ。
+func interactablesAtSameTile(world w.World, targetGrid *gc.GridElement) []ecs.Entity {
+	var found []ecs.Entity
 	interactableQuery := query.ActiveFilter2[gc.GridElement, gc.Interactable](world).Without(ecs.C[gc.Dead]()).Query()
 	for interactableQuery.Next() {
 		entity := interactableQuery.Entity()
-		if found != nil {
-			// 先着1件を採用する。途中 return せず反復は最後まで続ける。Ark のワールドロックを外すため
-			continue
-		}
 		ge := world.Components.GridElement.Get(entity)
 		// 直上タイルのみ
 		if ge.X == targetGrid.X && ge.Y == targetGrid.Y {
-			found = world.Components.Interactable.Get(entity)
-			foundEntity = entity
+			found = append(found, entity)
 		}
 	}
-	return found, foundEntity
+	return found
 }
 
 // GetAllInteractiveInteractablesInRange は範囲内の全てのインタラクティブなInteractableエンティティを取得する

--- a/internal/activity/player_actions_test.go
+++ b/internal/activity/player_actions_test.go
@@ -168,8 +168,33 @@ func TestExecuteWaitAction(t *testing.T) {
 	})
 }
 
-func TestGetInteractableAtSameTile(t *testing.T) {
+func TestInteractablesAtSameTile(t *testing.T) {
 	t.Parallel()
+
+	t.Run("同一タイルに複数あれば全件返す", func(t *testing.T) {
+		t.Parallel()
+		world := testutil.InitTestWorld(t)
+		coord := consts.Coord[consts.Tile]{X: 10, Y: 10}
+
+		// ポータルと NPC が同じタイルに同居する。先着1件でなく両方返ることを固定する。
+		portal := world.ECS.NewEntity()
+		world.Components.GridElement.Add(portal, &gc.GridElement{Coord: coord})
+		world.Components.Interactable.Add(portal, &gc.Interactable{
+			Interactions: []gc.InteractionKind{gc.InteractionPortalNext},
+		})
+		npc := world.ECS.NewEntity()
+		world.Components.GridElement.Add(npc, &gc.GridElement{Coord: coord})
+		world.Components.Interactable.Add(npc, &gc.Interactable{
+			Interactions: []gc.InteractionKind{gc.InteractionTalk},
+		})
+
+		targetGrid := &gc.GridElement{Coord: coord}
+		found := interactablesAtSameTile(world, targetGrid)
+
+		require.Len(t, found, 2)
+		assert.Contains(t, found, portal)
+		assert.Contains(t, found, npc)
+	})
 
 	t.Run("同じタイルのInteractableを取得できる", func(t *testing.T) {
 		t.Parallel()
@@ -183,10 +208,10 @@ func TestGetInteractableAtSameTile(t *testing.T) {
 		})
 
 		targetGrid := &gc.GridElement{Coord: consts.Coord[consts.Tile]{X: 10, Y: 10}}
-		interactable, foundEntity := getInteractableAtSameTile(world, targetGrid)
+		found := interactablesAtSameTile(world, targetGrid)
 
-		require.NotNil(t, interactable)
-		assert.Equal(t, interactableEntity, foundEntity)
+		require.Len(t, found, 1)
+		assert.Equal(t, interactableEntity, found[0])
 	})
 
 	t.Run("異なるタイルのInteractableは取得されない", func(t *testing.T) {
@@ -201,9 +226,9 @@ func TestGetInteractableAtSameTile(t *testing.T) {
 		})
 
 		targetGrid := &gc.GridElement{Coord: consts.Coord[consts.Tile]{X: 10, Y: 10}}
-		interactable, _ := getInteractableAtSameTile(world, targetGrid)
+		found := interactablesAtSameTile(world, targetGrid)
 
-		assert.Nil(t, interactable)
+		assert.Empty(t, found)
 	})
 
 	t.Run("死亡エンティティはInteractable対象から除外される", func(t *testing.T) {
@@ -219,9 +244,9 @@ func TestGetInteractableAtSameTile(t *testing.T) {
 		world.Components.Dead.Add(deadEntity, &gc.Dead{})
 
 		targetGrid := &gc.GridElement{Coord: consts.Coord[consts.Tile]{X: 10, Y: 10}}
-		interactable, _ := getInteractableAtSameTile(world, targetGrid)
+		found := interactablesAtSameTile(world, targetGrid)
 
-		assert.Nil(t, interactable)
+		assert.Empty(t, found)
 	})
 }
 

--- a/internal/activity/push_test.go
+++ b/internal/activity/push_test.go
@@ -40,6 +40,34 @@ func TestExecuteMoveAction_コントロールパネルへ歩き込むと開く(t
 	assert.Equal(t, consts.Coord[consts.Tile]{X: 5, Y: 5}, world.Components.GridElement.Get(player).Coord, "パネルを開いても移動はしない")
 }
 
+// TestExecuteMoveAction_同居ポータルは歩き込みの発動を隠さない は、Manual のポータルが OnCollision の
+// 対象と同じタイルに同居しても歩き込みの自動発動を取りこぼさないことを固定する。移動先の先着1件しか
+// 見ておらず、ポータルが先着すると NPC の会話などが発動しなかった回帰。
+func TestExecuteMoveAction_同居ポータルは歩き込みの発動を隠さない(t *testing.T) {
+	t.Parallel()
+	world := testutil.InitTestWorld(t)
+	addPusher(t, world, consts.Coord[consts.Tile]{X: 5, Y: 5}, consts.PushCostBase)
+	tile := consts.Coord[consts.Tile]{X: 6, Y: 5}
+
+	// 先に Manual のポータルを置く。先着で拾われても OnCollision を隠さないことを確かめる。
+	portal := world.ECS.NewEntity()
+	world.Components.GridElement.Add(portal, &gc.GridElement{Coord: tile})
+	world.Components.Interactable.Add(portal, &gc.Interactable{Interactions: []gc.InteractionKind{gc.InteractionPortalNext}})
+
+	// 同じタイルに OnCollision のコントロールパネルを同居させる。会話 NPC と同じ発動方式を代表させる。
+	panel := world.ECS.NewEntity()
+	world.Components.GridElement.Add(panel, &gc.GridElement{Coord: tile})
+	world.Components.BlockPass.Add(panel, &gc.BlockPass{})
+	world.Components.Interactable.Add(panel, &gc.Interactable{Interactions: []gc.InteractionKind{gc.InteractionCubePanel}})
+
+	require.NoError(t, activity.ExecuteMoveAction(world, gc.DirectionRight))
+
+	req := lifecycle.ConsumeStateChange(world)
+	require.NotNil(t, req, "ポータルが同居しても歩き込みの発動が出る")
+	_, ok := req.Payload.(gc.OpenCubePanel)
+	assert.True(t, ok, "同居ポータルに隠されずコントロールパネルが開く")
+}
+
 // addCube は指定座標に押せるキューブを作る
 func addCube(t *testing.T, world w.World, coord consts.Coord[consts.Tile]) ecs.Entity {
 	t.Helper()


### PR DESCRIPTION
## 概要

NPC がポータルの上に立っていると、その NPC に話しかけても会話が発生しない不具合を直す。

## 原因

歩き込みの自動インタラクション `ExecuteMoveAction` は、移動先タイルの Interactable を **先着1件だけ** 取得し、その OnCollision 方式のインタラクションを実行していた。

- NPC の会話 `InteractionTalk` は `ActivationWayOnCollision`
- ポータル `InteractionPortalNext/Prev` は `ActivationWayManual`

両者が同じタイルに同居し、クエリでポータルが先着すると、Manual のポータルは OnCollision ループで弾かれて何もせず、NPC の会話に到達しないまま移動処理へ落ちていた。結果、会話が発火しない。

## 修正

`getInteractableAtSameTile`（先着1件を返す）を `interactablesAtSameTile`（同一タイルの生存 Interactable を全件返す）へ変える。`ExecuteMoveAction` は全件を走査して OnCollision を探し、最初に発動できるものを実行する。開いた扉や非敵対 Melee が発動せず次のエンティティへ流れる既存挙動は保つ。

## 検証

- **回帰テスト**を追加。Manual のポータルを同居させても OnCollision の歩き込み発動が隠れないことを固定。会話 NPC と同じ発動方式を CubePanel で代表させた
- fix を外して先着1件へ戻すとこのテストは FAIL、fix ありで PASS することを確認済み
- ヘルパ単体テストに「同一タイルに複数あれば全件返す」を追加
- `make check` 全緑

🤖 Generated with [Claude Code](https://claude.com/claude-code)