### PR TITLE
docs(design): コード監査タスク 通信販売・食料鮮度・AI追跡・命中判定

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ $ make help
 | draft | [使う・送る・捨てる: 通信販売による第二の需要をコアに足す](docs/design/260813235334.md) | 0/0 | gamedesign, narrative |
 | draft | [背の低い家具を通行可能にして移動コストで体系化する](docs/design/260814140548.md) | 0/7（見送り1） | movement, combat, gamedesign |
 | draft | [腐敗システムの将来拡張](docs/design/260815125506.md) | 0/4 | item, gamedesign |
-| draft | [コード監査: 通信販売・食料鮮度・AI追跡・命中判定 2026-08-17](docs/design/260817001843.md) | 0/5 | item, combat, ecs |
+| draft | [コード監査: 通信販売・食料鮮度・AI追跡・命中判定 2026-08-17](docs/design/260817001843.md) | 0/6 | item, combat, ecs |
 
 
 ## Reference

--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ $ make help
 | draft | [使う・送る・捨てる: 通信販売による第二の需要をコアに足す](docs/design/260813235334.md) | 0/0 | gamedesign, narrative |
 | draft | [背の低い家具を通行可能にして移動コストで体系化する](docs/design/260814140548.md) | 0/7（見送り1） | movement, combat, gamedesign |
 | draft | [腐敗システムの将来拡張](docs/design/260815125506.md) | 0/4 | item, gamedesign |
+| draft | [コード監査: 通信販売・食料鮮度・AI追跡・命中判定 2026-08-17](docs/design/260817001843.md) | 0/5 | item, combat, ecs |
 
 
 ## Reference

