### PR TITLE
feat(states): デバッグ開始の初期所持に本を積む

### DIFF
--- a/internal/states/demo_start.go
+++ b/internal/states/demo_start.go
@@ -38,6 +38,11 @@ func (st *DemoStartState) OnStart(world w.World) error {
 		return err
 	}
 
+	// デバッグ用に本を初期所持へ積む。読書アクティビティを開始直後に試せるようにする
+	if _, err := lifecycle.SpawnBackpackItem(world, "grape_book", 1); err != nil {
+		return fmt.Errorf("failed to spawn debug book: %w", err)
+	}
+
 	st.SetTransition(es.Transition[w.World]{
 		Type:          es.TransReplace,
 		NewStateFuncs: []es.StateFactory[w.World]{newGameOverworldState(world)},


### PR DESCRIPTION
## 概要

`DemoStartState` のデバッグ初期所持へ本 `grape_book` を1冊足す。読書アクティビティを開始直後に試せるようにするためのデバッグ用の仕込み。

## 変更点

- `internal/states/demo_start.go`: `spawnDebugBiscuits` の隣で `SpawnBackpackItem(world, "grape_book", 1)` を呼び、バックパックへ本を積む

## 背景

既存の `spawnDebugBiscuits`（コメント: 「デバッグ用に…初期所持へ積む」）と同じデバッグ初期仕込みの場所に並べた。新しい仕組みは足さず、開始直後に試せる仕込み一式として一望できるようにしている。`grape_book` は crafting スキルを持つ実在アイテムで spawnable。

## 確認

- `make check` 全て green（build/test/lint/vuln）
- 単発の `SpawnBackpackItem` なのでヘルパー化せず直書き

🤖 Generated with [Claude Code](https://claude.com/claude-code)