### PR TITLE
test(lifecycle): カバレッジ増強

### DIFF
--- a/internal/world/lifecycle/spawn_prop_test.go
+++ b/internal/world/lifecycle/spawn_prop_test.go
@@ -52,3 +52,70 @@ func TestSpawnDungeonEntrance_ダンジョンポータルと同じアニメフ�
 	require.True(t, world.Components.DungeonEntrance.Has(e), "遺跡入口コンポーネントを持つ")
 	assert.Equal(t, "亡者の森", world.Components.DungeonEntrance.Get(e).DefinitionName, "進入先の遺跡定義名を運ぶ")
 }
+
+func TestOpenDoor_開くと通行と視界を遮らなくなる(t *testing.T) {
+	t.Parallel()
+	world := testutil.InitTestWorld(t)
+
+	door, err := lifecycle.SpawnDoor(world, consts.Coord[consts.Tile]{X: 3, Y: 4}, gc.DoorOrientationHorizontal)
+	require.NoError(t, err)
+	require.True(t, world.Components.BlockPass.Has(door), "生成直後は通行不可")
+	require.True(t, world.Components.BlockView.Has(door), "生成直後は視界を遮る")
+
+	require.NoError(t, lifecycle.OpenDoor(world, door))
+
+	assert.True(t, world.Components.Door.Get(door).IsOpen, "開いた状態になる")
+	assert.False(t, world.Components.BlockPass.Has(door), "通行可能になる")
+	assert.False(t, world.Components.BlockView.Has(door), "視界を遮らなくなる")
+	assert.Equal(t, "door_horizontal_open", world.Components.SpriteRender.Get(door).SpriteKey)
+}
+
+func TestOpenDoor_縦向きの扉は縦向きのスプライトになる(t *testing.T) {
+	t.Parallel()
+	world := testutil.InitTestWorld(t)
+
+	door, err := lifecycle.SpawnDoor(world, consts.Coord[consts.Tile]{X: 3, Y: 4}, gc.DoorOrientationVertical)
+	require.NoError(t, err)
+
+	require.NoError(t, lifecycle.OpenDoor(world, door))
+
+	assert.Equal(t, "door_vertical_open", world.Components.SpriteRender.Get(door).SpriteKey)
+}
+
+func TestOpenDoor_扉でないエンティティはエラーになる(t *testing.T) {
+	t.Parallel()
+	world := testutil.InitTestWorld(t)
+	notDoor := world.ECS.NewEntity()
+
+	err := lifecycle.OpenDoor(world, notDoor)
+
+	require.Error(t, err)
+	assert.EqualError(t, err, "entity is not a door")
+}
+
+func TestCloseDoor_閉じると通行不可と視界遮断に戻る(t *testing.T) {
+	t.Parallel()
+	world := testutil.InitTestWorld(t)
+
+	door, err := lifecycle.SpawnDoor(world, consts.Coord[consts.Tile]{X: 3, Y: 4}, gc.DoorOrientationHorizontal)
+	require.NoError(t, err)
+	require.NoError(t, lifecycle.OpenDoor(world, door))
+
+	require.NoError(t, lifecycle.CloseDoor(world, door))
+
+	assert.False(t, world.Components.Door.Get(door).IsOpen, "閉じた状態になる")
+	assert.True(t, world.Components.BlockPass.Has(door), "通行不可に戻る")
+	assert.True(t, world.Components.BlockView.Has(door), "視界を遮るようになる")
+	assert.Equal(t, "door_horizontal_closed", world.Components.SpriteRender.Get(door).SpriteKey)
+}
+
+func TestCloseDoor_扉でないエンティティはエラーになる(t *testing.T) {
+	t.Parallel()
+	world := testutil.InitTestWorld(t)
+	notDoor := world.ECS.NewEntity()
+
+	err := lifecycle.CloseDoor(world, notDoor)
+
+	require.Error(t, err)
+	assert.EqualError(t, err, "entity is not a door")
+}

--- a/internal/world/lifecycle/spawn_test.go
+++ b/internal/world/lifecycle/spawn_test.go
@@ -420,3 +420,67 @@ func TestAllItemsBelongToInventoryCategory(t *testing.T) {
 	}
 	assert.Empty(t, uncategorized, "InventoryCategoryに属していないアイテム: %v", uncategorized)
 }
