### PR TITLE
docs(design): コード監査タスク ダンジョン生成・戦闘継続・UI描画

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@
 | <img src="internal/states/testdata/TestGolden_LookAround.png" width="200" /><br>LookAround | <img src="internal/states/testdata/TestGolden_MainMenu.png" width="200" /><br>MainMenu | <img src="internal/states/testdata/TestGolden_Message.png" width="200" /><br>Message | <img src="internal/states/testdata/TestGolden_Overworld.png" width="200" /><br>Overworld |
 | <img src="internal/states/testdata/TestGolden_OverworldFrost.png" width="200" /><br>OverworldFrost | <img src="internal/states/testdata/TestGolden_OverworldMap.png" width="200" /><br>OverworldMap | <img src="internal/states/testdata/TestGolden_PersistentMessage.png" width="200" /><br>PersistentMessage | <img src="internal/states/testdata/TestGolden_SaveMenu.png" width="200" /><br>SaveMenu |
 | <img src="internal/states/testdata/TestGolden_SettingsMenu.png" width="200" /><br>SettingsMenu | <img src="internal/states/testdata/TestGolden_Shooting.png" width="200" /><br>Shooting | <img src="internal/states/testdata/TestGolden_ShopMenu.png" width="200" /><br>ShopMenu | <img src="internal/states/testdata/TestGolden_StorageMenu.png" width="200" /><br>StorageMenu |
+| <img src="internal/states/testdata/TestGolden_TavernMenu.png" width="200" /><br>TavernMenu | | | |
 
 
 各画像はゴールデンテストで自動生成される。
@@ -58,12 +59,13 @@ $ make help
 
 | status | ドキュメント | 進捗 | tags |
 |---|---|---|---|
-| in-progress | [activity パッケージのわかりやすさ改善](docs/design/260809163430.md) | 8/8（見送り2） | refactor |
 | draft | [難所調査から抽出した自走可能な改善のバックログ](docs/design/260724224417.md) | 0/11（見送り3） | refactor, ci, ecs, combat, meta |
 | draft | [施設内装の生成 —— doc 260725201431.md の未着手バックログ](docs/design/260731225939.md) | 1/33 | worldgen |
 | draft | [OSS 調査 2026-08](docs/design/260801002222.md) | 0/5 | meta, worldgen, combat, ui |
 | draft | [コード監査: ダンジョン生成・リロード・セーブ 2026-08-03](docs/design/260803144226.md) | 5/5 | worldgen, combat, save, ecs |
 | draft | [天気システムを設計する](docs/design/260805144630.md) | 0/7 | gamedesign, worldgen, ecs |
+| draft | [国際化 i18n を実装する](docs/design/260806095943.md) | 0/7 | meta, ui |
+| draft | [コード監査: ダンジョン生成・戦闘継続・UI描画 2026-08-10](docs/design/260810001803.md) | 0/5 | worldgen, combat, item, ui, ecs |
 
 
 ## Reference

--- a/README.md
+++ b/README.md
@@ -21,7 +21,6 @@
 | <img src="internal/states/testdata/TestGolden_LookAround.png" width="200" /><br>LookAround | <img src="internal/states/testdata/TestGolden_MainMenu.png" width="200" /><br>MainMenu | <img src="internal/states/testdata/TestGolden_Message.png" width="200" /><br>Message | <img src="internal/states/testdata/TestGolden_Overworld.png" width="200" /><br>Overworld |
 | <img src="internal/states/testdata/TestGolden_OverworldFrost.png" width="200" /><br>OverworldFrost | <img src="internal/states/testdata/TestGolden_OverworldMap.png" width="200" /><br>OverworldMap | <img src="internal/states/testdata/TestGolden_PersistentMessage.png" width="200" /><br>PersistentMessage | <img src="internal/states/testdata/TestGolden_SaveMenu.png" width="200" /><br>SaveMenu |
 | <img src="internal/states/testdata/TestGolden_SettingsMenu.png" width="200" /><br>SettingsMenu | <img src="internal/states/testdata/TestGolden_Shooting.png" width="200" /><br>Shooting | <img src="internal/states/testdata/TestGolden_ShopMenu.png" width="200" /><br>ShopMenu | <img src="internal/states/testdata/TestGolden_StorageMenu.png" width="200" /><br>StorageMenu |
