### PR TITLE
refactor(interaction): StackBundled bool を行単位の enum MenuUnit にする

### DIFF
--- a/internal/components/interactable.go
+++ b/internal/components/interactable.go
@@ -35,6 +35,16 @@ const (
 	MenuUnitStack MenuUnit = "STACK"
 )
 
+// Valid はMenuUnitの値が有効かを検証する
+func (enum MenuUnit) Valid() error {
+	switch enum {
+	case MenuUnitEntity, MenuUnitStack:
+		return nil
+	default:
+		return fmt.Errorf("get %s: %w", enum, ErrInvalidEnumType)
+	}
+}
+
 // InteractionKind は相互作用の種類を表す。
 // 種別ごとに Config() で発動プロトコル（発動範囲・発動方式）を持つ点が本質で、
 // これは domain コンポーネント（Door の開閉状態、Dialog のメッセージキー等）とは

--- a/internal/components/interactable.go
+++ b/internal/components/interactable.go
@@ -21,11 +21,19 @@ type Interactable struct {
 type InteractionConfig struct {
 	ActivationRange ActivationRange // 発動範囲
 	ActivationWay   ActivationWay   // 発動方式
-	// StackBundled は真なら、メニューの行をエンティティ単位でなくスタック単位で組む。
-	// 同一 StackKey の実体を1行に束ね、実行はスタック丸ごとを対象にする。
-	// 1個1エンティティのアイテムが個数ぶん同じ行に並ぶのを防ぐ
-	StackBundled bool
+	MenuUnit        MenuUnit        // メニューの行の単位
 }
+
+// MenuUnit は相互作用メニューの行の単位を表す
+type MenuUnit string
+
+const (
+	// MenuUnitEntity は1実体を1行にする。扉やNPCのような個体
+	MenuUnitEntity MenuUnit = "ENTITY"
+	// MenuUnitStack は同一 StackKey の実体を1行に束ね、実行はスタック丸ごとを対象にする。
+	// 1個1エンティティのアイテムが個数ぶん同じ行に並ぶのを防ぐ
+	MenuUnitStack MenuUnit = "STACK"
+)
 
 // InteractionKind は相互作用の種類を表す。
 // 種別ごとに Config() で発動プロトコル（発動範囲・発動方式）を持つ点が本質で、
@@ -73,15 +81,15 @@ const (
 func (k InteractionKind) Config() InteractionConfig {
 	switch k {
 	case InteractionItem:
-		return InteractionConfig{ActivationRange: ActivationRangeSameTile, ActivationWay: ActivationWayManual, StackBundled: true}
+		return InteractionConfig{ActivationRange: ActivationRangeSameTile, ActivationWay: ActivationWayManual, MenuUnit: MenuUnitStack}
 	case InteractionPortalNext, InteractionPortalPrev, InteractionDungeonEnter, InteractionItemAll:
-		return InteractionConfig{ActivationRange: ActivationRangeSameTile, ActivationWay: ActivationWayManual}
+		return InteractionConfig{ActivationRange: ActivationRangeSameTile, ActivationWay: ActivationWayManual, MenuUnit: MenuUnitEntity}
 	case InteractionDoor, InteractionTalk, InteractionMelee, InteractionCubePanel:
-		return InteractionConfig{ActivationRange: ActivationRangeAdjacent, ActivationWay: ActivationWayOnCollision}
+		return InteractionConfig{ActivationRange: ActivationRangeAdjacent, ActivationWay: ActivationWayOnCollision, MenuUnit: MenuUnitEntity}
 	case InteractionStorage, InteractionDisassemble, InteractionEnterCube, InteractionPullCube, InteractionAuction:
-		return InteractionConfig{ActivationRange: ActivationRangeAdjacent, ActivationWay: ActivationWayManual}
+		return InteractionConfig{ActivationRange: ActivationRangeAdjacent, ActivationWay: ActivationWayManual, MenuUnit: MenuUnitEntity}
 	case InteractionExitCube:
-		return InteractionConfig{ActivationRange: ActivationRangeSameTile, ActivationWay: ActivationWayManual}
+		return InteractionConfig{ActivationRange: ActivationRangeSameTile, ActivationWay: ActivationWayManual, MenuUnit: MenuUnitEntity}
 	}
 	return InteractionConfig{}
 }

--- a/internal/components/interactable_test.go
+++ b/internal/components/interactable_test.go
@@ -15,14 +15,15 @@ func TestInteractionKind_Config(t *testing.T) {
 		kind      InteractionKind
 		wantRange ActivationRange
 		wantWay   ActivationWay
+		wantUnit  MenuUnit
 	}{
-		{InteractionDoor, ActivationRangeAdjacent, ActivationWayOnCollision},
-		{InteractionTalk, ActivationRangeAdjacent, ActivationWayOnCollision},
-		{InteractionMelee, ActivationRangeAdjacent, ActivationWayOnCollision},
-		{InteractionItem, ActivationRangeSameTile, ActivationWayManual},
-		{InteractionItemAll, ActivationRangeSameTile, ActivationWayManual},
-		{InteractionPortalNext, ActivationRangeSameTile, ActivationWayManual},
-		{InteractionStorage, ActivationRangeAdjacent, ActivationWayManual},
+		{InteractionDoor, ActivationRangeAdjacent, ActivationWayOnCollision, MenuUnitEntity},
+		{InteractionTalk, ActivationRangeAdjacent, ActivationWayOnCollision, MenuUnitEntity},
+		{InteractionMelee, ActivationRangeAdjacent, ActivationWayOnCollision, MenuUnitEntity},
+		{InteractionItem, ActivationRangeSameTile, ActivationWayManual, MenuUnitStack},
+		{InteractionItemAll, ActivationRangeSameTile, ActivationWayManual, MenuUnitEntity},
+		{InteractionPortalNext, ActivationRangeSameTile, ActivationWayManual, MenuUnitEntity},
+		{InteractionStorage, ActivationRangeAdjacent, ActivationWayManual, MenuUnitEntity},
 	}
 
 	for _, tt := range tests {
@@ -31,6 +32,7 @@ func TestInteractionKind_Config(t *testing.T) {
 			config := tt.kind.Config()
 			assert.Equal(t, tt.wantRange, config.ActivationRange)
 			assert.Equal(t, tt.wantWay, config.ActivationWay)
+			assert.Equal(t, tt.wantUnit, config.MenuUnit)
 		})
 	}
 }