--- a/docs/design/260817001843.md
+++ b/docs/design/260817001843.md
@@ -1,0 +1,62 @@
+---
+status: draft
+tags: [item, combat, ecs]
+auto: needs-decision
+---
+
+# コード監査: 通信販売・食料鮮度・AI追跡・命中判定 2026-08-17
+
+## 背景
+
+自律コード監査ルーチンにより `internal/` 配下を4系統に分けて並列で横断的に精読した。golangci-lint（forcetypeassert・errcheck・nilerr/nilnil・exhaustive・makezero 等）が既に手厚く効いている前提で、機械的に捕まえられる問題は対象外とし、コードの意図と実装のズレを人手で追った。対象は特に直近で導入・変更された領域（通貨型 `consts.Currency`、通信販売/オークション、食料腐敗、家具の通行可能化）と、過去の監査（`260803144226.md`・`260810001803.md`）で扱っていない戦闘・AI領域を中心に選んだ。
+
+各候補は検出後にさらに自分で該当ファイルを読み直して敵対的に再検証した。反証できず、具体的な失敗シナリオを再現できたものだけを以下に残す。修正はしていない。取捨選択はレビューに委ねる。
+
+なお、精読中にもう1件、構造的には同種の不整合を検出したが、現行の到達手段が無いため今回は見送った。記録として残す。
+
+- `internal/activity/activity_manager.go` の `getPassCostAt`（移動コスト参照）と `internal/systems/vision.go` の `buildBlockViewIndex`（視界遮蔽参照）は、同じ「そのタイルに効いている家具エンティティ」を引く役割を持つ第三の実装 `internal/world/query/singleton.go` の `buildSpatialIndex`（`BlockPass` 用）とは異なり、`Dead` エンティティを除外するガード（`.Without(ecs.C[gc.Dead]())` 相当）を欠く。したがって家具がダメージで破壊され `Dead` が付いてから `DeadCleanupSystem` に回収されるまでの1フレームの間、理論上は破壊済みの家具が移動コスト・視界遮蔽を効かせ続けうる。ただし現行データでは `Fixed` な家具にダメージを与える手段はプレイヤーの直接攻撃のみで、`internal/states/dungeon.go` の system 実行順は攻撃処理の直後・同一フレーム内に `DeadCleanupSystem` が走るため、実際に踏める失敗シナリオを組み立てられなかった。AI が家具を攻撃対象に選ぶ経路も無い。将来、罠やAoEなど家具にダメージを与える手段が増えた時点でこのガード漏れが顕在化するので、その際に合わせて直す。
+
+## 問題
+
+### 1. `TransferUnits` でアイテムスタックを分割すると、分割した側の腐敗進行が新品にリセットされる
+
+- **file:line**: `internal/world/lifecycle/location.go:35-50`（`TransferUnits`）
+- **症状**: 劣化した食料スタックの一部だけを他人のバックパックへ渡すと、渡した側だけ新鮮な状態に戻る。
+- **失敗シナリオ**: `TransferUnits`（`location.go:35-50`）は分割元スタックを `ChangeItemCount(world, item, -count)`（42行目）で減数する一方、分割した `count` 個は `spawnItemBase(world, id, count)`（45行目）で**新規スポーンと同じ経路**で生成する。`spawnItemBase` は常に `Perishable{RotAccrued: 0}` かつ `RotUpdatedTurn = now` で組み立てる（`internal/world/lifecycle/spawn.go:244-246`）ため、元スタックが持っていた劣化量 `RotAccrued` は分割後の新エンティティへ一切引き継がれない。パンのスタック5個が古くなって `stale`/`rotten` 相当まで劣化している状態で、そのうち2個だけを別の所有者へ渡す、たとえば隊員へ配分する、通信販売や取引で一部だけ渡す、といった操作をすると、渡された2個は「焼きたて」のまま `RotAccrued=0` になり、残る3個だけが元の劣化量を保つ。これはスタック合流時に加重平均で劣化量を保つ `MergeRot`（`internal/components/perishable.go`、`TestMoveToBackpack_同鮮度の合流は劣化量を加重平均する` 等でテスト済み）と対称な操作でありながら、分割方向だけ劣化量を無条件に消し去る非対称なバグになっている。`TransferUnits` の既存テスト（`location_test.go:82-150`）は非劣化アイテムの `scrap_iron` だけを使っており、劣化アイテムでの分割は検証されていない。
+- **修正方針案**: `TransferUnits` で分割前に `query.AdvanceRot(world, item, now)` を呼んで元スタックの実効 `RotAccrued`/`RotUpdatedTurn` を確定させ、その値を `spawnItemBase` が返した新エンティティの `Perishable` へコピーする。
+
+### 2. 通信販売の入札額計算がスタック個数を無視しており、複数個をまとめて出品すると受取額が実質の重量・手数料に見合わなくなる
+
+- **file:line**: `internal/world/query/auction.go:26-31`（`AuctionOpeningBid`）、`:33-39`（`AuctionRaise`）
+- **症状**: 積み重ね可能なアイテムを複数個まとめて出品すると、開始価格・入札上げ幅は1個分の価値のまま計算される一方、配送料は個数ぶんの重量で計算されるため、個数が多いほど出品が割に合わなくなる。
+- **失敗シナリオ**: `AuctionOpeningBid`（27-31行目）と `AuctionRaise`（34-39行目）はどちらも `GetItemValue(world, item)` という**1個あたりの基準価値**だけを使い、個数を掛けない。一方、同じ役割を持つ通常のショップ売買 `BuyPrice`/`SellPrice`（`internal/world/query/shop.go:27-34`）は `base := GetItemValue(world, entity) * GetEntityCount(world, entity)` と明示的に個数を掛けている。さらに配送料 `AuctionShippingCost`（`auction.go:42-45`）は `GetEntityWeight` 経由で個数ぶんの総重量を正しく反映する（`internal/world/query/location.go:25-32` の `GetEntityWeight` が内部で `GetEntityCount` を掛ける）。`raw.toml` には `value` を持つ `stackable` アイテム（`ice_cream`・`almond`・`cookie` 等）が存在し、拾い集めるとバックパック内で自動的に1つのスタックへ統合される（`internal/world/lifecycle/location.go:23-28` の `mergeStackableItems`）。このスタックをアイテムアクションの「出品」から `StartAuctionListing`（`internal/states/item_action_state.go:182-189` 経由）すると、開始入札・以後の競り上げ額はすべて1個ぶんの価値のまま固定される一方、配送料と手数料はスタック全体の重量・落札額で計算されるため、個数が多いほど手取り（`CollectStagedItems` の `bid - ship - fee`、`auction.go:89-93`）が実質目減りする。既存のオークションテストは `angel_sword`・`shovel`・`fire_extinguisher` など非スタック品しか使っておらず、この欠落は未検証のまま残っている。
+- **修正方針案**: `BuyPrice`/`SellPrice` と同じパターンで、`AuctionOpeningBid`・`AuctionRaise` の `base` 算出に `* GetEntityCount(world, item)` を加える。
+
+### 3. 追跡AIが「見失ってから3ターン」ではなく「追跡開始から3ターン」で捜索をあきらめる
+
+- **file:line**: `internal/aiinput/planner_solo.go:126-134`（`updateFromChasing`）
+- **症状**: 3ターンを超えて追跡してきた敵は、プレイヤーを見失った瞬間にほぼ即座に追跡をやめて巡回状態へ降格する。仕様上意図されている「見失ってから3ターン以内は捜索継続」がほぼ機能しない。
+- **失敗シナリオ**: `updateFromSolo` の呼び出し元（`planner_solo.go:82`）は `elapsedTurns := currentTurn - solo.StartSubStateTurn` を1箇所で計算し、各サブステート関数へ渡す。`StartSubStateTurn` は `transitionToChasing`（`planner_solo.go:157-159`）で追跡開始時に一度セットされるだけで、追跡中にプレイヤーが見え続けていても更新されない。したがって `elapsedTurns` は「追跡を開始してからの経過ターン数」を意味し、「最後にプレイヤーを見てからの経過ターン数」にはならない。`updateFromChasing`（126-134行目）は `!canSeePlayer` かつ `elapsedTurns >= 3` で `transitionToDriving`（見失って捜索終了）する。追跡が3ターンより長く続いた状態でプレイヤーが物陰に入って見えなくなると、その瞬間もう `elapsedTurns` は3以上に達しているため、猶予なしに即座に巡回へ降格する。設計 doc（`docs/design/260702000038.md:213` 「追跡中 + 見失って3ターン以内 → 捜索継続」）が意図する「見失ってから3ターンの猶予」とは逆の挙動になっている。実際、兄弟関数 `updateFromFleeing`（136-143行目）は `canSeePlayer` の間 `solo.StartSubStateTurn = currentTurn`（141行目）を毎ターン更新しており、これにより逃走側は正しく「最後に見てからの経過ターン」を測れている。追跡側だけがこのリセットを欠く非対称な実装になっている。
+- **修正方針案**: `updateFromChasing` に `updateFromFleeing` と同じパターンを入れる。`canSeePlayer` の間は `solo.StartSubStateTurn = currentTurn` を毎ターン更新し、見失った時点からの経過ターンとして測り直す。
+
+### 4. `Abilities` を持たないターゲットへの攻撃が、コメントの意図に反して自動命中しない
+
+- **file:line**: `internal/activity/attack.go:318-345`（`calculateHitRate`）
+- **症状**: 什器・破壊可能な設置物など `Abilities` コンポーネントを持たない対象への攻撃が、ダイス運次第で最大95%の確率で外れる。
+- **失敗シナリオ**: `calculateHitRate`（325行目）のコメントは「Abilitiesを持たないターゲットには自動命中する」と明記しているが、実装は `targetAgility := 0` として敏捷度をゼロ扱いにするだけで、その後は通常の命中率式（332-335行目）をそのまま通し、`formula.MinHitRate`（5）〜`formula.MaxHitRate`（95）でクランプする（337-342行目）。実際に自動命中、すなわち100%を返す早期リターンは存在しない。`Abilities` を持つのはメンバー・敵などのキャラクターだけで（`internal/raw/raw.go:429-435`）、什器（`Fixed`）は `propRaw.Hp`（`raw.go:682-685`）でHPと `InteractionMelee` は持つが `Abilities` は持たない。したがって攻撃者の器用度が低い、または武器の命中補正が低い状況で什器を殴ると、コメントが約束する「必ず当たる」に反して、逃げも避けもしないはずの静止した対象への攻撃が最大95%の確率で外れうる。
+- **修正方針案**: `attacker` 側の早期リターン（320-322行目）と同じ形で、`!world.Components.Abilities.Has(target)` のとき命中率式を通さず固定の命中率（例: 100）を返す分岐を追加する。
+
+### 5. `CharModifiers.HeavyArmor`（重装備ペナルティ）が算出・画面表示されるだけで、実際のゲーム挙動に一切反映されていない
+
+- **file:line**: `internal/components/modifiers.go:155,223`（フィールド定義・算出）、`internal/states/character_info.go:198`（表示）
+- **症状**: キャラクター情報画面の「最大積載量」欄は重装備スキルの数値で変動するように見えるが、実際の所持可能重量には影響しない。
+- **失敗シナリオ**: `CharModifiers.HeavyArmor`（`modifiers.go:155`、コメント「重装備AGIペナルティ倍率」）は `RecalculateCharModifiers` 内で `SkillHeavyArmor`・`coeffHeavyArmor` から毎回算出され（`modifiers.go:223`）、`character_info.go:198` でラベル「Max load」/説明「Max load multiplier」として画面に表示される。しかし実際の所持可能重量計算 `UpdateWeightCapacity`（`internal/world/query/weight.go:20-42`）が参照するのは無関係な別フィールド `CharModifiers.MaxWeight`（`SkillWeightBearing` 由来）であり、`HeavyArmor` を読む箇所はコードベース全体を検索しても表示コード以外に存在しない。同じ構造体内で未実装のまま残っている `Exploration`・`NightVision` フィールドには「TODO: 〜実装時に適用する」という明示コメントが付いているのに対し、`HeavyArmor` にはそれが無く、フィールド自身のコメント「重装備AGIペナルティ倍率」と実際の画面ラベル「Max load（最大積載量）」も一致していない。プレイヤーが重装備スキルへ投資して画面上の数値が変化するのを見ても、AGIにもキャリー容量にも実際には何の影響も与えない。
+- **修正方針案**: `HeavyArmor` をフィールド名どおりAGIペナルティとして実際の計算に組み込むか、未実装なら `Exploration`/`NightVision` と同じ TODO コメントを付けて画面表示からも外し、プレイヤーに誤った印象を与えないようにする。
+
+## 進捗
+
+- [ ] 1. `TransferUnits` のスタック分割で分割先へ劣化量を引き継ぐ
+- [ ] 2. `AuctionOpeningBid`・`AuctionRaise` にスタック個数を掛ける
+- [ ] 3. 追跡AIの「見失ってから3ターン」判定を、見失った時点からの経過ターンで測るよう直す
+- [ ] 4. `Abilities` を持たないターゲットへの攻撃を実際に自動命中させる
+- [ ] 5. `CharModifiers.HeavyArmor` を実装に組み込むか、未実装として表示から外す