-| <img src="internal/states/testdata/TestGolden_TavernMenu.png" width="200" /><br>TavernMenu | | | |
 
 
 各画像はゴールデンテストで自動生成される。
@@ -59,12 +58,12 @@ $ make help
 
 | status | ドキュメント | 進捗 | tags |
 |---|---|---|---|
+| in-progress | [activity パッケージのわかりやすさ改善](docs/design/260809163430.md) | 8/8（見送り2） | refactor |
 | draft | [難所調査から抽出した自走可能な改善のバックログ](docs/design/260724224417.md) | 0/11（見送り3） | refactor, ci, ecs, combat, meta |
 | draft | [施設内装の生成 —— doc 260725201431.md の未着手バックログ](docs/design/260731225939.md) | 1/33 | worldgen |
 | draft | [OSS 調査 2026-08](docs/design/260801002222.md) | 0/5 | meta, worldgen, combat, ui |
 | draft | [コード監査: ダンジョン生成・リロード・セーブ 2026-08-03](docs/design/260803144226.md) | 5/5 | worldgen, combat, save, ecs |
 | draft | [天気システムを設計する](docs/design/260805144630.md) | 0/7 | gamedesign, worldgen, ecs |
-| draft | [国際化 i18n を実装する](docs/design/260806095943.md) | 0/7 | meta, ui |
 | draft | [コード監査: ダンジョン生成・戦闘継続・UI描画 2026-08-10](docs/design/260810001803.md) | 0/5 | worldgen, combat, item, ui, ecs |
 
 

--- a/docs/design/260810001803.md
+++ b/docs/design/260810001803.md
@@ -14,7 +14,7 @@ auto: needs-decision
 
 なお、精読中に他にも2件の実在する不具合を検出したが、現行データでは到達不能な潜在的地雷のため今回は見送った。記録として残す。
 
-- `internal/systems/render_sprite.go:408` の回転軸計算が `-sprite.Width/2, -sprite.Width/2` と Y 軸にも `Width` を使っており、`visual_effect.go:278` の正しい実装（`-Width/2, -Height/2`）と食い違う。現行の全スプライト（`tiles.json`・`single.json`）が実測で 32×32 の正方形のため症状が出ないだけで、将来非正方形スプライトを追加した瞬間に位置ズレとして顕在化する。
+- `internal/systems/render_sprite.go:408` の回転軸計算が `-sprite.Width/2, -sprite.Width/2` と Y 軸にも `Width` を使っており、`visual_effect.go:278` の正しい実装（`-Width/2, -Height/2`）と食い違う。現行の全スプライト（`tiles.json`・`single.json`）が実測で 32×32 の正方形のため症状が出ないだけで、将来非正方形スプライトを追加した瞬間に位置ズレとして顕在化する。Y 軸に `Height` を使うべき箇所を `Width` で代用しているのは自明なので、現行データでもローリスクな1行修正として別 PR で先に潰す価値がある。
 - `internal/systems/animation_system.go:52` の `frameInterval := TotalAnimationDuration / numFrames` は `AnimKeys` が121要素以上になるとゼロ除算パニックする。現行の `raw.toml` はどのエンティティも数フレームしか持たないため到達しないが、ロード時の検証は無い。
 
 ## 問題
@@ -24,14 +24,14 @@ auto: needs-decision
 - **file:line**: `internal/mapplanner/lib.go:601-631`（`selectRoom`）、`:635-649`（`randomPositionInRoom`）、`:653-667`（`randomPositionNear`）、`:683-689`（`isInAnyRoom`）
 - **症状**: 部屋の右端列・下端行が、アイテム・NPC配置やポータル配置の候補から漏れる。1タイル幅/高さの部屋はアンカー部屋として一切選ばれなくなる。
 - **失敗シナリオ**: `internal/components/field.go:28` のコメントで「Max は右下の隅」、`rect_room_test.go:11-14` のコメントで「Max が inclusive 規約」と明記されている通り、`RoomDraw.rectangle`（`room_draw.go:24-25`）・`BigRoomBuilder`（`big_room.go:63-64,88,155-156,167`）・`RuinsPlanner`（`ruins_planner.go:62,75,94-95`）はすべて `x <= room.Max.X` の inclusive ループで床を敷く。ところが `lib.go` の4関数だけが `Rect.Width()`（`= Max - Min`、`+1`なし）をそのまま使い、または `x < room.Max.X` の exclusive 比較をしている。例えば `Min.X=5, Max.X=6` の2タイル幅の部屋は列5・6の両方が床になるが、`randomPositionInRoom` は `rw = 6-5 = 1` から `IntN(1)` で常に列5だけを選び、列6は `isInAnyRoom(6, y)` でも「部屋外」と判定される。結果、`ItemPlanner`・`HostileNPCPlanner`（`inRoomSelector`/`nearSelector`）・`PortalPlanner`（`reachableSelector`）が部屋の右端列・下端行を配置候補から一律で除外し続ける。さらに `selectRoom` の面積重み計算は `w, h := int(r.Width()), int(r.Height())` を使うため、1タイル幅または高さの部屋は `w > 0 && h > 0` を満たさず重みゼロとなり、アンカー部屋として一切選ばれない。
