### PR TITLE
test(overlay): カバレッジ増強

### DIFF
--- a/internal/widgets/overlay/detail_test.go
+++ b/internal/widgets/overlay/detail_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/ebitenui/ebitenui/widget"
+	gc "github.com/kijimaD/ruins/internal/components"
 	"github.com/kijimaD/ruins/internal/testutil"
 	"github.com/kijimaD/ruins/internal/vrt"
 	"github.com/kijimaD/ruins/internal/widgets/entityspec"
@@ -81,6 +82,82 @@ func TestEntityDetailContent_死んだ実体は空を返しpanicしない(t *tes
 	})
 	assert.Empty(t, content.Name, "対象が無いので名前は出さない")
 	assert.Nil(t, content.Rows, "対象が無いので性能行は出さない")
+}
+
+// TestEntityDetailContent_生存している実体は名前と説明と性能行を返す は、Name・Description・
+// Abilities を持つ実体から詳細内容を正しく組み立てることを固定する。
+func TestEntityDetailContent_生存している実体は名前と説明と性能行を返す(t *testing.T) {
+	t.Parallel()
+
+	world := testutil.InitTestWorld(t)
+	e := world.ECS.NewEntity()
+	world.Components.Name.Add(e, &gc.Name{Name: "テストアイテム"})
+	world.Components.Description.Add(e, &gc.Description{Description: "テスト説明"})
+	world.Components.Abilities.Add(e, &gc.Abilities{
+		Vitality: gc.Ability{Base: 10},
+		Strength: gc.Ability{Base: 5},
+	})
+
+	content := EntityDetailContent(world, e)
+
+	assert.Equal(t, "テストアイテム", content.Name, "未訳のNameは原文のまま返る")
+	assert.Equal(t, "テスト説明", content.Desc, "未訳のDescriptionは原文のまま返る")
+	assert.Len(t, content.Rows, 6, "Abilitiesの性能行が6行分含まれる")
+}
+
+// TestEntityDetailContent_説明コンポーネントが無ければ空文字 は、Description を持たない実体でも
+// panicせず空文字を返すことを固定する。
+func TestEntityDetailContent_説明コンポーネントが無ければ空文字(t *testing.T) {
+	t.Parallel()
+
+	world := testutil.InitTestWorld(t)
+	e := world.ECS.NewEntity()
+	world.Components.Name.Add(e, &gc.Name{Name: "説明なしアイテム"})
+
+	content := EntityDetailContent(world, e)
+
+	assert.Equal(t, "説明なしアイテム", content.Name)
+	assert.Empty(t, content.Desc, "Descriptionコンポーネントが無ければ空文字を返す")
+}
+
+func TestNewEntityDetail_対象が無ければ開かない(t *testing.T) {
+	t.Parallel()
+
+	world := testutil.InitTestWorld(t)
+	d := NewEntityDetail(func() (ecs.Entity, bool) { return ecs.Entity{}, false })
+
+	d.Open(world)
+
+	assert.False(t, d.Active(), "provideがokを返さなければ開かない")
+}
+
+// TestNewEntityDetail_対象が死んでいれば開かない は、provide が返す実体がすでに削除されていても
+// ゼロ実体への Get で落ちずに開かないことを固定する。
+func TestNewEntityDetail_対象が死んでいれば開かない(t *testing.T) {
+	t.Parallel()
+
+	world := testutil.InitTestWorld(t)
+	e := world.ECS.NewEntity()
+	world.ECS.RemoveEntity(e)
+	d := NewEntityDetail(func() (ecs.Entity, bool) { return e, true })
+
+	assert.NotPanics(t, func() {
+		d.Open(world)
+	})
+	assert.False(t, d.Active(), "死んだ実体では開かない")
+}
+
+func TestNewEntityDetail_対象があれば実体から詳細を組み立てて開く(t *testing.T) {
+	t.Parallel()
+
+	world := testutil.InitTestWorld(t)
+	e := world.ECS.NewEntity()
+	world.Components.Name.Add(e, &gc.Name{Name: "回復薬"})
+	d := NewEntityDetail(func() (ecs.Entity, bool) { return e, true })
+
+	d.Open(world)
+
+	assert.True(t, d.Active(), "生存している実体があれば開く")
 }
 
 func TestDetailWindow_対象が無ければnilを返す(t *testing.T) {

--- a/internal/widgets/overlay/detail_test.go
+++ b/internal/widgets/overlay/detail_test.go
@@ -86,6 +86,8 @@ func TestEntityDetailContent_死んだ実体は空を返しpanicしない(t *tes
 
 // TestEntityDetailContent_生存している実体は名前と説明と性能行を返す は、Name・Description・
 // Abilities を持つ実体から詳細内容を正しく組み立てることを固定する。
+// EntityDetailContent は Name・Description・Abilities の3コンポーネントだけを参照し、spawn
+// 関数が付与する他コンポーネントの有無は結果に影響しないため、手作り実体で検証する。
 func TestEntityDetailContent_生存している実体は名前と説明と性能行を返す(t *testing.T) {
 	t.Parallel()
 
@@ -106,7 +108,8 @@ func TestEntityDetailContent_生存している実体は名前と説明と性能
 }
 
 // TestEntityDetailContent_説明コンポーネントが無ければ空文字 は、Description を持たない実体でも
-// panicせず空文字を返すことを固定する。
+// panicせず空文字を返すことを固定する。EntityDetailContent が参照するのは Name・Description・
+// Abilities のみなので、手作り実体で検証する。
 func TestEntityDetailContent_説明コンポーネントが無ければ空文字(t *testing.T) {
 	t.Parallel()
 

--- a/internal/widgets/overlay/window_test.go
+++ b/internal/widgets/overlay/window_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/ebitenui/ebitenui/widget"
+	gc "github.com/kijimaD/ruins/internal/components"
 	"github.com/kijimaD/ruins/internal/testutil"
 	"github.com/kijimaD/ruins/internal/vrt"
 	"github.com/kijimaD/ruins/internal/widgets/entityspec"
@@ -58,6 +59,23 @@ func TestDetailPageCount(t *testing.T) {
 			assert.Equal(t, tt.want, detailPageCount(tt.rowCount))
 		})
 	}
+}
+
+// TestDetailPageCount_実体の性能行数からページ数を算出する は、公開の DetailPageCount が
+// entityspec.SpecRows の行数を detailPageCount に正しく渡していることを固定する。
+func TestDetailPageCount_実体の性能行数からページ数を算出する(t *testing.T) {
+	t.Parallel()
+
+	world := testutil.InitTestWorld(t)
+
+	noComponent := world.ECS.NewEntity()
+	assert.Equal(t, 1, DetailPageCount(world, noComponent), "性能行が無い実体は1ページに丸める")
+
+	withAbilities := world.ECS.NewEntity()
+	world.Components.Abilities.Add(withAbilities, &gc.Abilities{
+		Vitality: gc.Ability{Base: 10},
+	})
+	assert.Equal(t, 1, DetailPageCount(world, withAbilities), "Abilitiesの6行は1ページに収まる")
 }
 
 func TestBuildDetailFromRows_説明は最終ページにだけ表示する(t *testing.T) {


### PR DESCRIPTION
## 概要

`internal/widgets/overlay` パッケージのテストカバレッジを増強する。テストのみ追加し、本体コードは変更しない。

## カバレッジ

- 変更前: 62.5%
- 変更後: 80.4%

## 狙った振る舞い

- `EntityDetailContent`: Name・Description・Abilities を持つ生存実体から名前・説明・性能行を正しく組み立てること。Description コンポーネントが無ければ空文字を返すこと
- `NewEntityDetail`: provide が対象なしを返す場合、対象が死んでいる場合はモーダルを開かないこと。生存している実体があれば開くこと
- `DetailPageCount`（`window.go` のエクスポート関数）: 実体の性能行数を `entityspec.SpecRows` 経由で正しく `detailPageCount` に渡し、ページ数を算出すること

`HandleInput` はテスト環境で実キー入力をシミュレートできないため、既存のカバレッジ上限のまま残る。

## 検証

- `go test -race ./internal/widgets/overlay/...`
- `golangci-lint run ./...`
- `go build ./...`

---
_Generated by [Claude Code](https://claude.ai/code/session_01QFc24nYzxESfwC7hj1cwnt)_