--- a/docs/design/260817001843.md
+++ b/docs/design/260817001843.md
@@ -23,7 +23,7 @@ auto: needs-decision
 - **file:line**: `internal/world/lifecycle/location.go:35-50`（`TransferUnits`）
 - **症状**: 劣化した食料スタックの一部だけを他人のバックパックへ渡すと、渡した側だけ新鮮な状態に戻る。
 - **失敗シナリオ**: `TransferUnits`（`location.go:35-50`）は分割元スタックを `ChangeItemCount(world, item, -count)`（42行目）で減数する一方、分割した `count` 個は `spawnItemBase(world, id, count)`（45行目）で**新規スポーンと同じ経路**で生成する。`spawnItemBase` は常に `Perishable{RotAccrued: 0}` かつ `RotUpdatedTurn = now` で組み立てる（`internal/world/lifecycle/spawn.go:244-246`）ため、元スタックが持っていた劣化量 `RotAccrued` は分割後の新エンティティへ一切引き継がれない。パンのスタック5個が古くなって `stale`/`rotten` 相当まで劣化している状態で、そのうち2個だけを別の所有者へ渡す、たとえば隊員へ配分する、通信販売や取引で一部だけ渡す、といった操作をすると、渡された2個は「焼きたて」のまま `RotAccrued=0` になり、残る3個だけが元の劣化量を保つ。これはスタック合流時に加重平均で劣化量を保つ `MergeRot`（`internal/components/perishable.go`、`TestMoveToBackpack_同鮮度の合流は劣化量を加重平均する` 等でテスト済み）と対称な操作でありながら、分割方向だけ劣化量を無条件に消し去る非対称なバグになっている。`TransferUnits` の既存テスト（`location_test.go:82-150`）は非劣化アイテムの `scrap_iron` だけを使っており、劣化アイテムでの分割は検証されていない。