-- **修正方針案**: `isInAnyRoom`・`randomPositionNear` の比較を `<=` に、`randomPositionInRoom`・`selectRoom` の幅・高さ計算を `Width()+1`/`Height()+1` に揃え、`ruins_planner.go:94-95` と同じ `+1` パターンに統一する。境界値のテストを `rect_room_test.go` の隣接テストとして追加する。
+- **修正方針案**: `isInAnyRoom`・`randomPositionNear` の比較を `<=` に、`randomPositionInRoom`・`selectRoom` の幅・高さ計算を `Width()+1`/`Height()+1` に揃え、`ruins_planner.go:94-95` と同じ `+1` パターンに統一する。根本原因はこの `+1` 補正が `addInteriorWalls`（`ruins_planner.go:94`）だけに適用され `lib.go` の4関数に漏れている非対称なので、`+1` を要する箇所を1つの規約に寄せる。テストは数タイル幅・高さの部屋で右端列・下端行が配置候補に入るかを見るプロパティベーステストを `rect_room_test.go` に追加し、配置の偏りを検出する。
 
 ### 2. ログレベルが読み込まれる前に設定ファイル読み込み失敗の警告が出されるため、設定破損が無音になる
 
 - **file:line**: `internal/cmd/play.go:42-53`、`internal/config/manager.go:31`、`internal/logger/config.go:24-27`、`internal/logger/logger.go:76-93`
 - **症状**: ユーザー設定ファイル `~/.config/ruins/settings.toml` が壊れている、または型が合わない値を含む場合に出るはずの警告ログが、`RUINS_LOG_LEVEL` をどう設定していても一切出力されない。
 - **失敗シナリオ**: `logger/config.go:24-27` の `globalConfig` はパッケージ初期値として `DefaultLevel: LevelIgnore`（`Level` は `Debug=0 < Info=1 < Warn=2 < Error=3 < Fatal=4 < Ignore=5` の順）を持つ。`logger.go:92` の `log()` は `level < categoryLevel` なら早期returnするため、`Warn`（レベル2）はおろか `Error`・`Fatal` でさえ `Ignore`（5）未満で握り潰される。この初期値を書き換える唯一の経路が `logger.LoadFromConfig`（`play.go:53`）だが、呼び出し順は `EnsureUserConfigFile`（`play.go:42-44`、失敗時 `Warn`）→ `config.Load()`（`play.go:47`、内部の `manager.go:31` で `loadUserConfig()` 失敗時に `Warn`）→ `logger.LoadFromConfig`（`play.go:53`）の順であり、警告を出すべき2箇所は両方とも `LoadFromConfig` より**前**に実行される。つまり設定読み込みの失敗を伝えるはずの警告は、ロガーが有効化される前に投げられ、必ず握り潰される。プレイヤーがsettings.tomlを手編集して型を誤る、または前回終了時のクラッシュで書き込みが中断される等でこの経路に入ると、ゲームは無警告でデフォルト値にフォールバックし、ウィンドウサイズや言語設定が意図せず変わった原因を追う手がかりがログに一切残らない。
