### PR TITLE
refactor(currency): 通貨に専用型 consts.Currency を導入する

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,6 @@ $ make help
 | status | ドキュメント | 進捗 | tags |
 |---|---|---|---|
 | in-progress | [通信販売: オークション形式の販売機構](docs/design/260814170822.md) | 5/6（見送り2） | gamedesign, item, ui |
-| accepted | [通貨に専用型 consts.Currency を導入する](docs/design/260816193627.md) | 0/6 | refactor, ui, item |
 | draft | [難所調査から抽出した自走可能な改善のバックログ](docs/design/260724224417.md) | 0/11（見送り3） | refactor, ci, ecs, combat, meta |
 | draft | [施設内装の生成 —— doc 260725201431.md の未着手バックログ](docs/design/260731225939.md) | 1/33 | worldgen |
 | draft | [OSS 調査 2026-08](docs/design/260801002222.md) | 0/5 | meta, worldgen, combat, ui |

--- a/docs/design/260816193627.md
+++ b/docs/design/260816193627.md
@@ -69,6 +69,7 @@ func AddCurrency(world w.World, e ecs.Entity, amount consts.Currency) error
 - 純粋に機械的な型付けで挙動は変わらない。着手時は `make check` で型不整合を洗い切る。
 - 別セッションで一括着手する想定。範囲はリポジトリ全体で確定済み。
 - アイテム基礎値 `gc.Value` は int のまま残す。通貨ドメインは財布・価格・入札・台帳に置き、`value → price`、`weight → 送料` は `Milligram → 送料` と同じ意味的な派生点として `consts.Currency(...)` で変換する。これは消すべき単位取り違え境界ではない。汎用モディファイア `Percent.ApplyInt` も int のままで、価格側で変換する。
+- 整数厳密性は金額の保持と加減算、比較に効く。価格や手数料は乗率が小数なので `float64` を経由して掛け、`consts.Currency` へ切り捨てる。これは `Milligram` の `ParseWeight` が `math.Round` を通すのと同じで、格納後の演算に float を持ち込まないという方針とは両立する。
 - 整形は `consts.Currency.String()` に集約し、`query.FormatCurrency` は廃止した。整形テストも `internal/consts/currency_test.go` へ移した。
 
 ## 進捗

--- a/docs/design/260816193627.md
+++ b/docs/design/260816193627.md
@@ -1,5 +1,5 @@
 ---
-status: accepted # draft|accepted|in-progress|done|superseded|dropped
+status: done # draft|accepted|in-progress|done|superseded|dropped
 tags: [refactor, ui, item]
 auto: mechanical # mechanical=無人着手可 / needs-decision=人の判断必須
 ---
@@ -68,12 +68,14 @@ func AddCurrency(world w.World, e ecs.Entity, amount consts.Currency) error
 - `consts.Milligram` が手本。整数演算と表示整形の分離、単位取り違えの型検知という利点をそのまま得る。
 - 純粋に機械的な型付けで挙動は変わらない。着手時は `make check` で型不整合を洗い切る。
 - 別セッションで一括着手する想定。範囲はリポジトリ全体で確定済み。
+- アイテム基礎値 `gc.Value` は int のまま残す。通貨ドメインは財布・価格・入札・台帳に置き、`value → price`、`weight → 送料` は `Milligram → 送料` と同じ意味的な派生点として `consts.Currency(...)` で変換する。これは消すべき単位取り違え境界ではない。汎用モディファイア `Percent.ApplyInt` も int のままで、価格側で変換する。
+- 整形は `consts.Currency.String()` に集約し、`query.FormatCurrency` は廃止した。整形テストも `internal/consts/currency_test.go` へ移した。
 
 ## 進捗
 
-- [ ] `consts.Currency` 型と `String()` を新設し整形を移設する
-- [ ] `Wallet.Currency` と `query` の通貨関数を `consts.Currency` へ
-- [ ] ショップと `gameaction` の価格を `consts.Currency` へ
-- [ ] HUD の通貨表示を `consts.Currency` へ
-- [ ] オークションの金額フィールドと定数を `consts.Currency` へ
-- [ ] `make check` で型不整合ゼロを確認する
+- [x] `consts.Currency` 型と `String()` を新設し整形を移設する
+- [x] `Wallet.Currency` と `query` の通貨関数を `consts.Currency` へ
+- [x] ショップと `gameaction` の価格を `consts.Currency` へ
+- [x] HUD の通貨表示を `consts.Currency` へ
+- [x] オークションの金額フィールドと定数を `consts.Currency` へ
+- [x] `make check` で型不整合ゼロを確認する

--- a/internal/components/auction.go
+++ b/internal/components/auction.go
@@ -1,5 +1,7 @@
 package components
 
+import "github.com/kijimaD/ruins/internal/consts"
+
 // 通信販売オークションの状態モデル。
 // 1つの品はオークションを一方向に進む。状態は専用の enum でなく、どのコンポーネントを持つかと、
 // 持ち物か出荷場所の収納かの位置で表す。
@@ -20,19 +22,19 @@ package components
 // AuctionListing は出品中の品に付く実行時状態。タグを貼った時点で採番し、以後その出品を Number で指す。
 // 入札が来るたび CurrentBid が上がり競売が延長する。入札が止まったターンに落札が確定し AuctionSold へ移る。
 type AuctionListing struct {
-	Number     int // 出品の連番。アイテム詳細で確認できる一意の識別子
-	CurrentBid int // 現在の入札額。入札が来るたびに上がる
-	LastTurn   int // 直近に入札判定した総ターン数。1ターンに1回だけ判定する
+	Number     int             // 出品の連番。アイテム詳細で確認できる一意の識別子
+	CurrentBid consts.Currency // 現在の入札額。入札が来るたびに上がる
+	LastTurn   int             // 直近に入札判定した総ターン数。1ターンに1回だけ判定する
 }
 
 // AuctionSold は落札済みで未出荷の品に付く実行時状態。出荷場所での出荷を待つ。
 // 落札から出荷には期限があり、期限までに積荷へ渡さないと店の評判が下がる。
 // 出荷すると手取りを入金し履歴へ記録して品を手放す。
 type AuctionSold struct {
-	Number    int  // 出品時の連番を引き継ぐ
-	Bid       int  // 確定した落札額。手取りは出荷時に発送料と手数料を引いて求める
-	DueTurn   int  // 出荷期限のターン。このターンまでに積荷へ渡さないと評判ペナルティを負う
-	Penalized bool // 期限超過のペナルティを既に課したか。二重に課さないための印
+	Number    int             // 出品時の連番を引き継ぐ
+	Bid       consts.Currency // 確定した落札額。手取りは出荷時に発送料と手数料を引いて求める
+	DueTurn   int             // 出荷期限のターン。このターンまでに積荷へ渡さないと評判ペナルティを負う
+	Penalized bool            // 期限超過のペナルティを既に課したか。二重に課さないための印
 }
 
 // AuctionStation はオークションの出荷場所。積荷はこの prop の収納に置き、集荷タイマーもここが持つ。
