### PR TITLE
test(save): TestMain で ebiten コンテキストに入れフレーキーを直す

### DIFF
--- a/internal/save/main_test.go
+++ b/internal/save/main_test.go
@@ -1,0 +1,15 @@
+package save
+
+import (
+	"os"
+	"testing"
+
+	"github.com/kijimaD/ruins/internal/vrt"
+)
+
+// TestMain はebitenグラフィックスコンテキスト内で全テストを実行する。
+// testutil.InitTestWorld が UIResources をロードし ebiten の実行状態に依存するため、
+// RunGame の外で走らせると glfw が実ディスプレイを開こうとして xvfb と競合し稀に失敗する。
+func TestMain(m *testing.M) {
+	os.Exit(vrt.RunTestMain(m))
+}

--- a/internal/save/main_test.go
+++ b/internal/save/main_test.go
@@ -8,8 +8,7 @@ import (
 )
 
 // TestMain はebitenグラフィックスコンテキスト内で全テストを実行する。
-// testutil.InitTestWorld が UIResources をロードし ebiten の実行状態に依存するため、
-// RunGame の外で走らせると glfw が実ディスプレイを開こうとして xvfb と競合し稀に失敗する。
+// UIResources のロードが ebiten の実行状態に依存するため必要
 func TestMain(m *testing.M) {
 	os.Exit(vrt.RunTestMain(m))
 }


### PR DESCRIPTION
## 問題

CI の test ジョブが稀に落ちる。`internal/save` のテストで glfw が実ディスプレイを開けず panic する。

```
glfw: X11: Failed to open display :99: a platform-specific error occurred
panic: glfw: The GLFW library is not initialized
FAIL	github.com/kijimaD/ruins/internal/save
```

## 原因

`internal/save` のテストは `testutil.InitTestWorld` で UIResources をロードし ebiten の実行状態に依存する。だが save パッケージには `TestMain` が無く、`ebiten.RunGame` の外でテストが走っていた。そのため glfw が遅延で実ディスプレイを開こうとし、xvfb の初期化と競合して稀に失敗していた。ebiten を触る他の7パッケージ(states・menuframe・overlay 等)は `TestMain` で `vrt.RunTestMain` を通しているが、save だけ漏れていた。

## 修正

`internal/save/main_test.go` を追加し、他パッケージと同じく `vrt.RunTestMain` 経由でテストを ebiten コンテキスト内で走らせる。glfw が RunGame により一度だけ正しく初期化され、遅延の実ディスプレイ open が起きなくなる。

`xvfb-run -a go test ./internal/save/` と `make test` が green。

🤖 Generated with [Claude Code](https://claude.com/claude-code)