-- **修正方針案**: `TransferUnits` で分割前に `query.AdvanceRot(world, item, now)` を呼んで元スタックの実効 `RotAccrued`/`RotUpdatedTurn` を確定させ、その値を `spawnItemBase` が返した新エンティティの `Perishable` へコピーする。
+- **修正方針案**: `TransferUnits` で分割前に元スタックが `Perishable` を持つか確認し、持つ場合のみ `query.AdvanceRot(world, item, now)` を呼んで実効 `RotAccrued`/`RotUpdatedTurn` を確定させ、その値を `spawnItemBase` が返した新エンティティの `Perishable` へコピーする。コピー先は直後の `MoveToBackpack` 経由で受取側スタックへ合流しうるため、合流時は既存の `MergeRot` の加重平均パスを通ることを確認する。
 
 ### 2. 通信販売の入札額計算がスタック個数を無視しており、複数個をまとめて出品すると受取額が実質の重量・手数料に見合わなくなる
 
@@ -44,14 +44,14 @@ auto: needs-decision
 - **file:line**: `internal/activity/attack.go:318-345`（`calculateHitRate`）
 - **症状**: 什器・破壊可能な設置物など `Abilities` コンポーネントを持たない対象への攻撃が、ダイス運次第で最大95%の確率で外れる。
 - **失敗シナリオ**: `calculateHitRate`（325行目）のコメントは「Abilitiesを持たないターゲットには自動命中する」と明記しているが、実装は `targetAgility := 0` として敏捷度をゼロ扱いにするだけで、その後は通常の命中率式（332-335行目）をそのまま通し、`formula.MinHitRate`（5）〜`formula.MaxHitRate`（95）でクランプする（337-342行目）。実際に自動命中、すなわち100%を返す早期リターンは存在しない。`Abilities` を持つのはメンバー・敵などのキャラクターだけで（`internal/raw/raw.go:429-435`）、什器（`Fixed`）は `propRaw.Hp`（`raw.go:682-685`）でHPと `InteractionMelee` は持つが `Abilities` は持たない。したがって攻撃者の器用度が低い、または武器の命中補正が低い状況で什器を殴ると、コメントが約束する「必ず当たる」に反して、逃げも避けもしないはずの静止した対象への攻撃が最大95%の確率で外れうる。