@@ -43,13 +45,13 @@ type AuctionStation struct {
 
 // AuctionRecord は1件の出荷実績。落札額から送料と手数料を引いた手取りまでを残す。
 type AuctionRecord struct {
-	Number int    // 出品の連番
-	Name   string // 売れた品の表示名
-	Bid    int    // 落札額
-	Ship   int    // 送料。重量に比例する
-	Fee    int    // 手数料。落札額に比例する
-	Net    int    // 手取り。落札額から送料と手数料を引いた額
-	Turn   int    // 売れた総ターン数
+	Number int             // 出品の連番
+	Name   string          // 売れた品の表示名
+	Bid    consts.Currency // 落札額
+	Ship   consts.Currency // 送料。重量に比例する
+	Fee    consts.Currency // 手数料。落札額に比例する
+	Net    consts.Currency // 手取り。落札額から送料と手数料を引いた額
+	Turn   int             // 売れた総ターン数
 }
 
 // AuctionEntryKind は金銭明細の種別。受取金か請求か。
@@ -68,10 +70,10 @@ type AuctionEntry struct {
 	Kind   AuctionEntryKind // 受取金か請求か
 	Number int              // 受取金のとき出品の連番。請求は0
 	Name   string           // 表示名。品名または請求名
-	Amount int              // 受取金は手取り、請求は請求額
-	Bid    int              // 明細の内訳。受取金のとき意味を持つ落札額
-	Ship   int              // 明細の内訳。配送料
-	Fee    int              // 明細の内訳。手数料
+	Amount consts.Currency  // 受取金は手取り、請求は請求額
+	Bid    consts.Currency  // 明細の内訳。受取金のとき意味を持つ落札額
+	Ship   consts.Currency  // 明細の内訳。配送料
+	Fee    consts.Currency  // 明細の内訳。手数料
 }
 
 // AuctionHistory は金銭明細と出荷実績の履歴、採番カウンタ、店の評判を持つシングルトン。

--- a/internal/components/components.go
+++ b/internal/components/components.go
@@ -101,7 +101,7 @@ type Dead struct{}
 
 // Wallet はプレイヤーの資金を管理する
 type Wallet struct {
-	Currency int
+	Currency consts.Currency
 }
 
 // HP は生命力・耐久を表すコンポーネント

--- a/internal/consts/currency.go
+++ b/internal/consts/currency.go
@@ -10,14 +10,13 @@ import (
 type Currency int
 
 // String はカンマ区切りと通貨記号で整形する。3桁ごとにカンマを入れ、負値は先頭に符号を付ける。
-// float 変換や整形はこの内部だけに閉じ、演算は Currency の int で行う
 func (c Currency) String() string {
 	str := fmt.Sprintf("%d", int(c))
 
 	negative := false
 	if c < 0 {
 		negative = true
-		str = str[1:] // マイナス記号を除去してから桁区切りする
+		str = str[1:]
 	}
 
 	var result string

--- a/internal/consts/currency.go
+++ b/internal/consts/currency.go
@@ -1,0 +1,36 @@
+package consts
+
+import (
+	"fmt"
+)
+
+// Currency は所持金や価格などの金額。整数で正確に扱い、表示整形は String に閉じる。
+// float の丸め誤差を避けるため加減算と比較はこの整数で行う。
+// 重量 Milligram と同じ設計で、単位取り違えを型で弾くために素の int と区別する。
+type Currency int
+
+// String はカンマ区切りと通貨記号で整形する。3桁ごとにカンマを入れ、負値は先頭に符号を付ける。
+// float 変換や整形はこの内部だけに閉じ、演算は Currency の int で行う
+func (c Currency) String() string {
+	str := fmt.Sprintf("%d", int(c))
+
+	negative := false
+	if c < 0 {
+		negative = true
+		str = str[1:] // マイナス記号を除去してから桁区切りする
+	}
+
+	var result string
+	for i, ch := range str {
+		if i > 0 && (len(str)-i)%3 == 0 {
+			result += ","
+		}
+		result += string(ch)
+	}
+
+	if negative {
+		result = "-" + result
+	}
+
+	return fmt.Sprintf("%s %s", IconCurrency, result)
+}

--- a/internal/consts/currency_test.go
+++ b/internal/consts/currency_test.go
@@ -1,0 +1,36 @@
+package consts
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCurrency_String_カンマ区切りと通貨記号で整形する(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		amount   Currency
+		expected string
+	}{
+		{"0", 0, "󱪯 0"},
+		{"1桁", 5, "󱪯 5"},
+		{"2桁", 99, "󱪯 99"},
+		{"3桁", 999, "󱪯 999"},
+		{"4桁でカンマ1つ", 1000, "󱪯 1,000"},
+		{"5桁", 12345, "󱪯 12,345"},
+		{"6桁", 100204, "󱪯 100,204"},
+		{"7桁", 1234567, "󱪯 1,234,567"},
+		{"8桁", 10000000, "󱪯 10,000,000"},
+		{"負の数", -1234, "󱪯 -1,234"},
+		{"負の数で大きい", -1234567, "󱪯 -1,234,567"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.expected, tt.amount.String())
+		})
+	}
+}

--- a/internal/save/serde_test.go
+++ b/internal/save/serde_test.go
@@ -331,12 +331,12 @@ func TestSerdeAuctionRoundtrip(t *testing.T) {
 		gotSold = newWorld.Components.AuctionSold.Get(sq.Entity())
 	}
 	require.NotNil(t, gotSold, "落札済みの品が復元される")
-	assert.Equal(t, 250, gotSold.Bid, "落札額が復元される")
+	assert.Equal(t, consts.Currency(250), gotSold.Bid, "落札額が復元される")
 	assert.Equal(t, 40, gotSold.DueTurn, "出荷期限が復元される")
 
 	nh := query.GetAuctionHistory(newWorld)
 	assert.Equal(t, 80, nh.Reputation, "店の評判が復元される")
 	require.Len(t, nh.Entries, 1, "未精算の金銭明細が復元される")
 	assert.Equal(t, gc.AuctionEntryReceipt, nh.Entries[0].Kind, "明細の種別が復元される")