-- **修正方針案**: `config.Load()` が発生した警告をエラー値やスライスとして呼び出し側に返し、`logger.LoadFromConfig` 実行後にまとめてログ出力する。または環境変数だけで先にログレベルを決定して `LoadFromConfig` を `EnsureUserConfigFile`/`config.Load()` より前に呼ぶ。
+- **修正方針案**: `config.Load()` が発生した警告をエラー値やスライスとして呼び出し側に返し、`logger.LoadFromConfig` 実行後にまとめてログ出力する。こちらは初期化順を動かさず副作用が小さいので第一候補にする。別案として環境変数だけで先にログレベルを決定して `LoadFromConfig` を `EnsureUserConfigFile`/`config.Load()` より前に呼ぶ方法があるが、これは既存の `RUINS_LOG_LEVEL` 等の環境変数サポートの範囲を確認してから採否を決める。
 
 ### 3. クラフトレシピの素材名参照がロード時に検証されておらず、タイプミスが「素材不足」として無音に劣化する
 
@@ -52,12 +52,28 @@ auto: needs-decision
 - **file:line**: `internal/widgets/messagelog/widget.go:71-80`（`Widget.Draw`）
 - **症状**: ダンジョン探索中、HUDが描画されるたびに新しいオフスクリーン画像がGPU上に確保され、使い捨てられる。
 - **失敗シナリオ**: `Widget.Draw`（`widget.go:73-74`）はサイズが正なら毎回無条件に `ebiten.NewImage(width, height)` を呼び、ウィジェットの描画に一度使った後は参照を保持せず破棄する。`Draw` は `internal/widgets/hud/message_area.go:112` → `internal/systems/hud_rendering.go` の `HUDRenderingSystem.Run` 経由で、ダンジョン探索中は毎フレーム、すなわち60FPSなら1秒間に60回呼ばれる。同じ問題に対して `internal/screeneffect/filter.go:27-38`（`Pipeline.Begin`）はサイズが変わらない限り既存のオフスクリーンを再利用し、`internal/states/look_around.go`・`internal/states/shooting.go` は `sync.Once` で明示的にキャッシュしていることをコメントで残しており、これがこのコードベースで確立された規約であることが確認できる。`messagelog.Widget` だけがこの規約を欠き、プレイ時間に比例してGPUテクスチャ確保が積み重なり続ける。
-- **修正方針案**: `Widget` 構造体にオフスクリーンバッファを持たせ、`screeneffect.Pipeline.Begin` と同様に幅・高さが変わった時だけ再確保し、それ以外は `Clear()` して再利用する。
+- **修正方針案**: `Widget` 構造体にオフスクリーンバッファを持たせ、`screeneffect.Pipeline.Begin` と同様に幅・高さが変わった時だけ再確保し、それ以外は `Clear()` して再利用する。着手前にベンチマークで実害を測る。`ebiten.NewImage` が返す画像はファイナライザで GPU テクスチャを回収するため必ずしも線形に積み上がらず、クラッシュには至らない。実害は確保スパイクと GC プレッシャーの増大なので、規約逸脱の是正としては妥当でも優先度は測定結果で判断する。
+
+## 優先度
+
+着手順は修正コストと再現性で決める。
+
+| 優先度 | 件 | 理由 |
+|---|---|---|
+| 高 | 4 | 1行修正で再現シナリオが明確 |
+| 高 | 3 | 低コストでデータバグ防止の効果が大きい |
+| 中 | 1 | 配置偏りはゲームプレイに影響するが症状が地味 |
+| 中 | 2 | 設定破損時のデバッグ品質のみに影響する |
+| 低 | 5 | まず実害規模をベンチマークで確認する |
+
+背景記録の `render_sprite.go:408` の Y 軸 `Width` 誤用は、現行データでもローリスクな1行修正なので別 PR で先に潰す。
 
 ## 進捗
 
-- [ ] 1. `MetaPlan` の部屋選択・配置ヘルパーの `Rect.Max` 扱いを inclusive 規約に揃える
-- [ ] 2. ログ初期化順序を直し、設定読み込み失敗の警告が握り潰されないようにする
-- [ ] 3. `ValidateReferences` にレシピ素材名の参照検証を追加する
-- [ ] 4. `isAreaSafe` のクエリから `Dead` エンティティを除外する
-- [ ] 5. `messagelog.Widget.Draw` のオフスクリーン画像をキャッシュし毎フレーム確保をやめる
+着手順に並べる。
+
+- [ ] 4. `isAreaSafe` のクエリから `Dead` エンティティを除外する（高）
+- [ ] 3. `ValidateReferences` にレシピ素材名の参照検証を追加する（高）
+- [ ] 1. `MetaPlan` の部屋選択・配置ヘルパーの `Rect.Max` 扱いを inclusive 規約に揃える（中）
+- [ ] 2. ログ初期化順序を直し、設定読み込み失敗の警告が握り潰されないようにする（中）
+- [ ] 5. `messagelog.Widget.Draw` のオフスクリーン画像をキャッシュし毎フレーム確保をやめる（低）