+
+func TestSpawnNeutralNPC_商人を生成すると在庫と会話データを持つ(t *testing.T) {
+	t.Parallel()
+
+	world := testutil.InitTestWorld(t)
+
+	npc, err := SpawnNeutralNPC(world, consts.Coord[consts.Tile]{X: 3, Y: 4}, "merchant")
+	require.NoError(t, err)
+
+	require.True(t, world.Components.FactionNeutral.Has(npc), "中立派閥を持つ")
+	require.True(t, world.Components.Dialog.Has(npc), "会話データを持つ")
+	assert.Equal(t, "merchant_greeting", world.Components.Dialog.Get(npc).MessageKey)
+
+	require.True(t, world.Components.GridElement.Has(npc))
+	assert.Equal(t, consts.Coord[consts.Tile]{X: 3, Y: 4}, world.Components.GridElement.Get(npc).Coord)
+
+	require.True(t, world.Components.HP.Has(npc))
+	hp := world.Components.HP.Get(npc)
+	assert.Equal(t, hp.Max, hp.Current, "全回復した状態で生成される")
+
+	require.True(t, world.Components.SoloAI.Has(npc), "移動パターンを持つのでAIを持つ")
+	solo := world.Components.SoloAI.Get(npc)
+	assert.Equal(t, gc.AIStateWaiting, solo.SubState)
+	assert.Equal(t, consts.Coord[consts.Tile]{X: 3, Y: 4}, solo.Origin, "生成位置がパトロール原点になる")
+	assert.Equal(t, consts.AIVisionDistance, solo.ViewDistance)
+
+	stock := query.GetStorageItems(world, npc)
+	assert.Len(t, stock, len(merchantStockItems), "商人は定義数の在庫を積む")
+}
+
+func TestSpawnNeutralNPC_商人以外は在庫を積まない(t *testing.T) {
+	t.Parallel()
+
+	world := testutil.InitTestWorld(t)
+
+	npc, err := SpawnNeutralNPC(world, consts.Coord[consts.Tile]{X: 1, Y: 1}, "suspicious_scientist")
+	require.NoError(t, err)
+
+	require.True(t, world.Components.FactionNeutral.Has(npc))
+	stock := query.GetStorageItems(world, npc)
+	assert.Empty(t, stock, "商人でないNPCは在庫を積まない")
+}
+
+func TestSpawnNeutralNPC_中立でないメンバーはエラーになる(t *testing.T) {
+	t.Parallel()
+
+	world := testutil.InitTestWorld(t)
+
+	_, err := SpawnNeutralNPC(world, consts.Coord[consts.Tile]{X: 0, Y: 0}, "ash")
+
+	require.Error(t, err)
+	assert.EqualError(t, err, "'ash' is not a neutral NPC")
+}
+
+func TestSpawnNeutralNPC_存在しない名前はエラーになる(t *testing.T) {
+	t.Parallel()
+
+	world := testutil.InitTestWorld(t)
+
+	_, err := SpawnNeutralNPC(world, consts.Coord[consts.Tile]{X: 0, Y: 0}, "no_such_member")
+
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "failed to generate neutral NPC")
+}


### PR DESCRIPTION
## 概要

`internal/world/lifecycle` パッケージへテストを追加し、カバレッジを増強する。本体コードの変更はなし。

## カバレッジ

- 変更前: 77.6%
- 変更後: 89.4%

## 追加したテスト

### `internal/world/lifecycle/spawn_prop_test.go`
`OpenDoor` / `CloseDoor` / `updateDoorState` はテストが無く0%だった。

- `TestOpenDoor_開くと通行と視界を遮らなくなる`: 扉を開くと `IsOpen` が真になり、`BlockPass` / `BlockView` が外れ、横向きのスプライトキーが `door_horizontal_open` に切り替わることを検証する
- `TestOpenDoor_縦向きの扉は縦向きのスプライトになる`: 縦向きの扉を開くとスプライトキーが `door_vertical_open` になることを検証する
- `TestOpenDoor_扉でないエンティティはエラーになる`: `Door` コンポーネントを持たないエンティティへの `OpenDoor` はエラー文言まで検証する
- `TestCloseDoor_閉じると通行不可と視界遮断に戻る`: 開いた扉を閉じると `BlockPass` / `BlockView` が付け直され、スプライトキーが `door_horizontal_closed` に戻ることを検証する
- `TestCloseDoor_扉でないエンティティはエラーになる`: `CloseDoor` のエラーパスをエラー文言まで検証する

### `internal/world/lifecycle/spawn_test.go`
`SpawnNeutralNPC` はテストが無く0%だった。

- `TestSpawnNeutralNPC_商人を生成すると在庫と会話データを持つ`: `merchant` を生成すると `FactionNeutral` / `Dialog` を持ち、全回復した状態で、位置がパトロール原点になり、定義数の在庫を積むことを検証する
- `TestSpawnNeutralNPC_商人以外は在庫を積まない`: `suspicious_scientist` は在庫を積まないことを検証する
- `TestSpawnNeutralNPC_中立でないメンバーはエラーになる`: `FactionNeutral` を持たないメンバーはエラー文言まで検証する
- `TestSpawnNeutralNPC_存在しない名前はエラーになる`: 存在しない名前を渡した場合のエラーを検証する

## 検証

- `make test`: 成功
- `make lint`: golangci-lint は0件。`govulncheck` はこの実行環境のネットワークポリシーで `vuln.go.dev` への接続が拒否されて失敗しており、本差分とは無関係な環境上の制約

---
_Generated by [Claude Code](https://claude.ai/code/session_01PWy8rxo5zuSvt5Go8hEsHQ)_