### PR TITLE
fix(render): 開いた扉はドロップシャドウを落とさない

### DIFF
--- a/internal/world/lifecycle/spawn_prop.go
+++ b/internal/world/lifecycle/spawn_prop.go
@@ -37,17 +37,21 @@ func updateDoorState(world w.World, doorEntity ecs.Entity, orientation gc.DoorOr
 	doorComp.Orientation = orientation
 	doorComp.IsOpen = isOpen
 
-	// スプライトキーを更新
+	// スプライトキーと高さを更新する。
+	// 開いた扉は平らな低い物として扱い、高さを下げる。高さが無いのでドロップシャドウを落とさず、
+	// 背の高い物の後ろに沈む。閉じた扉は高さのある障壁に戻す。
 	if world.Components.SpriteRender.Has(doorEntity) {
 		spriteRender := world.Components.SpriteRender.Get(doorEntity)
 
 		if isOpen {
+			spriteRender.Depth = gc.DepthNumRug
 			if orientation == gc.DoorOrientationHorizontal {
 				spriteRender.SpriteKey = "door_horizontal_open"
 			} else {
 				spriteRender.SpriteKey = "door_vertical_open"
 			}
 		} else {
+			spriteRender.Depth = gc.DepthNumTaller
 			if orientation == gc.DoorOrientationHorizontal {
 				spriteRender.SpriteKey = "door_horizontal_closed"
 			} else {

--- a/internal/world/lifecycle/spawn_test.go
+++ b/internal/world/lifecycle/spawn_test.go
@@ -360,6 +360,25 @@ func TestSpawnDoor(t *testing.T) {
 	})
 }
 
+func TestDoor_開閉で高さが切り替わる(t *testing.T) {
+	t.Parallel()
+	world := testutil.InitTestWorld(t)
+
+	door, err := SpawnDoor(world, consts.Coord[consts.Tile]{X: 10, Y: 10}, gc.DoorOrientationHorizontal)
+	require.NoError(t, err)
+
+	// 閉じた扉は高さのある障壁で、ドロップシャドウを落とす高さ
+	assert.Equal(t, gc.DepthNumTaller, world.Components.SpriteRender.Get(door).Depth)
+
+	// 開くと平らな低い物になり、影を落とさない高さへ下がる
+	require.NoError(t, OpenDoor(world, door))
+	assert.Equal(t, gc.DepthNumRug, world.Components.SpriteRender.Get(door).Depth)
+
+	// 閉じると高さが戻る
+	require.NoError(t, CloseDoor(world, door))
+	assert.Equal(t, gc.DepthNumTaller, world.Components.SpriteRender.Get(door).Depth)
+}
+
 func TestSpawnVisualEffect(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## 背景

扉が開いた状態でも、物体の下に出る黒い矩形のドロップシャドウが残っていた。

## 原因

`renderShadows` の「物体の影」パスは `Fixed`（または `TurnBased`）と高さ `Depth` でシャドウ対象を拾う。扉は開くと `BlockView`/`BlockPass` は外れるが `Fixed` と高さ `Depth`（`DepthNumTaller`）は残るため、このパスに拾われて影が残っていた。

## 変更（開閉で高さを切り替える）

- `updateDoorState` で開閉に応じて `Depth` を切り替える。開いた扉は平らな低い物として `DepthNumRug`、閉じた扉は高さのある障壁 `DepthNumTaller`
- 影は既存の「高さ `Depth > DepthNumRug` のものだけが落とす」判定で描かれるので、開いた扉は閾値から自然に外れる。**影の描画側 `render_sprite` は一切変更しない**

Depth は「影の可否」と「描画順」の両方を決める。副作用として開いた扉は背の高い物の後ろに沈むが、開いて平らに退く見た目として妥当。プレイヤーは元々最前面なので変化なし。

## テスト

- `TestDoor_開閉で高さが切り替わる`（`internal/world/lifecycle`）: 閉→`DepthNumTaller`、開→`DepthNumRug`、再び閉→`DepthNumTaller` の遷移を固定。これが影の有無に直結する

## 検証

- `make check` 通過（テスト緑・lint 0 issues・脆弱性なし）
- 既存ドアトグルテストも緑。既存 golden に開扉シーンが無いため golden 差分なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)