-	assert.Equal(t, 120, nh.Entries[0].Amount, "明細の金額が復元される")
+	assert.Equal(t, consts.Currency(120), nh.Entries[0].Amount, "明細の金額が復元される")
 }

--- a/internal/states/auction_menu.go
+++ b/internal/states/auction_menu.go
@@ -9,6 +9,7 @@ import (
 	"github.com/ebitenui/ebitenui/widget"
 	"github.com/hajimehoshi/ebiten/v2"
 	gc "github.com/kijimaD/ruins/internal/components"
+	"github.com/kijimaD/ruins/internal/consts"
 	es "github.com/kijimaD/ruins/internal/engine/states"
 	"github.com/kijimaD/ruins/internal/gamelog"
 	"github.com/kijimaD/ruins/internal/input"
@@ -114,19 +115,19 @@ type auctionTabData struct {
 type auctionItemRow struct {
 	Entity   ecs.Entity
 	Name     string
-	Status   string // 落札済みか出品中
-	Value    int    // 入札額。落札済みは落札額、出品中は現在値
-	HasValue bool   // 金額を出すか
+	Status   string          // 落札済みか出品中
+	Value    consts.Currency // 入札額。落札済みは落札額、出品中は現在値
+	HasValue bool            // 金額を出すか
 }
 
 // auctionLedgerRow は進行中・履歴タブの1行
 type auctionLedgerRow struct {
 	Number  int
 	Name    string
-	Bid     int
-	Ship    int
-	Fee     int
-	Net     int
+	Bid     consts.Currency
+	Ship    consts.Currency
+	Fee     consts.Currency
+	Net     consts.Currency
 	Turn    int
 	Ongoing bool
 	Shipped bool
@@ -301,11 +302,11 @@ func (st *AuctionMenuState) settleEntry(world w.World, index int) error {
 	switch e.Kind {
 	case gc.AuctionEntryReceipt:
 		gamelog.New(query.GetGameLog(world)).
-			Markup(query.T(world, "Collected %s. Received %s.", gamelog.Tag("item", e.Name), query.FormatCurrency(e.Amount))).
+			Markup(query.T(world, "Collected %s. Received %s.", gamelog.Tag("item", e.Name), e.Amount.String())).
 			Log()
 	case gc.AuctionEntryInvoice:
 		gamelog.New(query.GetGameLog(world)).
-			Markup(query.T(world, "Paid %s: %s.", query.T(world, e.Name), query.FormatCurrency(e.Amount))).
+			Markup(query.T(world, "Paid %s: %s.", query.T(world, e.Name), e.Amount.String())).
 			Log()
 	}
 	return nil
@@ -368,10 +369,10 @@ func auctionEntryDetail(world w.World, e gc.AuctionEntry) overlay.DetailContent 
 			Name: e.Name,
 			Rows: []entityspec.SpecRow{
 				{Label: query.T(world, "Kind"), Value: query.T(world, "Receipt")},
-				{Label: query.T(world, "Bid"), Value: query.FormatCurrency(e.Bid)},
-				{Label: query.T(world, "Shipping"), Value: query.FormatCurrency(e.Ship)},
-				{Label: query.T(world, "Fee"), Value: query.FormatCurrency(e.Fee)},
-				{Label: query.T(world, "Net"), Value: query.FormatCurrency(e.Amount)},
+				{Label: query.T(world, "Bid"), Value: e.Bid.String()},
+				{Label: query.T(world, "Shipping"), Value: e.Ship.String()},
+				{Label: query.T(world, "Fee"), Value: e.Fee.String()},
+				{Label: query.T(world, "Net"), Value: e.Amount.String()},
 			},
 		}
 	case gc.AuctionEntryInvoice:
@@ -379,7 +380,7 @@ func auctionEntryDetail(world w.World, e gc.AuctionEntry) overlay.DetailContent 
 			Name: query.T(world, e.Name),
 			Rows: []entityspec.SpecRow{
 				{Label: query.T(world, "Kind"), Value: query.T(world, "Invoice")},
-				{Label: query.T(world, "Amount"), Value: query.FormatCurrency(e.Amount)},
+				{Label: query.T(world, "Amount"), Value: e.Amount.String()},
 			},
 		}
 	}
@@ -394,10 +395,10 @@ func auctionLedgerDetail(world w.World, r auctionLedgerRow) overlay.DetailConten
 	}
 	rows := []entityspec.SpecRow{
 		{Label: query.T(world, "Number"), Value: "#" + strconv.Itoa(r.Number)},
-		{Label: bidLabel, Value: query.FormatCurrency(r.Bid)},
-		{Label: query.T(world, "Shipping"), Value: query.FormatCurrency(r.Ship)},
-		{Label: query.T(world, "Fee"), Value: query.FormatCurrency(r.Fee)},
-		{Label: query.T(world, "Net"), Value: query.FormatCurrency(r.Net)},
+		{Label: bidLabel, Value: r.Bid.String()},
+		{Label: query.T(world, "Shipping"), Value: r.Ship.String()},
+		{Label: query.T(world, "Fee"), Value: r.Fee.String()},
+		{Label: query.T(world, "Net"), Value: r.Net.String()},
 	}
 	if r.Shipped {
 		rows = append(rows, entityspec.SpecRow{Label: query.T(world, "Turn"), Value: strconv.Itoa(r.Turn)})
@@ -426,11 +427,11 @@ func (st *AuctionMenuState) buildFinanceContainer(world w.World, tab auctionTabD
 	for i, e := range tab.Entries {
 		kind := query.T(world, "Receipt")
 		name := e.Name
-		amount := query.FormatCurrency(e.Amount)
+		amount := e.Amount.String()
 		if e.Kind == gc.AuctionEntryInvoice {
 			kind = query.T(world, "Invoice")
 			name = query.T(world, e.Name)
-			amount = query.FormatCurrency(-e.Amount)
+			amount = (-e.Amount).String()
 		}
 		rows[i] = menuRow{Cells: []styled.Cell{
 			styled.TextCell(name), styled.TextCell(kind), styled.TextCell(amount),
@@ -447,7 +448,7 @@ func (st *AuctionMenuState) buildItemContainer(world w.World, tab auctionTabData
 	for i, it := range tab.Items {
 		value := ""
 		if it.HasValue {
-			value = query.FormatCurrency(it.Value)
+			value = it.Value.String()
 		}
 		rows[i] = menuRow{Cells: []styled.Cell{
 			styled.TextCell(it.Name), styled.TextCell(it.Status), styled.TextCell(value),
@@ -471,7 +472,7 @@ func (st *AuctionMenuState) buildLedgerContainer(world w.World, tab auctionTabDa
 			rows[i] = menuRow{Cells: []styled.Cell{
 				styled.TextCell("#" + strconv.Itoa(r.Number)),
 				styled.TextCell(r.Name),
-				styled.TextCell(query.FormatCurrency(r.Bid)),
+				styled.TextCell(r.Bid.String()),
 			}}
 		}
 		return renderMenuList(itemIndex, rows, []int{50, 200, 120},
@@ -490,7 +491,7 @@ func (st *AuctionMenuState) buildLedgerContainer(world w.World, tab auctionTabDa
 			styled.TextCell("#" + strconv.Itoa(r.Number)),
 			styled.TextCell(r.Name),
 			styled.TextCell(status),
-			styled.TextCell(query.FormatCurrency(r.Bid)),
+			styled.TextCell(r.Bid.String()),
 		}}
 	}
 	return renderMenuList(itemIndex, rows, []int{50, 170, 70, 110},

--- a/internal/states/item_action_state.go
+++ b/internal/states/item_action_state.go
@@ -184,7 +184,7 @@ func execTagItem(world w.World, entity ecs.Entity) (es.Transition[w.World], erro
 	number := query.StartAuctionListing(world, entity, now)
 	bid := world.Components.AuctionListing.Get(entity).CurrentBid
 	gamelog.New(query.GetGameLog(world)).
-		Markup(query.T(world, "Tagged %s as #%d. Opening bid %s.", gamelog.Tag("item", query.GetEntityName(entity, world)), number, query.FormatCurrency(bid))).
+		Markup(query.T(world, "Tagged %s as #%d. Opening bid %s.", gamelog.Tag("item", query.GetEntityName(entity, world)), number, bid.String())).
 		Log()
 	return es.Transition[w.World]{Type: es.TransPop}, nil
 }

--- a/internal/states/shop_menu.go
+++ b/internal/states/shop_menu.go
@@ -7,6 +7,7 @@ import (
 	"github.com/ebitenui/ebitenui/widget"
 	"github.com/hajimehoshi/ebiten/v2"
 	gc "github.com/kijimaD/ruins/internal/components"
+	"github.com/kijimaD/ruins/internal/consts"
 	es "github.com/kijimaD/ruins/internal/engine/states"
 	"github.com/kijimaD/ruins/internal/input"
 	"github.com/kijimaD/ruins/internal/inputmapper"
@@ -108,10 +109,10 @@ type shopTabData struct {
 // shopItemData は一覧1行分。名前・重量・個数は実体から都度出せるので持たず、
 // プレイヤーの所持金や倍率が要る値だけを持つ
 type shopItemData struct {
-	Entity   ecs.Entity // 在庫・持ち物の実体。表示も操作もこれから解決する
-	Price    int        // 価値と交渉スキルの倍率から出す。実体だけでは決まらない
-	IsBuy    bool       // 買いタブの行なら真
-	Disabled bool       // 所持金が足りず選べない
+	Entity   ecs.Entity      // 在庫・持ち物の実体。表示も操作もこれから解決する
+	Price    consts.Currency // 価値と交渉スキルの倍率から出す。実体だけでは決まらない
+	IsBuy    bool            // 買いタブの行なら真
+	Disabled bool            // 所持金が足りず選べない
 }
 
 // Fetch は世界から表示 props を構築する。menuloop.Model の Model 部にあたる。
@@ -137,7 +138,7 @@ func (st *ShopMenuState) Menu(props ShopProps) menuloop.MenuConfig {
 	return menuloop.MenuConfig{Key: "shop", TabCount: len(props.Tabs), ItemCounts: itemCounts, ItemsPerPage: menuItemsPerPage}
 }
 
-func (st *ShopMenuState) createTabs(world w.World, player ecs.Entity, currency int) []shopTabData {
+func (st *ShopMenuState) createTabs(world w.World, player ecs.Entity, currency consts.Currency) []shopTabData {
 	return []shopTabData{
 		{ID: "buy", Label: query.T(world, "Buy"), Items: st.createBuyItems(world, player, currency)},
 		{ID: "sell", Label: query.T(world, "Sell"), Items: st.createSellItems(world, player)},
@@ -145,7 +146,7 @@ func (st *ShopMenuState) createTabs(world w.World, player ecs.Entity, currency i
 }
 
 // createBuyItems は商人の在庫アイテムを買いタブへ並べる
-func (st *ShopMenuState) createBuyItems(world w.World, player ecs.Entity, currency int) []shopItemData {
+func (st *ShopMenuState) createBuyItems(world w.World, player ecs.Entity, currency consts.Currency) []shopItemData {
 	stock := query.GetStorageItems(world, st.merchant)
 	items := make([]shopItemData, 0, len(stock))
 
@@ -266,7 +267,7 @@ func (st *ShopMenuState) buildItemContainer(world w.World, tabs []shopTabData, t
 	for i, it := range currentTab.Items {
 		// 名前・個数・重量・アイコンは実体から都度出す。一覧の実体は毎フレーム集め直すので描画時も生存している
 		weight := query.GetEntityWeight(world, it.Entity).KgString()
-		rows[i] = itemMenuRow(world, it.Entity, query.FormatCurrency(it.Price), weight)
+		rows[i] = itemMenuRow(world, it.Entity, it.Price.String(), weight)
 	}
 	emptyText := query.T(world, "No goods")
 	if currentTab.ID == "sell" {

--- a/internal/systems/auction.go
+++ b/internal/systems/auction.go
@@ -2,6 +2,7 @@ package systems
 
 import (
 	gc "github.com/kijimaD/ruins/internal/components"
+	"github.com/kijimaD/ruins/internal/consts"
 	"github.com/kijimaD/ruins/internal/gamelog"
 	w "github.com/kijimaD/ruins/internal/world"
 	"github.com/kijimaD/ruins/internal/world/query"
@@ -146,8 +147,8 @@ func processAuctionItem(world w.World, item ecs.Entity, now int) {
 	logAuctionWon(world, name, bid)
 }
 
-func logAuctionWon(world w.World, name string, bid int) {
+func logAuctionWon(world w.World, name string, bid consts.Currency) {
 	gamelog.New(query.GetGameLog(world)).
-		Markup(query.T(world, "%s was won. Bid %s. Ready to ship.", gamelog.Tag("item", name), query.FormatCurrency(bid))).
+		Markup(query.T(world, "%s was won. Bid %s. Ready to ship.", gamelog.Tag("item", name), bid.String())).
 		Log()
 }

--- a/internal/systems/hud_extractor.go
+++ b/internal/systems/hud_extractor.go
@@ -246,7 +246,7 @@ func extractCurrencyData(world w.World) hud.CurrencyData {
 	config := hud.DefaultMessageAreaConfig
 
 	// プレイヤーの地髄を取得
-	currency := 0
+	var currency consts.Currency
 	query.Player(world, func(entity ecs.Entity) {
 		currency = query.GetCurrency(world, entity)
 	})

--- a/internal/systems/hud_extractor_test.go
+++ b/internal/systems/hud_extractor_test.go
@@ -487,7 +487,7 @@ func TestExtractCurrencyData(t *testing.T) {
 
 		data := extractCurrencyData(world)
 
-		assert.Equal(t, 12345, data.Currency)
+		assert.Equal(t, consts.Currency(12345), data.Currency)
 		assert.Equal(t, 320, data.ScreenDimensions.Width)
 		assert.Equal(t, 240, data.ScreenDimensions.Height)
 	})
@@ -498,7 +498,7 @@ func TestExtractCurrencyData(t *testing.T) {
 
 		data := extractCurrencyData(world)
 
-		assert.Equal(t, 0, data.Currency)
+		assert.Equal(t, consts.Currency(0), data.Currency)
 	})
 }
 
@@ -695,7 +695,7 @@ func TestExtractHUDData_全カテゴリのデータを集約する(t *testing.T)
 	data := ExtractHUDData(world)
 
 	assert.Equal(t, 10, data.GameInfo.PlayerHP)
-	assert.Equal(t, 500, data.CurrencyData.Currency)
+	assert.Equal(t, consts.Currency(500), data.CurrencyData.Currency)
 	require.Len(t, data.WeaponSlotsData.Slots, 5)
 	assert.Equal(t, 800, data.MinimapData.ScreenDimensions.Width)
 }

--- a/internal/widgets/entityspec/spec.go
+++ b/internal/widgets/entityspec/spec.go
@@ -80,7 +80,7 @@ func auctionListingRows(world w.World, l *gc.AuctionListing) []SpecRow {
 		{Label: query.T(world, "Auction"), Header: true},
 		{Label: query.T(world, "Number"), Value: "#" + strconv.Itoa(l.Number)},
 		{Label: query.T(world, "Status"), Value: query.T(world, "Bidding")},
-		{Label: query.T(world, "Current bid"), Value: query.FormatCurrency(l.CurrentBid)},
+		{Label: query.T(world, "Current bid"), Value: l.CurrentBid.String()},
 	}
 }
 
@@ -90,7 +90,7 @@ func auctionSoldRows(world w.World, s *gc.AuctionSold) []SpecRow {
 		{Label: query.T(world, "Auction"), Header: true},
 		{Label: query.T(world, "Number"), Value: "#" + strconv.Itoa(s.Number)},
 		{Label: query.T(world, "Status"), Value: query.T(world, "Won")},
-		{Label: query.T(world, "Bid"), Value: query.FormatCurrency(s.Bid)},
+		{Label: query.T(world, "Bid"), Value: s.Bid.String()},
 		{Label: query.T(world, "Ship by turn"), Value: strconv.Itoa(s.DueTurn)},
 	}
 }
@@ -251,7 +251,7 @@ func freshnessRow(world w.World, entity ecs.Entity) SpecRow {
 
 // valueRows は価値の行を返す
 func valueRows(world w.World, value *gc.Value) []SpecRow {
-	return []SpecRow{{Label: query.T(world, "Value"), Value: query.FormatCurrency(value.Value)}}
+	return []SpecRow{{Label: query.T(world, "Value"), Value: consts.Currency(value.Value).String()}}
 }
 
 // weightRows は重量の行を返す

--- a/internal/widgets/entityspec/spec_test.go
+++ b/internal/widgets/entityspec/spec_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/ebitenui/ebitenui/widget"
 	gc "github.com/kijimaD/ruins/internal/components"
+	"github.com/kijimaD/ruins/internal/consts"
 	"github.com/kijimaD/ruins/internal/testutil"
 	"github.com/kijimaD/ruins/internal/vrt"
 	"github.com/kijimaD/ruins/internal/widgets/entityspec"
@@ -227,7 +228,7 @@ func TestUpdateSpec_栄養と価値と重量を表示する(t *testing.T) {
 	assert.Contains(t, labels, "Nutrition", "栄養ラベルが表示される")
 	assert.Contains(t, labels, "25", "栄養量が表示される")
 	assert.Contains(t, labels, "Value", "価値ラベルが表示される")
-	assert.Contains(t, labels, query.FormatCurrency(1200), "価値がカンマ区切りの通貨表記で表示される")
+	assert.Contains(t, labels, consts.Currency(1200).String(), "価値がカンマ区切りの通貨表記で表示される")
 	assert.Contains(t, labels, "Weight", "重量ラベルが表示される")
 }
 
@@ -325,6 +326,6 @@ func TestUpdateSpecFromSpec_エンティティを生成せずに複数コンポ�
 	assert.Contains(t, labels, "42", "ProvidesHealing由来の回復量が表示される")
 	assert.Contains(t, labels, "Nutrition", "ProvidesNutrition由来のラベルが表示される")
 	assert.Contains(t, labels, "Progress", "Book由来の進捗行が表示される")
-	assert.Contains(t, labels, query.FormatCurrency(1200), "Value由来の価値が表示される")
+	assert.Contains(t, labels, consts.Currency(1200).String(), "Value由来の価値が表示される")
 	assert.Contains(t, labels, "Weight", "Weight由来のラベルが表示される")
 }

--- a/internal/widgets/hud/currency.go
+++ b/internal/widgets/hud/currency.go
@@ -5,8 +5,6 @@ import (
 	"github.com/hajimehoshi/ebiten/v2/text/v2"
 	theme "github.com/kijimaD/ruins/internal/widgets/theme"
 	w "github.com/kijimaD/ruins/internal/world"
-
-	"github.com/kijimaD/ruins/internal/world/query"
 )
 
 // CurrencyDisplay は地髄表示ウィジェット
@@ -44,7 +42,7 @@ func (c *CurrencyDisplay) Draw(screen *ebiten.Image, data CurrencyData) {
 	screenHeight := data.ScreenDimensions.Height
 
 	// 通貨テキスト
-	currencyText := query.FormatCurrency(data.Currency)
+	currencyText := data.Currency.String()
 
 	// テキストのサイズを計算
 	textWidth, textHeight := text.Measure(currencyText, c.face, 0)

--- a/internal/widgets/hud/data.go
+++ b/internal/widgets/hud/data.go
@@ -92,7 +92,7 @@ type MessageData struct {
 
 // CurrencyData は通貨表示に必要なデータ
 type CurrencyData struct {
-	Currency         int               // プレイヤーの所持地髄
+	Currency         consts.Currency   // プレイヤーの所持地髄
 	ScreenDimensions ScreenDimensions  // 画面サイズ
 	Config           MessageAreaConfig // 位置計算にメッセージエリアの情報が必要
 }

--- a/internal/world/gameaction/shop_extra_test.go
+++ b/internal/world/gameaction/shop_extra_test.go
@@ -91,7 +91,7 @@ func TestSellStock_価値0のアイテムは対価0で売れる(t *testing.T) {
 	require.NoError(t, SellStock(world, player, merchant, item), "価値0でも売却は成功する")
 
 	currency := query.GetCurrency(world, player)
-	assert.Equal(t, 0, currency, "無価値な品の対価は0で通貨は増えない")
+	assert.Equal(t, consts.Currency(0), currency, "無価値な品の対価は0で通貨は増えない")
 
 	// 売った品は商人の在庫へ並ぶ
 	require.True(t, world.Components.LocationInStorage.Has(item), "実体は商人の収納へ移る")

--- a/internal/world/gameaction/shop_test.go
+++ b/internal/world/gameaction/shop_test.go
@@ -17,7 +17,7 @@ func TestCalculateBuyPrice(t *testing.T) {
 	tests := []struct {
 		name      string
 		baseValue int
-		want      int
+		want      consts.Currency
 	}{
 		{"価値100のアイテム", 100, 200},
 		{"価値50のアイテム", 50, 100},
@@ -38,7 +38,7 @@ func TestCalculateSellPrice(t *testing.T) {
 	tests := []struct {
 		name      string
 		baseValue int
-		want      int
+		want      consts.Currency
 	}{
 		{"価値100のアイテム", 100, 50},
 		{"価値50のアイテム", 50, 25},

--- a/internal/world/query/auction.go
+++ b/internal/world/query/auction.go
@@ -20,33 +20,33 @@ const (
 
 	// AuctionPickupFee は集荷手数料。集荷1回につき定額でかかり、品ごとの配送料や手数料とは別立て。
 	// 小分けに集荷するほどかさむので、1回にまとめるほど得になる。
-	AuctionPickupFee = 100
+	AuctionPickupFee consts.Currency = 100
 )
 
 // AuctionOpeningBid は開始入札額を返す。基準価値に分散を掛けた控えめな額から競売が始まる。
-func AuctionOpeningBid(world w.World, item ecs.Entity) int {
+func AuctionOpeningBid(world w.World, item ecs.Entity) consts.Currency {
 	base := GetItemValue(world, item)
 	variance := 0.8 + world.Config.RNG.Float64()*0.4
-	return int(float64(base) * auctionOpeningMult * variance)
+	return consts.Currency(float64(base) * auctionOpeningMult * variance)
 }
 
 // AuctionRaise は1回の入札での上げ幅を返す。入札が来るたびこの額だけ現在値が上がる。
-func AuctionRaise(world w.World, item ecs.Entity) int {
+func AuctionRaise(world w.World, item ecs.Entity) consts.Currency {
 	base := GetItemValue(world, item)
 	variance := 0.8 + world.Config.RNG.Float64()*0.4
-	raise := max(int(float64(base)*auctionRaiseMult*variance), 1)
+	raise := max(consts.Currency(float64(base)*auctionRaiseMult*variance), 1)
 	return raise
 }
 
 // AuctionShippingCost は発送料を返す。重量に比例するので、重い安物は手取りを食う。
-func AuctionShippingCost(world w.World, item ecs.Entity) int {
+func AuctionShippingCost(world w.World, item ecs.Entity) consts.Currency {
 	weightKg := float64(GetEntityWeight(world, item)) / float64(consts.MilligramPerKg)
-	return int(weightKg * auctionShipRatePerKg)
+	return consts.Currency(weightKg * auctionShipRatePerKg)
 }
 
 // AuctionFee は手数料を返す。落札額に比例する。
-func AuctionFee(bid int) int {
-	return int(float64(bid) * auctionFeeRate)
+func AuctionFee(bid consts.Currency) consts.Currency {
+	return consts.Currency(float64(bid) * auctionFeeRate)
 }
 
 // GetAuctionHistory は出荷実績の履歴シングルトンを取得する。

--- a/internal/world/query/currency.go
+++ b/internal/world/query/currency.go
@@ -9,7 +9,7 @@ import (
 )
 
 // AddCurrency はエンティティに所持金を追加する
-func AddCurrency(world w.World, entity ecs.Entity, amount int) error {
+func AddCurrency(world w.World, entity ecs.Entity, amount consts.Currency) error {
 	wallet := world.Components.Wallet.Get(entity)
 	if wallet == nil {
 		return fmt.Errorf("entity has no Wallet component")
@@ -19,7 +19,7 @@ func AddCurrency(world w.World, entity ecs.Entity, amount int) error {
 }
 
 // GetCurrency はエンティティの所持金を取得する
-func GetCurrency(world w.World, entity ecs.Entity) int {
+func GetCurrency(world w.World, entity ecs.Entity) consts.Currency {
 	wallet := world.Components.Wallet.Get(entity)
 	if wallet == nil {
 		return 0
@@ -28,14 +28,14 @@ func GetCurrency(world w.World, entity ecs.Entity) int {
 }
 
 // HasCurrency は指定額以上の所持金を持っているか確認
-func HasCurrency(world w.World, entity ecs.Entity, amount int) bool {
+func HasCurrency(world w.World, entity ecs.Entity, amount consts.Currency) bool {
 	return GetCurrency(world, entity) >= amount
 }
 
 // ConsumeCurrency はエンティティの所持金を消費する
 // 所持金が足りない場合はfalseを返す
 // TODO(kijima): 使いにくいのを直す
-func ConsumeCurrency(world w.World, entity ecs.Entity, amount int) bool {
+func ConsumeCurrency(world w.World, entity ecs.Entity, amount consts.Currency) bool {
 	if !HasCurrency(world, entity, amount) {
 		return false
 	}
@@ -45,33 +45,4 @@ func ConsumeCurrency(world w.World, entity ecs.Entity, amount int) bool {
 	}
 	wallet.Currency -= amount
 	return true
-}
-
-// FormatCurrency は金額を通貨記号付きでフォーマットする
-// 3桁ごとにカンマで区切る
-func FormatCurrency(amount int) string {
-	// 数値を文字列に変換
-	str := fmt.Sprintf("%d", amount)
-
-	// 負の数の処理
-	negative := false
-	if amount < 0 {
-		negative = true
-		str = str[1:] // マイナス記号を除去
-	}
-
-	// 3桁ごとにカンマを挿入
-	var result string
-	for i, c := range str {
-		if i > 0 && (len(str)-i)%3 == 0 {
-			result += ","
-		}
-		result += string(c)
-	}
-
-	if negative {
-		result = "-" + result
-	}
-
-	return fmt.Sprintf("%s %s", consts.IconCurrency, result)
 }

--- a/internal/world/query/currency_test.go
+++ b/internal/world/query/currency_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	gc "github.com/kijimaD/ruins/internal/components"
+	"github.com/kijimaD/ruins/internal/consts"
 	"github.com/kijimaD/ruins/internal/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -23,7 +24,7 @@ func TestAddCurrency(t *testing.T) {
 
 	// 結果を検証
 	currency := GetCurrency(world, player)
-	assert.Equal(t, 150, currency, "通貨が150になるべき")
+	assert.Equal(t, consts.Currency(150), currency, "通貨が150になるべき")
 
 	// クリーンアップ
 	world.ECS.RemoveEntity(player)
@@ -39,12 +40,12 @@ func TestGetCurrency(t *testing.T) {
 
 	// 通貨を取得
 	currency := GetCurrency(world, player)
-	assert.Equal(t, 200, currency, "通貨が200であるべき")
+	assert.Equal(t, consts.Currency(200), currency, "通貨が200であるべき")
 
 	// Walletがない場合
 	playerWithoutWallet := world.ECS.NewEntity()
 	currency = GetCurrency(world, playerWithoutWallet)
-	assert.Equal(t, 0, currency, "Walletがない場合は0を返すべき")
+	assert.Equal(t, consts.Currency(0), currency, "Walletがない場合は0を返すべき")
 
 	// クリーンアップ
 	world.ECS.RemoveEntity(player)
@@ -79,17 +80,17 @@ func TestConsumeCurrency(t *testing.T) {
 	// 通貨を消費（成功）
 	success := ConsumeCurrency(world, player, 50)
 	assert.True(t, success, "消費が成功するべき")
-	assert.Equal(t, 50, GetCurrency(world, player), "残り50になるべき")
+	assert.Equal(t, consts.Currency(50), GetCurrency(world, player), "残り50になるべき")
 
 	// 通貨を消費（失敗：足りない）
 	success = ConsumeCurrency(world, player, 100)
 	assert.False(t, success, "消費が失敗するべき")
-	assert.Equal(t, 50, GetCurrency(world, player), "残り50のまま変わらないべき")
+	assert.Equal(t, consts.Currency(50), GetCurrency(world, player), "残り50のまま変わらないべき")
 
 	// 通貨を消費（成功：ちょうど）
 	success = ConsumeCurrency(world, player, 50)
 	assert.True(t, success, "消費が成功するべき")
-	assert.Equal(t, 0, GetCurrency(world, player), "残り0になるべき")
+	assert.Equal(t, consts.Currency(0), GetCurrency(world, player), "残り0になるべき")
 
 	// クリーンアップ
 	world.ECS.RemoveEntity(player)
@@ -105,41 +106,11 @@ func TestCurrencyOperationsWithoutWallet(t *testing.T) {
 	// 各操作がエラーを返すことを確認
 	err := AddCurrency(world, entity, 100)
 	require.Error(t, err, "Walletがない場合はエラーを返すべき")
-	assert.Equal(t, 0, GetCurrency(world, entity), "Walletがないので0")
+	assert.Equal(t, consts.Currency(0), GetCurrency(world, entity), "Walletがないので0")
 
 	assert.False(t, HasCurrency(world, entity, 1), "Walletがないのでfalse")
 	assert.False(t, ConsumeCurrency(world, entity, 1), "Walletがないのでfalse")
 
 	// クリーンアップ
 	world.ECS.RemoveEntity(entity)
-}
-
-func TestFormatCurrency(t *testing.T) {
-	t.Parallel()
-
-	tests := []struct {
-		name     string
-		amount   int
-		expected string
-	}{
-		{"0", 0, "󱪯 0"},
-		{"1桁", 5, "󱪯 5"},
-		{"2桁", 99, "󱪯 99"},
-		{"3桁", 999, "󱪯 999"},
-		{"4桁（カンマ1つ）", 1000, "󱪯 1,000"},
-		{"5桁", 12345, "󱪯 12,345"},
-		{"6桁", 100204, "󱪯 100,204"},
-		{"7桁", 1234567, "󱪯 1,234,567"},
-		{"8桁", 10000000, "󱪯 10,000,000"},
-		{"負の数", -1234, "󱪯 -1,234"},
-		{"負の数（大きい）", -1234567, "󱪯 -1,234,567"},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-			result := FormatCurrency(tt.amount)
-			assert.Equal(t, tt.expected, result)
-		})
-	}
 }

--- a/internal/world/query/shop.go
+++ b/internal/world/query/shop.go
@@ -1,6 +1,7 @@
 package query
 
 import (
+	"github.com/kijimaD/ruins/internal/consts"
 	w "github.com/kijimaD/ruins/internal/world"
 	"github.com/mlange-42/ark/ecs"
 )
@@ -12,22 +13,22 @@ const (
 )
 
 // CalculateBuyPrice は購入価格を計算する（価値の2倍）
-func CalculateBuyPrice(baseValue int) int {
-	return int(float64(baseValue) * BuyPriceMultiplier)
+func CalculateBuyPrice(baseValue int) consts.Currency {
+	return consts.Currency(float64(baseValue) * BuyPriceMultiplier)
 }
 
 // CalculateSellPrice は売却価格を計算する（価値の半分）
-func CalculateSellPrice(baseValue int) int {
-	return int(float64(baseValue) * SellPriceMultiplier)
+func CalculateSellPrice(baseValue int) consts.Currency {
+	return consts.Currency(float64(baseValue) * SellPriceMultiplier)
 }
 
 // BuyPrice はプレイヤーが entity を買うときの、交渉スキルの買値倍率込みの購入価格を返す。
 // base は価値と個数の積。店頭の表示価格と取引価格をこの1関数で揃える
-func BuyPrice(world w.World, player ecs.Entity, entity ecs.Entity) int {
+func BuyPrice(world w.World, player ecs.Entity, entity ecs.Entity) consts.Currency {
 	base := GetItemValue(world, entity) * GetEntityCount(world, entity)
 	price := CalculateBuyPrice(base)
 	if world.Components.CharModifiers.Has(player) {
-		price = world.Components.CharModifiers.Get(player).BuyPrice.ApplyInt(price)
+		price = consts.Currency(world.Components.CharModifiers.Get(player).BuyPrice.ApplyInt(int(price)))
 	}
 	return price
 }
@@ -35,11 +36,11 @@ func BuyPrice(world w.World, player ecs.Entity, entity ecs.Entity) int {
 // SellPrice はプレイヤーが entity を売るときの、交渉スキルの売値倍率込みの売却価格を返す。
 // base は価値と個数の積。店頭の表示価格と取引価格をこの1関数で揃える。
 // 無価値な品は素直に 0 を返す。売却自体は他の品と同様に可能で、対価が 0 になるだけ
-func SellPrice(world w.World, player ecs.Entity, entity ecs.Entity) int {
+func SellPrice(world w.World, player ecs.Entity, entity ecs.Entity) consts.Currency {
 	base := GetItemValue(world, entity) * GetEntityCount(world, entity)
 	price := CalculateSellPrice(base)
 	if world.Components.CharModifiers.Has(player) {
-		price = world.Components.CharModifiers.Get(player).SellPrice.ApplyInt(price)
+		price = consts.Currency(world.Components.CharModifiers.Get(player).SellPrice.ApplyInt(int(price)))
 	}
 	return price
 }

--- a/internal/world/query/shop_test.go
+++ b/internal/world/query/shop_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	gc "github.com/kijimaD/ruins/internal/components"
+	"github.com/kijimaD/ruins/internal/consts"
 	"github.com/kijimaD/ruins/internal/testutil"
 	"github.com/stretchr/testify/assert"
 )
@@ -13,7 +14,7 @@ func TestCalculateBuyPrice(t *testing.T) {
 	tests := []struct {
 		name      string
 		baseValue int
-		want      int
+		want      consts.Currency
 	}{
 		{"価値100", 100, 200},
 		{"価値50", 50, 100},
@@ -34,7 +35,7 @@ func TestCalculateSellPrice(t *testing.T) {
 	tests := []struct {
 		name      string
 		baseValue int
-		want      int
+		want      consts.Currency
 	}{
 		{"価値100", 100, 50},
 		{"価値50", 50, 25},
@@ -61,7 +62,7 @@ func TestSellPrice(t *testing.T) {
 		item := world.ECS.NewEntity()
 		world.Components.Value.Add(item, &gc.Value{Value: 0})
 
-		assert.Equal(t, 0, SellPrice(world, player, item), "無価値な品の対価は0")
+		assert.Equal(t, consts.Currency(0), SellPrice(world, player, item), "無価値な品の対価は0")
 	})
 
 	t.Run("倍率なしは価値の半分", func(t *testing.T) {
@@ -71,7 +72,7 @@ func TestSellPrice(t *testing.T) {
 		item := world.ECS.NewEntity()
 		world.Components.Value.Add(item, &gc.Value{Value: 100})
 
-		assert.Equal(t, 50, SellPrice(world, player, item), "CalculateSellPrice(100)=50")
+		assert.Equal(t, consts.Currency(50), SellPrice(world, player, item), "CalculateSellPrice(100)=50")
 	})
 
 	t.Run("交渉スキルの売値倍率が乗る", func(t *testing.T) {
@@ -82,7 +83,7 @@ func TestSellPrice(t *testing.T) {
 		item := world.ECS.NewEntity()
 		world.Components.Value.Add(item, &gc.Value{Value: 100})
 
-		assert.Equal(t, 100, SellPrice(world, player, item), "売値倍率200%で50が倍額100")
+		assert.Equal(t, consts.Currency(100), SellPrice(world, player, item), "売値倍率200%で50が倍額100")
 	})
 
 	t.Run("個数分だけ価値が乗る", func(t *testing.T) {
@@ -93,7 +94,7 @@ func TestSellPrice(t *testing.T) {
 		world.Components.Value.Add(item, &gc.Value{Value: 100})
 		world.Components.Stackable.Add(item, &gc.Stackable{Count: 3})
 
-		assert.Equal(t, 150, SellPrice(world, player, item), "価値100×3個の半分")
+		assert.Equal(t, consts.Currency(150), SellPrice(world, player, item), "価値100×3個の半分")
 	})
 }
 
@@ -108,7 +109,7 @@ func TestBuyPrice(t *testing.T) {
 		item := world.ECS.NewEntity()
 		world.Components.Value.Add(item, &gc.Value{Value: 100})
 
-		assert.Equal(t, 200, BuyPrice(world, player, item), "CalculateBuyPrice(100)=200")
+		assert.Equal(t, consts.Currency(200), BuyPrice(world, player, item), "CalculateBuyPrice(100)=200")
 	})
 
 	t.Run("交渉スキルの買値倍率が乗る", func(t *testing.T) {
@@ -119,7 +120,7 @@ func TestBuyPrice(t *testing.T) {
 		item := world.ECS.NewEntity()
 		world.Components.Value.Add(item, &gc.Value{Value: 100})
 
-		assert.Equal(t, 100, BuyPrice(world, player, item), "買値倍率50%で200が半額100")
+		assert.Equal(t, consts.Currency(100), BuyPrice(world, player, item), "買値倍率50%で200が半額100")
 	})
 }
 


### PR DESCRIPTION
## 概要

通貨を素の `int` でなく名前付き型 `consts.Currency` で扱い、重量 `Milligram` や座標 `Tile` と同じく単位取り違えをコンパイラで弾く。整数で正確に演算し、カンマ区切りと通貨記号の整形は `consts.Currency.String()` に集約する。設計は `docs/design/260816193627.md`。

## 変更点

- **新設** `internal/consts/currency.go`: `type Currency int` + `String()`。整形は旧 `query.FormatCurrency` と同一
- **廃止** `query.FormatCurrency`。全表示を `.String()` に寄せ、整形テストは `internal/consts/currency_test.go` へ移設
- **型付けした通貨フロー**: 財布 `Wallet.Currency`、`query` の Add/Get/Consume/Has、ショップ価格、HUD `CurrencyData`、オークションの金額フィールドと定数
- 通貨フロー内部に `int` 境界を残さない

## スコープ判断

アイテム基礎値 `gc.Value` は基礎ステータスなので `int` のまま置く。通貨ドメインは財布・価格・入札・台帳に限り、`value → price`・`weight → 送料` は `Milligram → 送料` と同じ意味的な派生点として `consts.Currency(...)` で明示する。これは消すべき単位取り違え境界ではない。

## テスト

- `make check` グリーン。lint 0 issues、脆弱性なし、全テスト通過
- 挙動は不変。金額の計算結果は現状と一致する

🤖 Generated with [Claude Code](https://claude.com/claude-code)