### PR TITLE
test(resources): NewUIResources の並列テスト競合をロックで直列化する

### DIFF
--- a/internal/resources/ui_test.go
+++ b/internal/resources/ui_test.go
@@ -2,6 +2,7 @@ package resources
 
 import (
 	"image/color"
+	"sync"
 	"testing"
 
 	"github.com/hajimehoshi/ebiten/v2/text/v2"
@@ -9,12 +10,26 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// ebitenui のグローバル状態、NineSlice キャッシュ等は並行アクセス安全でない。
+// 並列テストが同時に触れると競合するため、その生成をこのロックで直列化する。
+var ebitenuiMu sync.Mutex
+
+func withUILock(fn func()) {
+	ebitenuiMu.Lock()
+	defer ebitenuiMu.Unlock()
+	fn()
+}
+
 func TestNewUIResources_正常系で全リソースが構築される(t *testing.T) {
 	t.Parallel()
 
 	src := newTestFaceSource(t)
 
-	ui, err := NewUIResources([]*text.GoTextFaceSource{src})
+	var ui UIResources
+	var err error
+	withUILock(func() {
+		ui, err = NewUIResources([]*text.GoTextFaceSource{src})
+	})
 
 	require.NoError(t, err)
 	assert.NotNil(t, ui.Fonts)
@@ -65,7 +80,11 @@ func TestNewUIResources_正常系で全リソースが構築される(t *testing
 func TestNewUIResources_フォントソースが空だとエラー(t *testing.T) {
 	t.Parallel()
 
-	ui, err := NewUIResources(nil)
+	var ui UIResources
+	var err error
+	withUILock(func() {
+		ui, err = NewUIResources(nil)
+	})
 
 	require.Error(t, err)
 	require.ErrorIs(t, err, errNoFontSource)


### PR DESCRIPTION
## 概要

`race-check` CI が `internal/resources` で DATA RACE により失敗していた。原因を特定し、テスト側で直列化して解消する。

## 原因

`ebitenui/image.NewNineSliceColor` はロック無しのパッケージグローバル map `colorNineSlices` を色キャッシュに使う。`t.Parallel()` の複数テストが `NewUIResources()` 経由で同時にこの map を読み書きして競合していた。`NewUIResources` は先頭で `NewNineSliceColor` を呼ぶため、フォント無しで早期 return するテストも到達する。

- 競合当事者: `TestNewUIResources_正常系` と `TestNewUIResources_フォントソースが空だとエラー`
- `-race` 無しの通常 `test` では検出されず、`-shuffle=on` で並列順が変わるため flaky に見えていたが、実際は確定的なバグ

## なぜテスト側で直すか

ebitenui は単一 goroutine 前提のライブラリで、内部キャッシュに sync を持たない設計。本番は `maingame` の初期化で1回だけ `NewUIResources` を呼ぶため競合しない。競合は `t.Parallel()` がテストに持ち込んだ並列性に起因する。よって修正はテスト側の直列化が筋であり、既存の `vrt.WithUILock` と同じ方針を取る。

`internal/vrt` が `internal/resources` を import しており循環になるため vrt のものは直接使えない。同形の `withUILock` を resources テスト内に置く。

## 変更

- `internal/resources/ui_test.go` に `withUILock(fn func())` を追加し、`NewUIResources` 呼び出しを直列化。`t.Parallel()` は維持

本番コード変更なし。テストのみ。

## 検証

- `-race -shuffle=on` で5回連続 `ok`
- `make lint` 0 issues。`paralleltest`/`tparallel` も通過
- govulncheck クリーン

🤖 Generated with [Claude Code](https://claude.com/claude-code)