### PR TITLE
test(resources): カバレッジ増強

### DIFF
--- a/internal/resources/sprite_test.go
+++ b/internal/resources/sprite_test.go
@@ -25,7 +25,7 @@ func TestSpriteImage_シートが見つからなければエラー(t *testing.T)
 
 	img, err := SpriteImage(map[string]components.SpriteSheet{}, sr)
 
-	require.ErrorContains(t, err, "missing")
+	require.ErrorContains(t, err, `sprite sheet "missing" not found`)
 	assert.Nil(t, img)
 }
 
@@ -42,7 +42,7 @@ func TestSpriteImage_キーが見つからなければエラー(t *testing.T) {
 
 	img, err := SpriteImage(sheets, sr)
 
-	require.ErrorContains(t, err, "missing")
+	require.ErrorContains(t, err, `sprite key "missing" not found in sheet "sheet"`)
 	assert.Nil(t, img)
 }
 
@@ -61,7 +61,7 @@ func TestSpriteImage_テクスチャ画像が無ければエラー(t *testing.T)
 
 	img, err := SpriteImage(sheets, sr)
 
-	require.ErrorContains(t, err, "sheet")
+	require.ErrorContains(t, err, "has no texture image")
 	assert.Nil(t, img)
 }
 
@@ -105,4 +105,25 @@ func TestSpriteImage_テクスチャ範囲をはみ出す矩形はクランプ�
 	require.NotNil(t, img)
 	assert.Equal(t, 10, img.Bounds().Dx())
 	assert.Equal(t, 10, img.Bounds().Dy())
+}
+
+func TestSpriteImage_右端だけはみ出す矩形は右端だけクランプされる(t *testing.T) {
+	t.Parallel()
+
+	sheets := map[string]components.SpriteSheet{
+		"sheet": {
+			Texture: components.Texture{Image: ebiten.NewImage(10, 10)},
+			Sprites: map[string]components.Sprite{
+				"key": {X: 5, Y: 0, Width: 20, Height: 4},
+			},
+		},
+	}
+	sr := &components.SpriteRender{SpriteSheetName: "sheet", SpriteKey: "key"}
+
+	img, err := SpriteImage(sheets, sr)
+
+	require.NoError(t, err)
+	require.NotNil(t, img)
+	assert.Equal(t, 5, img.Bounds().Dx())
+	assert.Equal(t, 4, img.Bounds().Dy())
 }

--- a/internal/resources/sprite_test.go
+++ b/internal/resources/sprite_test.go
@@ -1,0 +1,108 @@
+package resources
+
+import (
+	"testing"
+
+	"github.com/hajimehoshi/ebiten/v2"
+	"github.com/kijimaD/ruins/internal/components"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSpriteImage_SpriteRenderがnilならエラー(t *testing.T) {
+	t.Parallel()
+
+	img, err := SpriteImage(map[string]components.SpriteSheet{}, nil)
+
+	require.ErrorContains(t, err, "sprite render is nil")
+	assert.Nil(t, img)
+}
+
+func TestSpriteImage_シートが見つからなければエラー(t *testing.T) {
+	t.Parallel()
+
+	sr := &components.SpriteRender{SpriteSheetName: "missing", SpriteKey: "a"}
+
+	img, err := SpriteImage(map[string]components.SpriteSheet{}, sr)
+
+	require.ErrorContains(t, err, "missing")
+	assert.Nil(t, img)
+}
+
+func TestSpriteImage_キーが見つからなければエラー(t *testing.T) {
+	t.Parallel()
+
+	sheets := map[string]components.SpriteSheet{
+		"sheet": {
+			Texture: components.Texture{Image: ebiten.NewImage(10, 10)},
+			Sprites: map[string]components.Sprite{},
+		},
+	}
+	sr := &components.SpriteRender{SpriteSheetName: "sheet", SpriteKey: "missing"}
+
+	img, err := SpriteImage(sheets, sr)
+
+	require.ErrorContains(t, err, "missing")
+	assert.Nil(t, img)
+}
+
+func TestSpriteImage_テクスチャ画像が無ければエラー(t *testing.T) {
+	t.Parallel()
+
+	sheets := map[string]components.SpriteSheet{
+		"sheet": {
+			Texture: components.Texture{Image: nil},
+			Sprites: map[string]components.Sprite{
+				"key": {X: 0, Y: 0, Width: 4, Height: 4},
+			},
+		},
+	}
+	sr := &components.SpriteRender{SpriteSheetName: "sheet", SpriteKey: "key"}
+
+	img, err := SpriteImage(sheets, sr)
+
+	require.ErrorContains(t, err, "sheet")
+	assert.Nil(t, img)
+}
+
+func TestSpriteImage_矩形どおりに切り出す(t *testing.T) {
+	t.Parallel()
+
+	sheets := map[string]components.SpriteSheet{
+		"sheet": {
+			Texture: components.Texture{Image: ebiten.NewImage(20, 20)},
+			Sprites: map[string]components.Sprite{
+				"key": {X: 2, Y: 3, Width: 5, Height: 6},
+			},
+		},
+	}
+	sr := &components.SpriteRender{SpriteSheetName: "sheet", SpriteKey: "key"}
+
+	img, err := SpriteImage(sheets, sr)
+
+	require.NoError(t, err)
+	require.NotNil(t, img)
+	assert.Equal(t, 5, img.Bounds().Dx())
+	assert.Equal(t, 6, img.Bounds().Dy())
+}
+
+func TestSpriteImage_テクスチャ範囲をはみ出す矩形はクランプされる(t *testing.T) {
+	t.Parallel()
+
+	sheets := map[string]components.SpriteSheet{
+		"sheet": {
+			Texture: components.Texture{Image: ebiten.NewImage(10, 10)},
+			Sprites: map[string]components.Sprite{
+				"key": {X: -5, Y: -5, Width: 20, Height: 20},
+			},
+		},
+	}
+	sr := &components.SpriteRender{SpriteSheetName: "sheet", SpriteKey: "key"}
+
+	img, err := SpriteImage(sheets, sr)
+
+	require.NoError(t, err)
+	require.NotNil(t, img)
+	assert.Equal(t, 10, img.Bounds().Dx())
+	assert.Equal(t, 10, img.Bounds().Dy())
+}


### PR DESCRIPTION
## 概要

`internal/resources` のカバレッジを 71.5% → 76.3% に増強する。`internal/resources/sprite.go` の `SpriteImage` は分岐がテストされておらず 0% だったため、`internal/resources/sprite_test.go` を新規追加して検証する。

## 対象

`SpriteImage` は `SpriteRender` からスプライトシート上の部分画像を解決する関数。以下を検証する。

- `SpriteRender` が nil の場合はエラー
- 指定したスプライトシート名が見つからない場合はエラー
- 指定したスプライトキーがシート内に見つからない場合はエラー
- シートにテクスチャ画像が無い場合はエラー
- 正常系: 指定した矩形どおりに部分画像を切り出す
- 境界: テクスチャ範囲をはみ出す矩形はテクスチャ範囲にクランプされる

## 変更範囲

テストファイルのみ追加。本体コードの変更は無い。

## 検証

- `go test ./internal/resources/...`: PASS
- `golangci-lint run ./internal/resources/...`: 0 issues
- `go build ./...`: 成功

---
_Generated by [Claude Code](https://claude.ai/code/session_01PBUMaLtFLqAfNtsLTr1j4a)_