### PR TITLE
docs(loot): レビュー指摘の意図を2箇所コメントで補う

### DIFF
--- a/internal/balance/loot.go
+++ b/internal/balance/loot.go
@@ -57,6 +57,8 @@ func GenerateRoomLoot(master oapi.Raws, trials int, seed uint64) []FacilityLoot 
 		// role -> item -> 合計個数 / 出た試行数
 		total := map[string]map[string]int{}
 		present := map[string]map[string]int{}
+		// add は合計個数だけを積む。present は「その item が出た試行数」で試行ごとに1回だけ数えるため、
+		// ここでは触らず試行末尾の集計ループで加算する。present[role] の初期化だけここで揃えておく。
 		add := func(role, name string, count int) {
 			if total[role] == nil {
 				total[role] = map[string]int{}

--- a/internal/mapplanner/interior/sprite_golden_test.go
+++ b/internal/mapplanner/interior/sprite_golden_test.go
@@ -432,6 +432,7 @@ func drawLootMarker(img *image.RGBA, origin, pos Vec) {
 			}
 		}
 	}
+	// 文字は image/draw が dst 境界でクリップするので上限ガードは要らない。配置も計画層が footprint 内へ限る。
 	d.Dot = fixed.P(x0, y0+11) // basicfont.Face7x13 のベースラインは上端から約11px
 	d.DrawString(label)
 }


### PR DESCRIPTION
PR #612 のレビュー対応の follow-up。マージに間に合わなかったコメント2件を拾う。

## 変更
- `internal/balance/loot.go`: `add` クロージャが `present` を加算しない理由を明記。合計個数と「出た試行数」で加算経路を分ける意図を1行で残す。
- `internal/mapplanner/interior/sprite_golden_test.go`: loot マーカーの文字描画が `image/draw` の境界クリップで安全な理由を明記。上限ガードは不要。

いずれもコメントのみで挙動不変。`make check` 緑。

🤖 Generated with [Claude Code](https://claude.com/claude-code)