--- a/docs/design/260810001803.md
+++ b/docs/design/260810001803.md
@@ -1,0 +1,63 @@
+---
+status: draft
+tags: [worldgen, combat, item, ui, ecs]
+auto: needs-decision
+---
+
+# コード監査: ダンジョン生成・戦闘継続・UI描画 2026-08-10
+
+## 背景
+
+自律コード監査ルーチンにより `internal/` 配下を6系統に分けて並列で横断的に精読した。golangci-lint（forcetypeassert・errcheck・nilerr/nilnil・exhaustive・makezero 等）が既に手厚く効いている前提で、機械的に捕まえられる問題は対象外とし、コードの意図と実装のズレを人手で追った。既存の監査doc（`260803144226.md` 等）で挙がった問題とは重複しない。
+
+各候補は検出後にさらに自分で該当ファイルを読み直して敵対的に再検証した。反証できず、具体的な失敗シナリオを再現できたものだけを以下に残す。修正はしていない。取捨選択はレビューに委ねる。
+
+なお、精読中に他にも2件の実在する不具合を検出したが、現行データでは到達不能な潜在的地雷のため今回は見送った。記録として残す。
+
+- `internal/systems/render_sprite.go:408` の回転軸計算が `-sprite.Width/2, -sprite.Width/2` と Y 軸にも `Width` を使っており、`visual_effect.go:278` の正しい実装（`-Width/2, -Height/2`）と食い違う。現行の全スプライト（`tiles.json`・`single.json`）が実測で 32×32 の正方形のため症状が出ないだけで、将来非正方形スプライトを追加した瞬間に位置ズレとして顕在化する。
+- `internal/systems/animation_system.go:52` の `frameInterval := TotalAnimationDuration / numFrames` は `AnimKeys` が121要素以上になるとゼロ除算パニックする。現行の `raw.toml` はどのエンティティも数フレームしか持たないため到達しないが、ロード時の検証は無い。
+
+## 問題
+
+### 1. `MetaPlan` の部屋選択・配置ヘルパーが `Rect.Max` を exclusive として扱っており、部屋描画の inclusive 規約と食い違う
+
+- **file:line**: `internal/mapplanner/lib.go:601-631`（`selectRoom`）、`:635-649`（`randomPositionInRoom`）、`:653-667`（`randomPositionNear`）、`:683-689`（`isInAnyRoom`）
+- **症状**: 部屋の右端列・下端行が、アイテム・NPC配置やポータル配置の候補から漏れる。1タイル幅/高さの部屋はアンカー部屋として一切選ばれなくなる。
+- **失敗シナリオ**: `internal/components/field.go:28` のコメントで「Max は右下の隅」、`rect_room_test.go:11-14` のコメントで「Max が inclusive 規約」と明記されている通り、`RoomDraw.rectangle`（`room_draw.go:24-25`）・`BigRoomBuilder`（`big_room.go:63-64,88,155-156,167`）・`RuinsPlanner`（`ruins_planner.go:62,75,94-95`）はすべて `x <= room.Max.X` の inclusive ループで床を敷く。ところが `lib.go` の4関数だけが `Rect.Width()`（`= Max - Min`、`+1`なし）をそのまま使い、または `x < room.Max.X` の exclusive 比較をしている。例えば `Min.X=5, Max.X=6` の2タイル幅の部屋は列5・6の両方が床になるが、`randomPositionInRoom` は `rw = 6-5 = 1` から `IntN(1)` で常に列5だけを選び、列6は `isInAnyRoom(6, y)` でも「部屋外」と判定される。結果、`ItemPlanner`・`HostileNPCPlanner`（`inRoomSelector`/`nearSelector`）・`PortalPlanner`（`reachableSelector`）が部屋の右端列・下端行を配置候補から一律で除外し続ける。さらに `selectRoom` の面積重み計算は `w, h := int(r.Width()), int(r.Height())` を使うため、1タイル幅または高さの部屋は `w > 0 && h > 0` を満たさず重みゼロとなり、アンカー部屋として一切選ばれない。
+- **修正方針案**: `isInAnyRoom`・`randomPositionNear` の比較を `<=` に、`randomPositionInRoom`・`selectRoom` の幅・高さ計算を `Width()+1`/`Height()+1` に揃え、`ruins_planner.go:94-95` と同じ `+1` パターンに統一する。境界値のテストを `rect_room_test.go` の隣接テストとして追加する。
+
+### 2. ログレベルが読み込まれる前に設定ファイル読み込み失敗の警告が出されるため、設定破損が無音になる
+
+- **file:line**: `internal/cmd/play.go:42-53`、`internal/config/manager.go:31`、`internal/logger/config.go:24-27`、`internal/logger/logger.go:76-93`
+- **症状**: ユーザー設定ファイル `~/.config/ruins/settings.toml` が壊れている、または型が合わない値を含む場合に出るはずの警告ログが、`RUINS_LOG_LEVEL` をどう設定していても一切出力されない。
+- **失敗シナリオ**: `logger/config.go:24-27` の `globalConfig` はパッケージ初期値として `DefaultLevel: LevelIgnore`（`Level` は `Debug=0 < Info=1 < Warn=2 < Error=3 < Fatal=4 < Ignore=5` の順）を持つ。`logger.go:92` の `log()` は `level < categoryLevel` なら早期returnするため、`Warn`（レベル2）はおろか `Error`・`Fatal` でさえ `Ignore`（5）未満で握り潰される。この初期値を書き換える唯一の経路が `logger.LoadFromConfig`（`play.go:53`）だが、呼び出し順は `EnsureUserConfigFile`（`play.go:42-44`、失敗時 `Warn`）→ `config.Load()`（`play.go:47`、内部の `manager.go:31` で `loadUserConfig()` 失敗時に `Warn`）→ `logger.LoadFromConfig`（`play.go:53`）の順であり、警告を出すべき2箇所は両方とも `LoadFromConfig` より**前**に実行される。つまり設定読み込みの失敗を伝えるはずの警告は、ロガーが有効化される前に投げられ、必ず握り潰される。プレイヤーがsettings.tomlを手編集して型を誤る、または前回終了時のクラッシュで書き込みが中断される等でこの経路に入ると、ゲームは無警告でデフォルト値にフォールバックし、ウィンドウサイズや言語設定が意図せず変わった原因を追う手がかりがログに一切残らない。
+- **修正方針案**: `config.Load()` が発生した警告をエラー値やスライスとして呼び出し側に返し、`logger.LoadFromConfig` 実行後にまとめてログ出力する。または環境変数だけで先にログレベルを決定して `LoadFromConfig` を `EnsureUserConfigFile`/`config.Load()` より前に呼ぶ。
+
+### 3. クラフトレシピの素材名参照がロード時に検証されておらず、タイプミスが「素材不足」として無音に劣化する
+
+- **file:line**: `internal/raw/validate.go:44-70`（`ValidateReferences` の呼び出し一覧）、`internal/raw/raw.go:336-348`（`NewRecipeSpec`）、`internal/world/gameaction/craft.go:55-73`（`CanCraft`）
+- **症状**: レシピの素材名 `oapi.Recipe.Inputs[].Name` にタイプミスがあってもロードは成功し、該当レシピはプレイ中ずっと「素材不足」表示のままクラフト不能になる。原因はUIにもログにも出ない。
+- **失敗シナリオ**: `ValidateReferences`（`validate.go:47-70`）は `validateItemTableReferences`・`validateItemGroupReferences`・`validateEnemyTableReferences`・`validateCommandTableWeaponReferences` など他テーブルの文字列参照は網羅的に検証するが、`Recipe.Inputs[].Name → Item` の参照だけは検証関数が存在しない。`oapi.Recipe` のスキーマ検証（`ValidateRaws`）も `EntityName` を単なる文字列制約としてしか見ないためタイプミスを検出できない。データ作成者が `assets/metadata/entities/raw/raw.toml` のレシピ素材名を誤記すると、`CanCraft`（`craft.go:55-73`）内の `query.FindStackableInInventory(world, recipeInput.Name)` が単純な名前一致スキャンのため必ず `found=false` を返し、`CanCraft` は `(false, nil)` を返す。**エラーではなく単なる「不可」**として扱われるため、プレイヤーは他の素材をどれだけ持っていてもそのレシピを永久にクラフトできず、原因もログに残らない。これは `validateCommandTableWeaponReferences` が武器名タイプミス対策として既に導入されているのと全く同じ失敗モードで、`validate.go` 自身のコメント（「実行時の解決失敗をロード時エラーに前倒しする」）が意図する対称性をレシピだけが欠いている。
+- **修正方針案**: `validateItemTableReferences` 等と同じパターンで `validateRecipeReferences` を追加し、`Recipes[].Inputs[].Name` が `Items` に存在することを検証して `ValidateReferences` から呼ぶ。
+
+### 4. `isAreaSafe` が死亡直後・未清掃のエンティティを敵として数え、休息・読書・分解を誤って中断する
+
+- **file:line**: `internal/activity/activity.go:205-230`（`isAreaSafe`）
+- **症状**: 隣接する敵を仲間が倒した直後、`DeadCleanupSystem` による削除が間に合わないタイミングでプレイヤーが休息・読書・分解を試みると、「周囲に敵がいるため中断」と表示されてしまう。実際には脅威は既に死亡している。
+- **失敗シナリオ**: `isAreaSafe`（`activity.go:216`）は `query.ActiveFilter1[gc.GridElement](world)` でエンティティを走査するが、この `ActiveFilter1`（`query/active.go:29-31`）は `Suspended` だけを除外し `Dead` は除外しない。敵対判定の `query.FactionRelation`（`query/faction.go:36-49`）も `Dead` を一切見ない。一方 `internal/states/dungeon.go:205-221` のシステム実行順は `AnimationSystem → DeadCleanupSystem → TurnSystem → ...` で、`DeadCleanupSystem` は**1フレームにつき1回**しか呼ばれない。`TurnSystem.fastForwardActivity`（`turn_system.go:77-95`）は休息等の待機コマンドで最大100ターンを1フレーム内で圧縮実行し、その中で毎ターン `runAIPhase` を呼ぶ。この圧縮ループの最中に仲間が隣接する敵を倒すと、その敵は `Dead` を付与されるが `DeadCleanupSystem` は次フレームまで呼ばれないため、同じ圧縮ループ内の次ターンの `isAreaSafe` はまだ削除されていない死体を拾い、`FactionRelation` が `RelationHostile` を返し、`hasHostile = true` になる。`query.FindNearestCharacter`（`query/nearest.go:66`）や `player_actions.go:125`・`auto_interaction_system.go:39` など他の到達可能性判定は `.Without(ecs.C[gc.Dead]())` を明示的に付けており、`query/active.go` 自身のコメントもこれを標準パターンとして案内しているが、`isAreaSafe` だけがこの除外を欠いている。
+- **修正方針案**: `isAreaSafe` のクエリに `.Without(ecs.C[gc.Dead]())` を追加し、`query.ActiveFilter1[gc.GridElement](world).Without(ecs.C[gc.Dead]()).Query()` とする。
+
+### 5. メッセージログHUDウィジェットが毎フレーム `ebiten.NewImage` をキャッシュ・破棄なしに確保している
+
+- **file:line**: `internal/widgets/messagelog/widget.go:71-80`（`Widget.Draw`）
+- **症状**: ダンジョン探索中、HUDが描画されるたびに新しいオフスクリーン画像がGPU上に確保され、使い捨てられる。
+- **失敗シナリオ**: `Widget.Draw`（`widget.go:73-74`）はサイズが正なら毎回無条件に `ebiten.NewImage(width, height)` を呼び、ウィジェットの描画に一度使った後は参照を保持せず破棄する。`Draw` は `internal/widgets/hud/message_area.go:112` → `internal/systems/hud_rendering.go` の `HUDRenderingSystem.Run` 経由で、ダンジョン探索中は毎フレーム、すなわち60FPSなら1秒間に60回呼ばれる。同じ問題に対して `internal/screeneffect/filter.go:27-38`（`Pipeline.Begin`）はサイズが変わらない限り既存のオフスクリーンを再利用し、`internal/states/look_around.go`・`internal/states/shooting.go` は `sync.Once` で明示的にキャッシュしていることをコメントで残しており、これがこのコードベースで確立された規約であることが確認できる。`messagelog.Widget` だけがこの規約を欠き、プレイ時間に比例してGPUテクスチャ確保が積み重なり続ける。
+- **修正方針案**: `Widget` 構造体にオフスクリーンバッファを持たせ、`screeneffect.Pipeline.Begin` と同様に幅・高さが変わった時だけ再確保し、それ以外は `Clear()` して再利用する。
+
+## 進捗
+
+- [ ] 1. `MetaPlan` の部屋選択・配置ヘルパーの `Rect.Max` 扱いを inclusive 規約に揃える
+- [ ] 2. ログ初期化順序を直し、設定読み込み失敗の警告が握り潰されないようにする
+- [ ] 3. `ValidateReferences` にレシピ素材名の参照検証を追加する
+- [ ] 4. `isAreaSafe` のクエリから `Dead` エンティティを除外する
+- [ ] 5. `messagelog.Widget.Draw` のオフスクリーン画像をキャッシュし毎フレーム確保をやめる


