### PR TITLE
docs(design): 進捗が全完了の設計 doc を done にする

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,13 +98,10 @@ $ make help
 
 | status | ドキュメント | 進捗 | tags |
 |---|---|---|---|
-| in-progress | [activity パッケージのわかりやすさ改善](docs/design/260809163430.md) | 8/8（見送り2） | refactor |
-| in-progress | [一覧のセルをアイコンを持てる型にし、アイテム・装備にアイコンを表示する](docs/design/260810093849.md) | 7/7 | ui, item |
 | in-progress | [隊員（NPC 仲間）を削除する](docs/design/260810222240.md) | 3/4（見送り1） | gamedesign, member |
 | draft | [難所調査から抽出した自走可能な改善のバックログ](docs/design/260724224417.md) | 0/11（見送り3） | refactor, ci, ecs, combat, meta |
 | draft | [施設内装の生成 —— doc 260725201431.md の未着手バックログ](docs/design/260731225939.md) | 1/33 | worldgen |
 | draft | [OSS 調査 2026-08](docs/design/260801002222.md) | 0/5 | meta, worldgen, combat, ui |
-| draft | [コード監査: ダンジョン生成・リロード・セーブ 2026-08-03](docs/design/260803144226.md) | 5/5 | worldgen, combat, save, ecs |
 | draft | [天気システムを設計する](docs/design/260805144630.md) | 0/7 | gamedesign, worldgen, ecs |
 | draft | [コード監査: ダンジョン生成・戦闘継続・UI描画 2026-08-10](docs/design/260810001803.md) | 0/5 | worldgen, combat, item, ui, ecs |
 | draft | [食料の腐敗](docs/design/260813080544.md) | 0/11（見送り2） | item, gamedesign |

--- a/README.md
+++ b/README.md
@@ -98,7 +98,6 @@ $ make help
 
 | status | ドキュメント | 進捗 | tags |
 |---|---|---|---|
-| in-progress | [隊員（NPC 仲間）を削除する](docs/design/260810222240.md) | 3/4（見送り1） | gamedesign, member |
 | draft | [難所調査から抽出した自走可能な改善のバックログ](docs/design/260724224417.md) | 0/11（見送り3） | refactor, ci, ecs, combat, meta |
 | draft | [施設内装の生成 —— doc 260725201431.md の未着手バックログ](docs/design/260731225939.md) | 1/33 | worldgen |
 | draft | [OSS 調査 2026-08](docs/design/260801002222.md) | 0/5 | meta, worldgen, combat, ui |

--- a/docs/design/260803144226.md
+++ b/docs/design/260803144226.md
@@ -1,5 +1,5 @@
 ---
-status: draft
+status: done
 tags: [worldgen, combat, save, ecs]
 auto: needs-decision
 ---

--- a/docs/design/260809163430.md
+++ b/docs/design/260809163430.md
@@ -1,5 +1,5 @@
 ---
-status: in-progress # draft|accepted|in-progress|done|superseded|dropped
+status: done # draft|accepted|in-progress|done|superseded|dropped
 tags: [refactor] # 領域ラベル
 auto: needs-decision # mechanical=無人着手可 / needs-decision=人の判断必須
 ---

--- a/docs/design/260810093849.md
+++ b/docs/design/260810093849.md
@@ -1,5 +1,5 @@
 ---
-status: in-progress # draft|accepted|in-progress|done|superseded|dropped
+status: done # draft|accepted|in-progress|done|superseded|dropped
 tags: [ui, item]
 auto: needs-decision
 ---

--- a/docs/design/260810222240.md
+++ b/docs/design/260810222240.md
@@ -1,5 +1,5 @@
 ---
-status: in-progress # draft|accepted|in-progress|done|superseded|dropped
+status: done # draft|accepted|in-progress|done|superseded|dropped
 tags: [gamedesign, member]
 auto: needs-decision # mechanical=無人着手可 / needs-decision=人の判断必須
 ---
@@ -45,5 +45,5 @@ auto: needs-decision # mechanical=無人着手可 / needs-decision=人の判断�
 - [x] design.md から隊員前提の節と散在参照を削除する
 - [x] 隊員専用 mock を削除し index を整理する
 - [x] 隊員関連コード（SquadMember・SquadPolicy 等）を除去する
-- [ ] 単独プレイ向けの押し・運搬・補給・行動順を再設計する（連鎖課題）
+- [~] 単独プレイ向けの押し・運搬・補給・行動順の再設計は本 doc の対象外とし、別途詰める連鎖課題とする
 - [~] 分隊制・基地建設モード・役割分担主軸は不採用


### PR DESCRIPTION
## 概要

進捗の open な `- [ ]` がゼロになった設計 doc を done へ遷移する。done の基準は `internal/designdoc/doc.go` の「open な `- [ ]` がゼロ」。README の未完了一覧から外れる。コード変更は無い。

## 対象

| doc | 旧 status | 内容 |
|---|---|---|
| 260803144226 | draft | 起動時クラッシュ耐性・参照検証。PR #584 系で全完了 |
| 260809163430 | in-progress | アクティビティの Execute→Validate 一本化・命名整理。`[x]`＋`[~]` のみ |
| 260810093849 | in-progress | アイテムメニューのセル/アイコン化。7件すべて完了 |
| 260810222240 | in-progress | 隊員（NPC 仲間）の削除。PR #632 で完了 |

## 補足: 260810222240 の open タスク是正

隊員削除 doc に1件だけ open な「単独プレイ向けの再設計（連鎖課題）」が残っていた。ただし doc 本文が「本 doc では決めず、別途詰める連鎖課題」「solo 機構は未決として空けておく」と明言しており、この再設計は doc のスコープ外。`- [ ]` でなく `- [~]`（見送り、別途）が本来の姿なので是正した。削除そのものは完了している。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D1o2YJAmJdWCD5efK84yt9