-- **修正方針案**: `attacker` 側の早期リターン（320-322行目）と同じ形で、`!world.Components.Abilities.Has(target)` のとき命中率式を通さず固定の命中率（例: 100）を返す分岐を追加する。
+- **修正方針案**: `attacker` 側の早期リターン（320-322行目）と同じ形で、`!world.Components.Abilities.Has(target)` のとき命中率式を通さず固定の命中率（例: 100）を返す分岐を追加する。あるいは呼び出し元 `rollHitCheckWithModifier` 側で target の `Abilities` 有無を分岐し、`calculateHitRate` を経由せず必中・非クリティカルを直接返す形にすると、命中率100とクリティカル判定（`roll <= formula.CriticalHitThreshold`）の関係が明示的になる。どちらでも機能的には等価。
 
 ### 5. `CharModifiers.HeavyArmor`（重装備ペナルティ）が算出・画面表示されるだけで、実際のゲーム挙動に一切反映されていない
 
 - **file:line**: `internal/components/modifiers.go:155,223`（フィールド定義・算出）、`internal/states/character_info.go:198`（表示）
 - **症状**: キャラクター情報画面の「最大積載量」欄は重装備スキルの数値で変動するように見えるが、実際の所持可能重量には影響しない。
 - **失敗シナリオ**: `CharModifiers.HeavyArmor`（`modifiers.go:155`、コメント「重装備AGIペナルティ倍率」）は `RecalculateCharModifiers` 内で `SkillHeavyArmor`・`coeffHeavyArmor` から毎回算出され（`modifiers.go:223`）、`character_info.go:198` でラベル「Max load」/説明「Max load multiplier」として画面に表示される。しかし実際の所持可能重量計算 `UpdateWeightCapacity`（`internal/world/query/weight.go:20-42`）が参照するのは無関係な別フィールド `CharModifiers.MaxWeight`（`SkillWeightBearing` 由来）であり、`HeavyArmor` を読む箇所はコードベース全体を検索しても表示コード以外に存在しない。同じ構造体内で未実装のまま残っている `Exploration`・`NightVision` フィールドには「TODO: 〜実装時に適用する」という明示コメントが付いているのに対し、`HeavyArmor` にはそれが無く、フィールド自身のコメント「重装備AGIペナルティ倍率」と実際の画面ラベル「Max load（最大積載量）」も一致していない。プレイヤーが重装備スキルへ投資して画面上の数値が変化するのを見ても、AGIにもキャリー容量にも実際には何の影響も与えない。
