### PR TITLE
feat(states): 名付け画面を IME 対応の textinput.Field 入力へ

### DIFF
--- a/internal/states/character_naming.go
+++ b/internal/states/character_naming.go
@@ -93,10 +93,10 @@ func (st *CharacterNamingState) Update(world w.World) (es.Transition[w.World], e
 	props = st.mount.GetProps()
 
 	// IME 入力を進め、確定テキストを props へ同期する
-	if field, ok := hooks.GetRef[*textinput.Field](st.mount.Store(), "imeField"); ok && field != nil {
+	if field, ok := hooks.GetRef[*textinput.Field](st.mount.Store(), "imeField"); ok {
 		// 合成窓の位置。表示ウィジェットの矩形が取れれば使う
 		bounds := image.Rect(0, 0, consts.GameWidth, consts.GameHeight)
-		if ti, ok := hooks.GetRef[*widget.TextInput](st.mount.Store(), "textInput"); ok && ti != nil {
+		if ti, ok := hooks.GetRef[*widget.TextInput](st.mount.Store(), "textInput"); ok {
 			if r := ti.GetWidget().Rect; !r.Empty() {
 				bounds = r
 			}
@@ -264,7 +264,7 @@ func (st *CharacterNamingState) buildUI(world w.World) *ebitenui.UI {
 		return f
 	})
 
-	// テキスト入力ウィジェットは表示専用にする。入力は field が担うのでフォーカスは取らない。
+	// テキスト入力ウィジェットは表示専用。入力は field が担うのでフォーカスを持たない。
 	textInput := hooks.UseRef(st.mount.Store(), "textInput", func() *widget.TextInput {
 		return widget.NewTextInput(
 			widget.TextInputOpts.WidgetOpts(

--- a/internal/states/character_naming.go
+++ b/internal/states/character_naming.go
@@ -2,12 +2,15 @@ package states
 
 import (
 	"fmt"
+	"image"
 	"time"
 	"unicode/utf8"
 
 	"github.com/ebitenui/ebitenui"
 	"github.com/ebitenui/ebitenui/widget"
 	"github.com/hajimehoshi/ebiten/v2"
+	"github.com/hajimehoshi/ebiten/v2/exp/textinput"
+	"github.com/hajimehoshi/ebiten/v2/inpututil"
 	"github.com/kijimaD/ruins/internal/config"
 	"github.com/kijimaD/ruins/internal/consts"
 	es "github.com/kijimaD/ruins/internal/engine/states"
@@ -86,14 +89,31 @@ func (st *CharacterNamingState) Update(world w.World) (es.Transition[w.World], e
 		resetTimer()
 	}
 
-	// TextInput から現在の値を同期
-	if textInput, ok := hooks.GetRef[*widget.TextInput](st.mount.Store(), "textInput"); ok && textInput != nil {
-		currentText := textInput.GetText()
-		if currentText != props.CurrentName {
-			st.mount.SetProps(namingProps{
-				CurrentName:  currentText,
-				ErrorMessage: props.ErrorMessage,
-			})
+	// エラークリアが走った可能性があるので props を取り直す
+	props = st.mount.GetProps()
+
+	// IME 入力を進め、確定テキストを props へ同期する
+	if field, ok := hooks.GetRef[*textinput.Field](st.mount.Store(), "imeField"); ok && field != nil {
+		// 合成窓の位置。表示ウィジェットの矩形が取れれば使う
+		bounds := image.Rect(0, 0, consts.GameWidth, consts.GameHeight)
+		if ti, ok := hooks.GetRef[*widget.TextInput](st.mount.Store(), "textInput"); ok && ti != nil {
+			if r := ti.GetWidget().Rect; !r.Empty() {
+				bounds = r
+			}
+		}
+		if _, err := field.HandleInputWithBounds(bounds); err != nil {
+			return es.Transition[w.World]{}, err
+		}
+		// backspace は noime が拾わないので自前で消す。合成中は OS に委ねる
+		if _, _, composing := field.CompositionSelection(); !composing && inpututil.IsKeyJustPressed(ebiten.KeyBackspace) {
+			if t := field.Text(); t != "" {
+				_, size := utf8.DecodeLastRuneInString(t)
+				trimmed := t[:len(t)-size]
+				field.SetTextAndSelection(trimmed, len(trimmed), len(trimmed))
+			}
+		}
+		if committed := field.Text(); committed != props.CurrentName {
+			st.mount.SetProps(namingProps{CurrentName: committed, ErrorMessage: props.ErrorMessage})
 		}
 	}
 
@@ -236,9 +256,17 @@ func (st *CharacterNamingState) buildUI(world w.World) *ebitenui.UI {
 		),
 	)
 
-	// テキスト入力を作成
+	// IME 対応の入力フィールド。Windows/WASM/macOS は OS の IME、Linux は AppendInputChars で英数のみ。
+	field := hooks.UseRef(st.mount.Store(), "imeField", func() *textinput.Field {
+		f := &textinput.Field{}
+		f.SetTextAndSelection(props.CurrentName, len(props.CurrentName), len(props.CurrentName))
+		f.Focus()
+		return f
+	})
+
+	// テキスト入力ウィジェットは表示専用にする。入力は field が担うのでフォーカスは取らない。
 	textInput := hooks.UseRef(st.mount.Store(), "textInput", func() *widget.TextInput {
-		ti := widget.NewTextInput(
+		return widget.NewTextInput(
 			widget.TextInputOpts.WidgetOpts(
 				widget.WidgetOpts.LayoutData(widget.RowLayoutData{
 					Position: widget.RowLayoutPositionCenter,
@@ -252,10 +280,9 @@ func (st *CharacterNamingState) buildUI(world w.World) *ebitenui.UI {
 			widget.TextInputOpts.Padding(&res.TextInput.Padding),
 			widget.TextInputOpts.Placeholder(query.T(world, "Name")),
 		)
-		ti.SetText(props.CurrentName)
-		ti.Focus(true)
-		return ti
 	})
+	// 変換中を含む表示テキストを反映する
+	textInput.SetText(field.TextForRendering())
 
 	// エラーメッセージ
 	errorText := widget.NewText(


### PR DESCRIPTION
## 概要

キャラクター名付け画面のテキスト入力を `exp/textinput.Field` ベースへ移行し、Windows/WASM/macOS で日本語の IME 入力を可能にする。

## 変更点

`internal/states/character_naming.go`

- 入力の真実源を `textinput.Field` にする。ebitenui の `widget.TextInput` は `field.TextForRendering()` を映す表示専用にし、フォーカスは持たせない。変換中の未確定文字列も表示に出る。
- `Update` で `field.HandleInputWithBounds(bounds)` を呼び入力を進める。bounds は表示ウィジェットの矩形を使い、IME の変換窓を入力欄付近に出す。
- `noime` は backspace を拾わないため、非合成時のみ末尾 rune を自前で削る。合成中は OS に委ねる。

## プラットフォーム別の挙動

| 環境 | 日本語入力 | 検証 |
|---|---|---|
| WASM | OS の IME | ○ 実機で日本語入力を確認 |
| Windows | OS の IME | 未検証。WASM が通ったので契約上は動く見込み |
| macOS | OS の IME | 未検証 |
| Linux | 英数のみ、従来どおり | ○ 回帰なし |

## 検証

- `make check` はビルド・lint・テスト・脆弱性すべてクリーン。
- WASM で実際に日本語の変換・確定が動くことを確認済み。
- Linux 開発機では英数入力が従来どおり動き、回帰しないことを確認済み。Windows/macOS の実挙動は該当環境でのビルド確認が別途必要。