@@ -42,6 +44,7 @@ func TestInteractionKind_Config_Unknown(t *testing.T) {
 	config := InteractionKind("UNKNOWN").Config()
 	require.Error(t, config.ActivationRange.Valid(), "未知の種類は無効なConfigを返す")
 	require.Error(t, config.ActivationWay.Valid(), "未知の種類は無効なConfigを返す")
+	require.Error(t, config.MenuUnit.Valid(), "未知の種類は無効なConfigを返す")
 }
 
 // TestActivationRange_Valid は有効なActivationRangeの検証
@@ -148,6 +151,7 @@ func TestInteractionKind_ConfigConsistency(t *testing.T) {
 		InteractionDoor, InteractionTalk, InteractionItem, InteractionItemAll,
 		InteractionStorage, InteractionMelee, InteractionDisassemble,
 		InteractionEnterCube, InteractionExitCube, InteractionPullCube, InteractionCubePanel,
+		InteractionAuction,
 	}
 
 	for _, kind := range kinds {
@@ -156,6 +160,7 @@ func TestInteractionKind_ConfigConsistency(t *testing.T) {
 			config := kind.Config()
 			require.NoError(t, config.ActivationRange.Valid(), "%s のActivationRangeは有効でなければならない", kind)
 			require.NoError(t, config.ActivationWay.Valid(), "%s のActivationWayは有効でなければならない", kind)
+			require.NoError(t, config.MenuUnit.Valid(), "%s のMenuUnitは有効でなければならない", kind)
 		})
 	}
 }