-- **修正方針案**: `HeavyArmor` をフィールド名どおりAGIペナルティとして実際の計算に組み込むか、未実装なら `Exploration`/`NightVision` と同じ TODO コメントを付けて画面表示からも外し、プレイヤーに誤った印象を与えないようにする。
+- **修正方針案**: 2案ある。5a: 先に `Exploration`/`NightVision` と同じ TODO コメントを付けて画面表示から外し、未実装であることをコードで明示する。5b: `HeavyArmor` をフィールド名どおりAGIペナルティとして実際の計算に組み込む。5b はどこにどう適用するか別途設計が要るため、まず 5a で誤った印象を止めるのが安全。
 
 ## 進捗
 
@@ -59,4 +59,5 @@ auto: needs-decision
 - [ ] 2. `AuctionOpeningBid`・`AuctionRaise` にスタック個数を掛ける
 - [ ] 3. 追跡AIの「見失ってから3ターン」判定を、見失った時点からの経過ターンで測るよう直す
 - [ ] 4. `Abilities` を持たないターゲットへの攻撃を実際に自動命中させる
-- [ ] 5. `CharModifiers.HeavyArmor` を実装に組み込むか、未実装として表示から外す
+- [ ] 5a. `CharModifiers.HeavyArmor` に TODO コメントを付けて画面表示から外す
+- [ ] 5b. `HeavyArmor` をAGIペナルティ計算に組み込む（別途設計が必要）


### PR DESCRIPTION
## 概要

自律コード監査ルーチンによる横断調査です。golangci-lint（forcetypeassert・errcheck・nilerr/nilnil・exhaustive・makezero 等）が既に手厚く効いている前提で、機械的に捕まえられる問題は対象外とし、コードの意図と実装のズレを人手で追いました。直近で導入・変更された領域（通信販売/オークション、食料腐敗、通貨型）と、過去の監査doc（`260803144226.md`・`260810001803.md`）で扱っていない戦闘・AI領域を中心に、4系統に分けて並列調査し、各候補を敵対的に自己検証しました。

タスク doc: `docs/design/260817001843.md`

## 検出した問題（5件）

1. `TransferUnits` でアイテムスタックを分割すると、分割した側の腐敗進行が新品にリセットされる（`internal/world/lifecycle/location.go`）
2. 通信販売の入札額計算がスタック個数を無視しており、複数個をまとめて出品すると受取額が実質の重量・手数料に見合わなくなる（`internal/world/query/auction.go`）
3. 追跡AIが「見失ってから3ターン」ではなく「追跡開始から3ターン」で捜索をあきらめる（`internal/aiinput/planner_solo.go`）
4. `Abilities` を持たないターゲットへの攻撃が、コメントの意図に反して自動命中しない（`internal/activity/attack.go`）
5. `CharModifiers.HeavyArmor`（重装備ペナルティ）が算出・画面表示されるだけで、実際のゲーム挙動に一切反映されていない（`internal/components/modifiers.go` 他）

各項目の file:line・症状・具体的な失敗シナリオ・修正方針案はタスク doc 本文を参照してください。

これはあくまで提案です。コードは修正していません。取捨選択は人によるレビューに委ねます。

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kvi6vXo3Eeis2RWp5THcHK)_