### PR TITLE
fix(shop): 価値0アイテムの売却クラッシュを直す

### DIFF
--- a/internal/states/shop_menu.go
+++ b/internal/states/shop_menu.go
@@ -7,7 +7,6 @@ import (
 	"github.com/ebitenui/ebitenui/widget"
 	"github.com/hajimehoshi/ebiten/v2"
 	gc "github.com/kijimaD/ruins/internal/components"
-	"github.com/kijimaD/ruins/internal/consts"
 	es "github.com/kijimaD/ruins/internal/engine/states"
 	"github.com/kijimaD/ruins/internal/input"
 	"github.com/kijimaD/ruins/internal/inputmapper"
@@ -114,21 +113,17 @@ type shopItemData struct {
 	Disabled bool       // 所持金が足りず選べない
 }
 
-// Fetch は世界から表示 props を構築する。menurt.Model の Model 部にあたる
+// Fetch は世界から表示 props を構築する。menurt.Model の Model 部にあたる。
+// プレイヤーが居なければ空の props を返す。価格は query.BuyPrice/SellPrice が取引と揃えて出す
 func (st *ShopMenuState) Fetch(world w.World) ShopProps {
-	var currency int
-	buyPriceMod, sellPriceMod := consts.PercentBase, consts.PercentBase
-	query.Player(world, func(playerEntity ecs.Entity) {
-		currency = query.GetCurrency(world, playerEntity)
-		if world.Components.CharModifiers.Has(playerEntity) {
-			mods := world.Components.CharModifiers.Get(playerEntity)
-			buyPriceMod = mods.BuyPrice
-			sellPriceMod = mods.SellPrice
-		}
-	})
+	player, err := query.GetPlayerEntity(world)
+	if err != nil {
+		return ShopProps{}
+	}
+	currency := query.GetCurrency(world, player)
 
 	return ShopProps{
-		Tabs: st.createTabs(world, currency, buyPriceMod, sellPriceMod),
+		Tabs: st.createTabs(world, player, currency),
 	}
 }
 
@@ -141,21 +136,20 @@ func (st *ShopMenuState) Menu(props ShopProps) menurt.MenuConfig {
 	return menurt.MenuConfig{Key: "shop", TabCount: len(props.Tabs), ItemCounts: itemCounts, ItemsPerPage: menuItemsPerPage}
 }
 
-func (st *ShopMenuState) createTabs(world w.World, currency int, buyPriceMod, sellPriceMod consts.Percent) []shopTabData {
+func (st *ShopMenuState) createTabs(world w.World, player ecs.Entity, currency int) []shopTabData {
 	return []shopTabData{
-		{ID: "buy", Label: query.T(world, "Buy"), Items: st.createBuyItems(world, currency, buyPriceMod)},
-		{ID: "sell", Label: query.T(world, "Sell"), Items: st.createSellItems(world, sellPriceMod)},
+		{ID: "buy", Label: query.T(world, "Buy"), Items: st.createBuyItems(world, player, currency)},
+		{ID: "sell", Label: query.T(world, "Sell"), Items: st.createSellItems(world, player)},
 	}
 }
 
 // createBuyItems は商人の在庫を買いタブへ並べる。アイテムと隊員候補が同列に並ぶ
-func (st *ShopMenuState) createBuyItems(world w.World, currency int, buyPriceMod consts.Percent) []shopItemData {
+func (st *ShopMenuState) createBuyItems(world w.World, player ecs.Entity, currency int) []shopItemData {
 	stock := query.GetStorageItems(world, st.merchant)
 	items := make([]shopItemData, 0, len(stock))
 
 	for _, entity := range stock {
-		base := query.GetItemValue(world, entity) * query.GetEntityCount(world, entity)
-		price := buyPriceMod.ApplyInt(query.CalculateBuyPrice(base))
+		price := query.BuyPrice(world, player, entity)
 		items = append(items, shopItemData{
 			Entity:   entity,
 			Price:    price,
@@ -167,20 +161,13 @@ func (st *ShopMenuState) createBuyItems(world w.World, currency int, buyPriceMod
 	return items
 }
 
-// createSellItems はプレイヤーの持ち物を売りタブへ並べる。売ると実体が商人の在庫へ移る。
-// プレイヤーが居ないときは何も並べない。存在確認を先に済ませ、収集クエリは query.Player の
-// コールバック外で回してクエリのネストを避ける
-func (st *ShopMenuState) createSellItems(world w.World, sellPriceMod consts.Percent) []shopItemData {
-	if _, err := query.GetPlayerEntity(world); err != nil {
-		return nil
-	}
-
+// createSellItems はプレイヤーの持ち物を売りタブへ並べる。売ると実体が商人の在庫へ移る
+func (st *ShopMenuState) createSellItems(world w.World, player ecs.Entity) []shopItemData {
 	var items []shopItemData
 	sellQuery := ecs.NewFilter2[gc.Name, gc.LocationInBackpack](world.ECS).Query()
 	for sellQuery.Next() {
 		entity := sellQuery.Entity()
-		base := query.GetItemValue(world, entity) * query.GetEntityCount(world, entity)
-		price := sellPriceMod.ApplyInt(query.CalculateSellPrice(base))
+		price := query.SellPrice(world, player, entity)
 		items = append(items, shopItemData{
 			Entity: entity,
 			Price:  price,
@@ -224,6 +211,10 @@ func (st *ShopMenuState) buySellSelected(world w.World) error {
 		if err != nil {
 			return fmt.Errorf("failed to buy: %w", err)
 		}
+		return nil
+	}
+	// 選択が古く実体が消えていれば何もしない。dead entity への移動は panic するため先に守る
+	if !world.ECS.Alive(item.Entity) {
 		return nil
 	}
 	var err error

--- a/internal/states/shop_menu_test.go
+++ b/internal/states/shop_menu_test.go
@@ -3,9 +3,11 @@ package states
 import (
 	"testing"
 
+	"github.com/kijimaD/ruins/internal/consts"
 	es "github.com/kijimaD/ruins/internal/engine/states"
 	"github.com/kijimaD/ruins/internal/inputmapper"
 	"github.com/kijimaD/ruins/internal/testutil"
+	"github.com/kijimaD/ruins/internal/world/lifecycle"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -27,6 +29,9 @@ func TestShopMenuState_FetchProps(t *testing.T) {
 	state := &ShopMenuState{}
 	world := testutil.InitTestWorld(t)
 	require.NoError(t, state.OnStart(world))
+	// ショップはプレイヤーが居て初めて開く。価格はプレイヤーの交渉スキルから決まるため必須
+	_, err := lifecycle.SpawnPlayer(world, consts.Coord[consts.Tile]{X: 5, Y: 5}, "ash")
+	require.NoError(t, err)
 
 	props := state.Fetch(world)
 

--- a/internal/world/gameaction/shop.go
+++ b/internal/world/gameaction/shop.go
@@ -12,7 +12,7 @@ import (
 // BuyStock はプレイヤーが商人の在庫アイテムを買う。実体を商人の収納からプレイヤーのバックパックへ移す。
 // 通貨が足りなければ何もせずエラーを返す
 func BuyStock(world w.World, player ecs.Entity, item ecs.Entity) error {
-	price := buyPrice(world, player, item)
+	price := query.BuyPrice(world, player, item)
 
 	if !query.HasCurrency(world, player, price) {
 		return fmt.Errorf("not enough currency: need %d, have %d", price, query.GetCurrency(world, player))
@@ -35,10 +35,7 @@ func BuyStock(world w.World, player ecs.Entity, item ecs.Entity) error {
 // SellStock はプレイヤーが持ち物を商人へ売る。実体を商人の収納へ移し、代金を受け取る。
 // 売った品は商人の在庫として店頭に並ぶ
 func SellStock(world w.World, player ecs.Entity, merchant ecs.Entity, item ecs.Entity) error {
-	price := sellPrice(world, player, item)
-	if price == 0 {
-		return fmt.Errorf("this item cannot be sold")
-	}
+	price := query.SellPrice(world, player, item)
 
 	if err := lifecycle.MoveToStorage(world, item, merchant); err != nil {
 		return fmt.Errorf("failed to move item to merchant storage: %w", err)
@@ -57,7 +54,7 @@ func SellStock(world w.World, player ecs.Entity, merchant ecs.Entity, item ecs.E
 // HireRecruit はプレイヤーが商人の在庫の隊員候補を雇う。候補を隊員として活性化し、代金を支払う。
 // 通貨が足りなければ何もせずエラーを返す
 func HireRecruit(world w.World, player ecs.Entity, recruit ecs.Entity) error {
-	price := buyPrice(world, player, recruit)
+	price := query.BuyPrice(world, player, recruit)
 
 	if !query.HasCurrency(world, player, price) {
 		return fmt.Errorf("not enough currency: need %d, have %d", price, query.GetCurrency(world, player))
@@ -75,24 +72,4 @@ func HireRecruit(world w.World, player ecs.Entity, recruit ecs.Entity) error {
 	}
 
 	return nil
-}
-
-// buyPrice は交渉スキルの買値倍率込みの購入価格を返す
-func buyPrice(world w.World, player ecs.Entity, entity ecs.Entity) int {
-	base := query.GetItemValue(world, entity) * query.GetEntityCount(world, entity)
-	price := query.CalculateBuyPrice(base)
-	if world.Components.CharModifiers.Has(player) {
-		price = world.Components.CharModifiers.Get(player).BuyPrice.ApplyInt(price)
-	}
-	return price
-}
-
-// sellPrice は交渉スキルの売値倍率込みの売却価格を返す
-func sellPrice(world w.World, player ecs.Entity, entity ecs.Entity) int {
-	base := query.GetItemValue(world, entity) * query.GetEntityCount(world, entity)
-	price := query.CalculateSellPrice(base)
-	if world.Components.CharModifiers.Has(player) {
-		price = world.Components.CharModifiers.Get(player).SellPrice.ApplyInt(price)
-	}
-	return price
 }

--- a/internal/world/gameaction/shop_extra_test.go
+++ b/internal/world/gameaction/shop_extra_test.go
@@ -67,8 +67,8 @@ func TestBuyStock_交渉スキルで買値が変わる(t *testing.T) {
 	assert.Equal(t, 1000-discountedPrice, currency, "買値倍率50%で半額になる")
 }
 
-// TestSellStock_価値0のアイテムは売却できない はValueコンポーネントを持たないアイテムの売却がエラーになることを確認する。
-func TestSellStock_価値0のアイテムは売却できない(t *testing.T) {
+// TestSellStock_価値0のアイテムは対価0で売れる は無価値な品でも売却は成功し、対価が0になることを確認する。
+func TestSellStock_価値0のアイテムは対価0で売れる(t *testing.T) {
 	t.Parallel()
 	world := testutil.InitTestWorld(t)
 
@@ -76,12 +76,19 @@ func TestSellStock_価値0のアイテムは売却できない(t *testing.T) {
 	world.Components.Wallet.Add(player, &gc.Wallet{Currency: 0})
 	merchant := world.ECS.NewEntity()
 	item := world.ECS.NewEntity()
+	world.Components.Value.Add(item, &gc.Value{Value: 0})
+	world.Components.Name.Add(item, &gc.Name{Name: "Scrap"})
+	world.Components.RawID.Add(item, &gc.RawID{ID: "scrap"})
+	world.Components.Stackable.Add(item, &gc.Stackable{Count: 1})
 
-	err := SellStock(world, player, merchant, item)
-	require.ErrorContains(t, err, "cannot be sold")
+	require.NoError(t, SellStock(world, player, merchant, item), "価値0でも売却は成功する")
 
 	currency := query.GetCurrency(world, player)
-	assert.Equal(t, 0, currency, "売却失敗時は通貨が変動しない")
+	assert.Equal(t, 0, currency, "無価値な品の対価は0で通貨は増えない")
+
+	// 売った品は商人の在庫へ並ぶ
+	require.True(t, world.Components.LocationInStorage.Has(item), "実体は商人の収納へ移る")
+	assert.Equal(t, merchant, world.Components.LocationInStorage.Get(item).Owner)
 }
 
 // TestSellStock_交渉スキルで売値が変わる はCharModifiers.SellPriceが売却価格に反映されることを確認する。

--- a/internal/world/query/shop.go
+++ b/internal/world/query/shop.go
@@ -21,6 +21,29 @@ func CalculateSellPrice(baseValue int) int {
 	return int(float64(baseValue) * SellPriceMultiplier)
 }
 
+// BuyPrice はプレイヤーが entity を買うときの、交渉スキルの買値倍率込みの購入価格を返す。
+// base は価値と個数の積。店頭の表示価格と取引価格をこの1関数で揃える
+func BuyPrice(world w.World, player ecs.Entity, entity ecs.Entity) int {
+	base := GetItemValue(world, entity) * GetEntityCount(world, entity)
+	price := CalculateBuyPrice(base)
+	if world.Components.CharModifiers.Has(player) {
+		price = world.Components.CharModifiers.Get(player).BuyPrice.ApplyInt(price)
+	}
+	return price
+}
+
+// SellPrice はプレイヤーが entity を売るときの、交渉スキルの売値倍率込みの売却価格を返す。
+// base は価値と個数の積。店頭の表示価格と取引価格をこの1関数で揃える。
+// 無価値な品は素直に 0 を返す。売却自体は他の品と同様に可能で、対価が 0 になるだけ
+func SellPrice(world w.World, player ecs.Entity, entity ecs.Entity) int {
+	base := GetItemValue(world, entity) * GetEntityCount(world, entity)
+	price := CalculateSellPrice(base)
+	if world.Components.CharModifiers.Has(player) {
+		price = world.Components.CharModifiers.Get(player).SellPrice.ApplyInt(price)
+	}
+	return price
+}
+
 // GetItemValue はアイテムの基本価値を取得する
 func GetItemValue(world w.World, entity ecs.Entity) int {
 	if !world.Components.Value.Has(entity) {

--- a/internal/world/query/shop_test.go
+++ b/internal/world/query/shop_test.go
@@ -39,7 +39,7 @@ func TestCalculateSellPrice(t *testing.T) {
 		{"価値100", 100, 50},
 		{"価値50", 50, 25},
 		{"価値0", 0, 0},
-		{"価値1", 1, 0},
+		{"価値1は切り捨てで0", 1, 0},
 	}
 
 	for _, tt := range tests {
@@ -48,6 +48,79 @@ func TestCalculateSellPrice(t *testing.T) {
 			assert.Equal(t, tt.want, CalculateSellPrice(tt.baseValue))
 		})
 	}
+}
+
+// TestSellPrice は表示と取引で共有する売値を検証する。交渉倍率・個数連動・無価値な品の対価0を覆う
+func TestSellPrice(t *testing.T) {
+	t.Parallel()
+
+	t.Run("価値0の売値は0", func(t *testing.T) {
+		t.Parallel()
+		world := testutil.InitTestWorld(t)
+		player := world.ECS.NewEntity()
+		item := world.ECS.NewEntity()
+		world.Components.Value.Add(item, &gc.Value{Value: 0})
+
+		assert.Equal(t, 0, SellPrice(world, player, item), "無価値な品の対価は0")
+	})
+
+	t.Run("倍率なしは価値の半分", func(t *testing.T) {
+		t.Parallel()
+		world := testutil.InitTestWorld(t)
+		player := world.ECS.NewEntity()
+		item := world.ECS.NewEntity()
+		world.Components.Value.Add(item, &gc.Value{Value: 100})
+
+		assert.Equal(t, 50, SellPrice(world, player, item), "CalculateSellPrice(100)=50")
+	})
+
+	t.Run("交渉スキルの売値倍率が乗る", func(t *testing.T) {
+		t.Parallel()
+		world := testutil.InitTestWorld(t)
+		player := world.ECS.NewEntity()
+		world.Components.CharModifiers.Add(player, &gc.CharModifiers{SellPrice: 200})
+		item := world.ECS.NewEntity()
+		world.Components.Value.Add(item, &gc.Value{Value: 100})
+
+		assert.Equal(t, 100, SellPrice(world, player, item), "売値倍率200%で50が倍額100")
+	})
+
+	t.Run("個数分だけ価値が乗る", func(t *testing.T) {
+		t.Parallel()
+		world := testutil.InitTestWorld(t)
+		player := world.ECS.NewEntity()
+		item := world.ECS.NewEntity()
+		world.Components.Value.Add(item, &gc.Value{Value: 100})
+		world.Components.Stackable.Add(item, &gc.Stackable{Count: 3})
+
+		assert.Equal(t, 150, SellPrice(world, player, item), "価値100×3個の半分")
+	})
+}
+
+// TestBuyPrice は表示と取引で共有する買値を検証する。交渉倍率・個数連動を覆う
+func TestBuyPrice(t *testing.T) {
+	t.Parallel()
+
+	t.Run("倍率なしは価値の2倍", func(t *testing.T) {
+		t.Parallel()
+		world := testutil.InitTestWorld(t)
+		player := world.ECS.NewEntity()
+		item := world.ECS.NewEntity()
+		world.Components.Value.Add(item, &gc.Value{Value: 100})
+
+		assert.Equal(t, 200, BuyPrice(world, player, item), "CalculateBuyPrice(100)=200")
+	})
+
+	t.Run("交渉スキルの買値倍率が乗る", func(t *testing.T) {
+		t.Parallel()
+		world := testutil.InitTestWorld(t)
+		player := world.ECS.NewEntity()
+		world.Components.CharModifiers.Add(player, &gc.CharModifiers{BuyPrice: 50})
+		item := world.ECS.NewEntity()
+		world.Components.Value.Add(item, &gc.Value{Value: 100})
+
+		assert.Equal(t, 100, BuyPrice(world, player, item), "買値倍率50%で200が半額100")
+	})
 }
 
 func TestGetItemValue(t *testing.T) {


### PR DESCRIPTION
## 概要

鉄くずなど `value=0` のアイテムを売るとクラッシュしていた不具合を修正する。無価値な品も他の品と同様に売却でき、対価が0になるだけにする。あわせて売買価格の計算を `query` へ一本化する。

## 原因

売値が0のとき `SellStock` が `this item cannot be sold` を致命エラーで返し、`command execution failed: failed to sell: this item cannot be sold` でプロセスが落ちていた。売却不能という正常な状態を fatal error で返していたのが真因。

## 設計方針

「本当に無価値なものは value 0 のまま」を原則とする。raw データは触らず、floor も敷かない。無価値な品は素直に対価0で売れる。0 が「無価値」の意味を保つ。

## 修正

- `SellStock` の `price==0` 致命パスを除去する。無価値でも売却は成功し、通貨が増えないだけ
- `query.BuyPrice` / `query.SellPrice` を新設し、価値×個数・Calculate・交渉倍率を集約する。表示価格と取引価格を同じ関数から出し、両者がずれる余地を構造的に無くす
- `gameaction` の private `buyPrice` / `sellPrice` を削除し query を直接呼ぶ
- `states` は倍率の抽出と受け渡しをやめ、player を渡して query を呼ぶだけにする
- 売却ハンドラに実体消滅ガードを追加する。古い選択で dead entity を売る panic を買いと対称に塞ぐ
- player 不在の判定を `Fetch` に集約する

## 検証

- `make check` 緑。lint 0 issues・脆弱性なし
- 価値0の売却テスト、`query.SellPrice`/`BuyPrice` のユニットテストを追加

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017bNxVvzzwu4wL4GvYiCSxM