--- a/internal/states/action_handlers.go
+++ b/internal/states/action_handlers.go
@@ -108,12 +108,15 @@ func GetSameTileManualActions(world w.World) []InteractionAction {
 
 // splitByMenuUnit は種別を、行の単位の宣言 Config().MenuUnit に従ってスタック単位と
 // エンティティ単位へ分ける。一覧を組む関数はこの振り分けに従う。
-// 両方を持つ実体は両経路に載り、束ね行と個別行が並ぶ
+// 両方を持つ実体は両経路に載り、束ね行と個別行が並ぶ。
+// switch に default を置かず、単位の追加漏れを exhaustive linter に検知させる。
+// 未知の種別の単位はゼロ値で raw/save 由来でありうるので、行を組まず黙って落とす
 func splitByMenuUnit(kinds []gc.InteractionKind) (stack, entity []gc.InteractionKind) {
 	for _, kind := range kinds {
-		if kind.Config().MenuUnit == gc.MenuUnitStack {
+		switch kind.Config().MenuUnit {
+		case gc.MenuUnitStack:
 			stack = append(stack, kind)
-		} else {
+		case gc.MenuUnitEntity:
 			entity = append(entity, kind)
 		}
 	}

--- a/internal/states/action_handlers.go
+++ b/internal/states/action_handlers.go
@@ -43,9 +43,9 @@ func GetInteractionActions(world w.World) []InteractionAction {
 		}
 
 		interactable := world.Components.Interactable.Get(interactableEntity)
-		// スタック束ねの種別を持つ実体は束ね経路へ集める。拾得は同タイルに限られるので
+		// スタック単位の種別を持つ実体は束ね経路へ集める。拾得は同タイルに限られるので
 		// 位置を無視して束ねても別タイルの同種が混ざることはない
-		bundled, individual := splitByStackBundled(interactable.Interactions)
+		bundled, individual := splitByMenuUnit(interactable.Interactions)
 		if len(bundled) > 0 {
 			itemEntities = append(itemEntities, interactableEntity)
 		}
@@ -94,7 +94,7 @@ func GetSameTileManualActions(world w.World) []InteractionAction {
 		if len(filtered) == 0 {
 			continue
 		}
-		bundled, individual := splitByStackBundled(filtered)
+		bundled, individual := splitByMenuUnit(filtered)
 		if len(bundled) > 0 {
 			itemEntities = append(itemEntities, entity)
 		}
@@ -106,18 +106,18 @@ func GetSameTileManualActions(world w.World) []InteractionAction {
 	return appendItemPickupActions(world, actions, itemEntities)
 }
 
-// splitByStackBundled は種別を、スタック単位で束ねる行にするものとエンティティ単位の行にする
-// ものへ分ける。束ねるかは種別の宣言 Config().StackBundled が決め、一覧を組む関数はこれに従う。
+// splitByMenuUnit は種別を、行の単位の宣言 Config().MenuUnit に従ってスタック単位と
+// エンティティ単位へ分ける。一覧を組む関数はこの振り分けに従う。
 // 両方を持つ実体は両経路に載り、束ね行と個別行が並ぶ
-func splitByStackBundled(kinds []gc.InteractionKind) (bundled, individual []gc.InteractionKind) {
+func splitByMenuUnit(kinds []gc.InteractionKind) (stack, entity []gc.InteractionKind) {
 	for _, kind := range kinds {
-		if kind.Config().StackBundled {
-			bundled = append(bundled, kind)
+		if kind.Config().MenuUnit == gc.MenuUnitStack {
+			stack = append(stack, kind)
 		} else {
-			individual = append(individual, kind)
+			entity = append(entity, kind)
 		}
 	}
-	return bundled, individual
+	return stack, entity
 }
 
 // appendItemPickupActions は itemEntities をスタックごとに1行へ束ねて拾得アクションを足す。
@@ -173,7 +173,7 @@ func getInteractionActions(world w.World, interactable *gc.Interactable, interac
 				})
 			}
 		case gc.InteractionItem:
-			// StackBundled な種別は splitByStackBundled で束ね経路へ振られ、ここには来ない。
+			// スタック単位の種別は splitByMenuUnit で束ね経路へ振られ、ここには来ない。
 			// 拾得行は appendItemPickupActions がスタック単位で組む
 		case gc.InteractionPortalNext:
 			result = append(result, InteractionAction{


### PR DESCRIPTION
## 概要

相互作用メニューの行の単位を表す `InteractionConfig.StackBundled bool` を、string enum の `MenuUnit` に変える。#665 のフォローアップ。

## 変更内容

- `MenuUnit` 型を新設し、`ENTITY`（1実体1行）と `STACK`（同一 StackKey を1行に束ね、実行はスタック丸ごと）を定義する
- `Config()` は全 case で行の単位を明示する。Item だけ `STACK`、他は `ENTITY`
- メニュー生成の振り分けを `splitByMenuUnit` に改名し、`MenuUnit` の比較で分岐する

## 理由

- 隣の `ActivationRange`・`ActivationWay` が string enum なのに、これだけ bool でスタイルが割れていた
- 意味的にも真偽でなく行の単位の選択で、enum 規約「type X string、iota は使わない」に沿うと値が `%v` やログにそのまま読める
- 名前は既存の命名系列、発動範囲・発動方式、に合わせて `MenuUnit`。`〜Type` 接尾辞は情報を足さないため使わない

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D1o2YJAmJdWCD5efK84yt9