### PR DESCRIPTION
## 概要

自律コード監査ルーチンにより `internal/` 配下を6系統に分けて並列で横断的に精読した。golangci-lint（forcetypeassert・errcheck・nilerr/nilnil・exhaustive・makezero 等）が既に手厚く効いている前提で、機械的に捕まえられる問題は対象外とし、コードの意図と実装のズレを人手で追った。各候補は検出後に自分で該当ファイルを読み直して敵対的に再検証し、反証できず具体的な失敗シナリオを示せたものだけを残した。

コードの修正はしていない。docs/design/260810001803.md にタスクdocを1本追加するのみ。**これは提案であり、実際に着手するかどうかは人がレビューで取捨選択する。**

## 検出した問題（5件）

1. `internal/mapplanner/lib.go` の部屋選択・配置ヘルパー4関数が `Rect.Max` を exclusive として扱っており、`RoomDraw` 等の inclusive 規約と食い違う。全ダンジョンで部屋の右端列・下端行がアイテム/NPC/ポータル配置の候補から漏れ、1タイル幅/高さの部屋はアンカーとして選ばれない。
2. `internal/cmd/play.go`・`internal/config/manager.go` の設定読み込み失敗の警告が、ログレベルが読み込まれる前に発行されるため必ず握り潰される。設定ファイル破損時に原因を追う手がかりがログに残らない。
3. `internal/raw/validate.go` の `ValidateReferences` がクラフトレシピの素材名参照だけ検証しておらず、タイプミスがロード時エラーにならず「素材不足」として無音に劣化する。武器名参照で既に導入済みの対策がレシピには及んでいない。
4. `internal/activity/activity.go` の `isAreaSafe` が `Dead` エンティティを除外しておらず、`TurnSystem.fastForwardActivity` の圧縮ターン内で仲間が敵を倒した直後、未清掃の死体を敵として数えて休息・読書・分解を誤って中断する。
5. `internal/widgets/messagelog/widget.go` の `Widget.Draw` が毎フレーム `ebiten.NewImage` をキャッシュ・破棄なしに確保しており、他のコードで確立されているキャッシュ規約から外れている。ダンジョン探索中継続的にGPUテクスチャ確保が積み重なる。

詳細は各項目の file:line・失敗シナリオ・修正方針案を `docs/design/260810001803.md` に記載。

精読中に他2件の実在する不具合も見つけたが、現行データでは到達不能な潜在的地雷のため今回のタスクdocには起票せず、doc内の「背景」に記録のみ残した（`render_sprite.go` の回転軸計算のWidth/Height取り違え、`animation_system.go` のアニメーションフレーム数121以上でのゼロ除算）。

## テスト計画

- [x] `go build ./...`
- [x] `make generate`（README再生成・`go run . designdoc validate` 相当を含む）
- [ ] レビューでの取捨選択後、着手する項目ごとに `make check`

---
_Generated by [Claude Code](https://claude.ai/code/session_01NgHeuYwY6YymhKDCo6TSLR)_