### PR TITLE
初期言語を Steam のロケールから決める

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ $ make help
 | draft | [腐敗システムの将来拡張](docs/design/260815125506.md) | 0/4 | item, gamedesign |
 | draft | [コード監査: 通信販売・食料鮮度・AI追跡・命中判定 2026-08-17](docs/design/260817001843.md) | 0/5（見送り1） | item, combat, ecs |
 | draft | [身体の不調: 少数部位の負傷と、まとめて配る手当て](docs/design/260821232324.md) | 0/11 | gamedesign, combat, item, ecs |
+| draft | [初期言語をホストと Steam のロケールから決め、ビルドで固定できるようにする](docs/design/260823004406.md) | 0/8 | ui, steam, save |
 
 
 ## Reference

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ $ make help
 | draft | [腐敗システムの将来拡張](docs/design/260815125506.md) | 0/4 | item, gamedesign |
 | draft | [コード監査: 通信販売・食料鮮度・AI追跡・命中判定 2026-08-17](docs/design/260817001843.md) | 0/5（見送り1） | item, combat, ecs |
 | draft | [身体の不調: 少数部位の負傷と、まとめて配る手当て](docs/design/260821232324.md) | 0/11 | gamedesign, combat, item, ecs |
-| draft | [初期言語をホストと Steam のロケールから決め、ビルドで固定できるようにする](docs/design/260823004406.md) | 0/8 | ui, steam, save |
+| draft | [初期言語を Steam のロケールから決め、ビルドで固定できるようにする](docs/design/260823004406.md) | 0/6 | ui, steam, save |
 
 
 ## Reference

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ $ make help
 | draft | [腐敗システムの将来拡張](docs/design/260815125506.md) | 0/4 | item, gamedesign |
 | draft | [コード監査: 通信販売・食料鮮度・AI追跡・命中判定 2026-08-17](docs/design/260817001843.md) | 0/5（見送り1） | item, combat, ecs |
 | draft | [身体の不調: 少数部位の負傷と、まとめて配る手当て](docs/design/260821232324.md) | 0/11 | gamedesign, combat, item, ecs |
-| draft | [初期言語をホストと Steam のロケールから決め、ビルドで固定できるようにする](docs/design/260823004406.md) | 0/8 | ui, steam, save |
+| draft | [初期言語をホストと Steam のロケールから決め、ビルドで固定できるようにする](docs/design/260823004406.md) | 0/7 | ui, steam, save |
 
 
 ## Reference

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ $ make help
 | draft | [腐敗システムの将来拡張](docs/design/260815125506.md) | 0/4 | item, gamedesign |
 | draft | [コード監査: 通信販売・食料鮮度・AI追跡・命中判定 2026-08-17](docs/design/260817001843.md) | 0/5（見送り1） | item, combat, ecs |
 | draft | [身体の不調: 少数部位の負傷と、まとめて配る手当て](docs/design/260821232324.md) | 0/11 | gamedesign, combat, item, ecs |
-| draft | [初期言語をホストと Steam のロケールから決め、ビルドで固定できるようにする](docs/design/260823004406.md) | 0/7 | ui, steam, save |
+| draft | [初期言語をホストと Steam のロケールから決め、ビルドで固定できるようにする](docs/design/260823004406.md) | 0/8 | ui, steam, save |
 
 
 ## Reference

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ $ make help
 | draft | [腐敗システムの将来拡張](docs/design/260815125506.md) | 0/4 | item, gamedesign |
 | draft | [コード監査: 通信販売・食料鮮度・AI追跡・命中判定 2026-08-17](docs/design/260817001843.md) | 0/5（見送り1） | item, combat, ecs |
 | draft | [身体の不調: 少数部位の負傷と、まとめて配る手当て](docs/design/260821232324.md) | 0/11 | gamedesign, combat, item, ecs |
-| draft | [初期言語を Steam のロケールから決め、ビルドで固定できるようにする](docs/design/260823004406.md) | 0/6 | ui, steam, save |
+| draft | [初期言語を Steam のロケールから決める](docs/design/260823004406.md) | 0/4 | ui, steam, save |
 
 
 ## Reference

--- a/docs/design/260823004406.md
+++ b/docs/design/260823004406.md
@@ -4,7 +4,7 @@ tags: [ui, steam, save] # 領域ラベル
 auto: needs-decision # mechanical=無人着手可 / needs-decision=人の判断必須
 ---
 
-# 初期言語を Steam のロケールから決め、ビルドで固定できるようにする
+# 初期言語を Steam のロケールから決める
 
 ## 背景
 
@@ -12,9 +12,9 @@ auto: needs-decision # mechanical=無人着手可 / needs-decision=人の判断�
 
 配布は Steam を主軸に据える。Steam ではユーザがゲームごとに言語を選び、その言語が起動時にゲームへ渡る。ここで**言語別にビルドを分けるのは主流でなく、むしろアンチパターン**になる。言語を切り替えるのに再インストールが要り、Steam の言語ドロップダウンと噛み合わず、保守も配信も言語ぶん倍になる。重い言語資産のためには言語別 depot があるが、これは実行ファイルの分割ではない。ruins はテキスト中心で重い言語資産が無いので、depot 分割すら不要。
 
-そこで**単一ビルドのまま、Steam でユーザが選んだ言語を初期値に反映する**。プレイヤーの言語選好は Steam クライアントの言語設定に表れ、それが game-language として起動時に渡る。加えてビルドごとに初期言語を固定できる口も持つ。プレイヤーが設定画面で選んだ言語は従来どおり最優先で残す。
+そこで**単一ビルドのまま、Steam でユーザが選んだ言語を初期値に反映する**。プレイヤーの言語選好は Steam クライアントの言語設定に表れ、それが game-language として起動時に渡る。プレイヤーが設定画面で選んだ言語は従来どおり最優先で残す。
 
-**Steam 以外のビルドではホストロケールの判定はしない。** 開発ビルドと WASM 体験版は、ビルド固定 `consts.DefaultLang` があればそれ、無ければ `en` で起動する。OS や ブラウザのロケールを読む仕組みは持たない。自動判定は Steam の game-language に一本化し、非 Steam は固定値で足りるとする。
+**Steam 以外のビルドではホストロケールの判定はしない。** 開発ビルドと WASM 体験版は `en` で起動する。OS や ブラウザのロケールを読む仕組みも、ビルドで言語を固定する仕組みも持たない。自動判定は Steam の game-language に一本化する。
 
 言語のマスタ機構は既にある。対応言語は `i18n.SupportedLangs`(`ja`/`en`)、現在言語は ECS シングルトン `UserSettings.Language` が持ち、`query.T` が訳を引く。本 doc が足すのは、その初期値をどう決めるかの1点だけ。
 
@@ -26,7 +26,6 @@ Steam 連携も既にある。`internal/steam` が `github.com/hajimehoshi/go-st
 
 - 初期言語を Steam の game-language から決める。既存の `internal/steam` から取る。
 - 明示設定 `RUINS_LANGUAGE` env / toml と、プレイヤーが設定画面で選んだ言語は最優先で尊重する。
-- ビルドごとに初期言語を固定できる。`AppVersion` と同じ ldflags 注入に乗せる。
 - Steam の言語は対応言語 `i18n.SupportedLangs` へ寄せ、未対応や取得不能は最終的に `en` へフォールバックする。
 - 判定はアプリ起動の入口だけで行う。テストと VRT は config に言語を直接注入して判定を通さず、golden を不変に保つ。
 - 単一ビルドを配布する。言語別ビルドはしない。
@@ -46,10 +45,9 @@ Steam 連携も既にある。`internal/steam` が `github.com/hajimehoshi/go-st
 
 1. **明示設定** `RUINS_LANGUAGE` env / toml `language`。運用とテストの固定。
 2. **Steam の game-language**。`internal/steam` の `GameLanguage()`。`-tags steam` のみ非空。
-3. **ビルド時固定** `consts.DefaultLang`。ldflags で空でなければこれ。
-4. **フォールバック** `en`。
+3. **フォールバック** `en`。
 
-Steam を主軸にするので 2 を 3 より上に置く。Steam でユーザが選んだ言語は、ビルド固定より優先されるべき。ビルド固定 3 は非 Steam の市場別配布や検証用の保険。ホストロケール判定は段に持たない。
+自動判定は Steam の game-language だけ。ホストロケールもビルド固定も段に持たない。非 Steam で明示設定が無ければ `en` になる。
 
 ### Steam の言語受け取り
 
@@ -78,18 +76,6 @@ var steamLangToCode = map[string]string{
 }
 ```
 
-### ビルド時固定
-
-`AppVersion` と同じ ldflags 注入に乗せる。
-
-```go
-// internal/consts
-// DefaultLang はビルド時に固定する初期言語。空なら Steam の game-language に委ね、それも無ければ en。
-var DefaultLang = ""
-```
-
-Makefile の各ターゲットが `-X github.com/kijimaD/ruins/internal/consts.DefaultLang=ja` のように設定できる。Steam ビルドは空にして Steam の game-language を活かす。非 Steam の市場別配布で言語を固定したいときだけ値を入れる。
-
 ### 解決の実行位置と明示設定の判定
 
 判定は `config.Load()` の中だけで行う。`Load` は toml と env を読んだあと、言語が**明示されていなければ**優先順位で確定し、`config.User.Language` へ入れてから検証へ渡す。
@@ -108,30 +94,26 @@ func resolveInitialLang(explicit string, hasExplicit bool) string {
 	if lang := steam.GameLanguage(); lang != "" {
 		return lang // Steam の game-language。非 Steam ビルドは空
 	}
-	if consts.DefaultLang != "" {
-		return consts.DefaultLang // 各ビルドの固定
-	}
 	return "en" // 源泉言語へフォールバック
 }
 ```
 
 - `hasExplicit` は `os.LookupEnv("RUINS_LANGUAGE")` の存在と toml の `IsDefined("language")` の論理和。`explicit` はそのとき読めた値。
-- `config.DefaultUserConfig()` の既定は `en` のまま。テストと VRT は config を直接構築して `en` を注入し、`Load` を通らないので Steam 判定も走らず、**golden は不変**。判定が走るのは実アプリの `Load` 経路だけ。`consts.DefaultLang` のゼロ値 `""` と `DefaultUserConfig` の `en` の役割は別で、前者は「ビルド固定が無い」印、後者は直接構築時の終端フォールバック。
+- `config.DefaultUserConfig()` の既定は `en` のまま。テストと VRT は config を直接構築して `en` を注入し、`Load` を通らないので Steam 判定も走らず、**golden は不変**。判定が走るのは実アプリの `Load` 経路だけ。
 - 判定結果は toml へ書き戻さない。プレイヤーが設定画面で明示選択したときだけ、既存の設定永続経路に乗せて `settings.toml` へ保存する。`settings.toml` はマシンごとで Steam Cloud に載せない。よって言語の明示選択もマシンごとに閉じ、別マシンでは再判定される。
-- WASM は体験版でセーブ無効かつ非 Steam なので、常に `consts.DefaultLang` か `en` で起動する。
+- WASM は体験版でセーブ無効かつ非 Steam なので、明示設定が無ければ常に `en` で起動する。
 
 ## 変更箇所
 
 | ファイル | 変更内容 |
 |---|---|
-| `internal/consts` | `DefaultLang` の ldflags 変数を追加する |
 | `internal/steam` | `GameLanguage()` を追加する。`steam` タグ版は `GetCurrentGameLanguage()` を対応コードへ正規化し、タグ無し版は空を返す |
 | `internal/cmd` または `internal/config` | 起動時に `resolveInitialLang` で `config.User.Language` を確定する |
 | `internal/config/config.go` | 既定 `en` は維持する。空を受けて解決結果を入れる受け口だけ調整する |
-| `Makefile` | 各ビルドで `-X consts.DefaultLang=`（既定は空）を通す口を足す |
 
 ## 採用しなかった方法
 
+- **ビルド時に言語を固定する口を持つ**。`AppVersion` と同じ ldflags で `consts.DefaultLang` を注入する案だったが却下。Steam が game-language でユーザの言語を運び、非 Steam は開発と体験版に限られ `en` で足りる。市場別の固定ビルドの必要が無いので、固定の口を持たない。
 - **Steam 以外でホストロケールを判定する**。却下。OS の `LANG`/`LC_*` や ブラウザの `navigator.languages` を読む `internal/locale` を build tag で分ける案だったが、判定源とパッケージが増え、`x/text` のマッチも要る。配布の主軸は Steam で、Steam の game-language がユーザの言語選好を運ぶ。非 Steam は開発と体験版に限られ、固定値か `en` で足りる。自動判定を Steam に一本化して設計を減らす。
 - **言語別ビルド**。Steam の言語ドロップダウンと噛み合わず、切り替えに再インストールが要り、保守と配信が言語ぶん倍になる。単一ビルドに実行時選択を載せる。
 - **言語別 depot でビルドを分ける**。depot 分割は重い言語資産のための仕組みで、ruins はテキスト中心なので不要。単一 depot にする。
@@ -141,15 +123,13 @@ func resolveInitialLang(explicit string, hasExplicit bool) string {
 
 ## コメント
 
-- Steam の言語は `-tags steam` の製品ビルドでのみ効く。開発と WASM は `GameLanguage()` が空を返し、`consts.DefaultLang` か `en` へ落ちる。Steam 配布の段取り自体は steam タグの doc に委ね、本 doc は言語解決に閉じる。
+- Steam の言語は `-tags steam` の製品ビルドでのみ効く。開発と WASM は `GameLanguage()` が空を返し、明示設定が無ければ `en` へ落ちる。Steam 配布の段取り自体は steam タグの doc に委ね、本 doc は言語解決に閉じる。
 - プレイヤーの明示選択は既存の `SaveUserConfig` で `settings.toml` へ永続する。`settings.toml` はマシンごととし、Steam Cloud には載せない。セーブデータは Cloud に載せる。言語は `settings.toml` にあるのでマシンごとに閉じ、Steam の機器ごとの game-language と衝突しない。Steam Cloud の Auto-Cloud はセーブファイルだけを対象にし、`settings.toml` は含めない。セーブの Cloud 設定自体は save の設計に属し、本 doc では方針だけを記す。
 - Steam 語の対応表 `steamLangToCode` と `SupportedLangs` の二重管理を、手順でなくテストで固定する。`SupportedLangs` の各コードが `steamLangToCode` の値に現れることを検査するテストを置き、増設時のドリフトを機械的に弾く。
 
 ## 進捗
 
 - [ ] `internal/steam` に `GameLanguage()` を追加する。`steam` タグ版は `GetCurrentGameLanguage()` を対応コードへ正規化、タグ無しは空
-- [ ] `internal/consts` に ldflags の `DefaultLang` を追加する
 - [ ] 起動時に `resolveInitialLang` で初期言語を確定し、config へ入れる
 - [ ] テストと VRT が `en` 注入で判定を通らないことを確認し、golden 不変を担保する
 - [ ] `steamLangToCode` と `SupportedLangs` の整合をテストで固定し、対応言語増設時のドリフトを弾く
-- [ ] Makefile に `-X consts.DefaultLang=` の口を足す。Steam ビルドは空にする

--- a/docs/design/260823004406.md
+++ b/docs/design/260823004406.md
@@ -148,7 +148,7 @@ func resolveInitialLang(explicit string, hasExplicit bool) string {
 
 - `hasExplicit` は `os.LookupEnv("RUINS_LANGUAGE")` の存在と toml の `IsDefined("language")` の論理和。`explicit` はそのとき読めた値。
 - `config.DefaultUserConfig()` の既定は `en` のまま。テストと VRT は config を直接構築して `en` を注入し、`Load` を通らないので自動判定も走らず、**golden は不変**。判定が走るのは実アプリの `Load` 経路だけ。`consts.DefaultLang` のゼロ値 `""` と `DefaultUserConfig` の `en` の役割は別で、前者は「ビルド固定が無い」印、後者は直接構築時の終端フォールバック。
-- 判定結果は toml へ書き戻さない。プレイヤーが設定画面で明示選択したときだけ、既存の設定永続経路に乗せて保存する。
+- 判定結果は toml へ書き戻さない。プレイヤーが設定画面で明示選択したときだけ、既存の設定永続経路に乗せて `settings.toml` へ保存する。`settings.toml` はマシンごとで Steam Cloud に載せない。よって言語の明示選択もマシンごとに閉じ、別マシンでは再判定される。
 - WASM は体験版でセーブ無効の方針なので、明示選択は永続せず毎起動で再判定になる。トライアルでは許容する。
 
 ## 変更箇所
@@ -176,7 +176,7 @@ func resolveInitialLang(explicit string, hasExplicit bool) string {
 ## コメント
 
 - Steam の言語は `-tags steam` の製品ビルドでのみ効く。開発と WASM は `GameLanguage()` が空を返し、ホストロケール判定へ落ちる。Steam 配布の段取り自体は steam タグの doc に委ね、本 doc は言語解決に閉じる。
-- プレイヤーの明示選択の永続経路。native は toml へ書き戻すか、既存の save に持たせるか。判定の初期値決定とは別の永続の設計で、ここは開いておく。
+- プレイヤーの明示選択は既存の `SaveUserConfig` で `settings.toml` へ永続する。`settings.toml` はマシンごととし、Steam Cloud には載せない。セーブデータは Cloud に載せる。言語は `settings.toml` にあるのでマシンごとに閉じ、Steam の機器ごとの game-language と衝突しない。Steam Cloud の Auto-Cloud はセーブファイルだけを対象にし、`settings.toml` は含めない。セーブの Cloud 設定自体は save の設計に属し、本 doc では方針だけを記す。
 - Steam 語の対応表 `steamLangToCode` と `SupportedLangs` の二重管理を、手順でなくテストで固定する。`SupportedLangs` の各コードが `steamLangToCode` の値に現れることを検査するテストを置き、増設時のドリフトを機械的に弾く。
 
 ## 進捗

--- a/docs/design/260823004406.md
+++ b/docs/design/260823004406.md
@@ -121,15 +121,20 @@ var DefaultLang = ""
 
 Makefile の各ターゲットが `-X github.com/kijimaD/ruins/internal/consts.DefaultLang=ja` のように設定でき、空なら自動判定。Steam ビルドは空にして Steam の game-language を活かす。
 
-### 解決の実行位置
+### 解決の実行位置と明示設定の判定
 
-判定は `internal/cmd` のアプリ起動時だけで行う。config を組み立てる前に初期言語を確定し、`config.User.Language` へ入れてから検証へ渡す。
+判定は `config.Load()` の中だけで行う。`Load` は toml と env を読んだあと、言語が**明示されていなければ**自動判定へ進み、確定値を `config.User.Language` へ入れてから検証へ渡す。
+
+「明示された」の判定は源泉の有無で見る。既定値 `en` と明示された `en` を区別する必要があるため、値の中身でなく設定の有無で判定する。
+
+- env は `os.LookupEnv("RUINS_LANGUAGE")` の第2戻り値で存在を見る。空文字の明示と未設定を区別する。
+- toml は `BurntSushi/toml` の `MetaData.IsDefined("language")` で、ファイルにフィールドがあるかを見る。
 
 ```go
-// cmd のブートストラップ内
-func resolveInitialLang(explicit string) string {
-	if explicit != "" {
-		return explicit // RUINS_LANGUAGE / toml
+// config.Load 内
+func resolveInitialLang(explicit string, hasExplicit bool) string {
+	if hasExplicit {
+		return explicit // env RUINS_LANGUAGE か toml language が明示された
 	}
 	if lang := steam.GameLanguage(); lang != "" {
 		return lang // Steam の game-language。非 Steam ビルドは空
@@ -141,7 +146,8 @@ func resolveInitialLang(explicit string) string {
 }
 ```
 
-- `config.DefaultUserConfig()` の既定は `en` のまま。テストと VRT は config を直接構築して `en` を注入するので判定を通らず、**golden は不変**。判定が走るのは実アプリの起動経路だけ。
+- `hasExplicit` は `os.LookupEnv("RUINS_LANGUAGE")` の存在と toml の `IsDefined("language")` の論理和。`explicit` はそのとき読めた値。
+- `config.DefaultUserConfig()` の既定は `en` のまま。テストと VRT は config を直接構築して `en` を注入し、`Load` を通らないので自動判定も走らず、**golden は不変**。判定が走るのは実アプリの `Load` 経路だけ。`consts.DefaultLang` のゼロ値 `""` と `DefaultUserConfig` の `en` の役割は別で、前者は「ビルド固定が無い」印、後者は直接構築時の終端フォールバック。
 - 判定結果は toml へ書き戻さない。プレイヤーが設定画面で明示選択したときだけ、既存の設定永続経路に乗せて保存する。
 - WASM は体験版でセーブ無効の方針なので、明示選択は永続せず毎起動で再判定になる。トライアルでは許容する。
 
@@ -171,7 +177,7 @@ func resolveInitialLang(explicit string) string {
 
 - Steam の言語は `-tags steam` の製品ビルドでのみ効く。開発と WASM は `GameLanguage()` が空を返し、ホストロケール判定へ落ちる。Steam 配布の段取り自体は steam タグの doc に委ね、本 doc は言語解決に閉じる。
 - プレイヤーの明示選択の永続経路。native は toml へ書き戻すか、既存の save に持たせるか。判定の初期値決定とは別の永続の設計で、ここは開いておく。
-- Steam 語の対応表は対応言語を増やすたびに更新が要る。`SupportedLangs` と二重管理になりうるので、増設時に両方を触る手順を残す。
+- Steam 語の対応表 `steamLangToCode` と `SupportedLangs` の二重管理を、手順でなくテストで固定する。`SupportedLangs` の各コードが `steamLangToCode` の値に現れることを検査するテストを置き、増設時のドリフトを機械的に弾く。
 
 ## 進捗
 
@@ -181,4 +187,5 @@ func resolveInitialLang(explicit string) string {
 - [ ] `internal/consts` に ldflags の `DefaultLang` を追加する
 - [ ] `cmd` の起動時に `resolveInitialLang` で初期言語を確定し、config へ入れる
 - [ ] テストと VRT が `en` 注入で判定を通らないことを確認し、golden 不変を担保する
+- [ ] `steamLangToCode` と `SupportedLangs` の整合をテストで固定し、対応言語増設時のドリフトを弾く
 - [ ] Makefile に `-X consts.DefaultLang=` の口を足す。Steam ビルドは空にする

--- a/docs/design/260823004406.md
+++ b/docs/design/260823004406.md
@@ -16,6 +16,8 @@ auto: needs-decision # mechanical=無人着手可 / needs-decision=人の判断�
 
 言語のマスタ機構は既にある。対応言語は `i18n.SupportedLangs`(`ja`/`en`)、現在言語は ECS シングルトン `UserSettings.Language` が持ち、`query.T` が訳を引く。本 doc が足すのは、その初期値をどう決めるかの1点だけ。
 
+Steam 連携も既にある。`internal/steam` が `github.com/hajimehoshi/go-steamworks` を build tag `steam` で統合し、`RestartAppIfNecessary` と `Init` を実装済み。go-steamworks は `ebitengine/purego` 経由で cgo を要さない。同 SDK は `SteamApps().GetCurrentGameLanguage()` を公開しており、Steam でユーザが選んだ言語を正規の API で取れる。よって Steam の言語は起動引数のパースでなく、この既存パッケージから取る。
+
 ## 要件
 
 **Hard**
@@ -29,7 +31,7 @@ auto: needs-decision # mechanical=無人着手可 / needs-decision=人の判断�
 
 **Soft**
 
-- Steamworks SDK を組まなくても Steam の `-language` 引数で機能する。将来 `GetCurrentGameLanguage()` へ差し替えられる形にする。
+- Steam の言語は既存の `internal/steam` の `GetCurrentGameLanguage()` から取る。`-tags steam` のビルドでのみ効き、非 Steam ビルドでは no-op になる。
 
 **Anti**
 
@@ -44,7 +46,7 @@ auto: needs-decision # mechanical=無人着手可 / needs-decision=人の判断�
 プレイヤーがまだ明示選択していないときの初期言語を、次の順で決める。上ほど優先。
 
 1. **明示設定** `RUINS_LANGUAGE` env / toml `language`。運用とテストの固定。
-2. **Steam の game-language**。Steam 起動時に渡る `-language` 引数。
+2. **Steam の game-language**。`internal/steam` の `GetCurrentGameLanguage()`。`-tags steam` のみ非空。
 3. **ビルド時固定** `consts.DefaultLang`。ldflags で空でなければこれ。
 4. **ホストロケール**。native は OS の `LANG`/`LC_*`、WASM はブラウザの `navigator.languages`。
 5. **フォールバック** `en`。
@@ -70,18 +72,25 @@ func Detect() []string
 
 ### Steam の言語受け取り
 
-Steam は起動時に選択言語を渡す。当面は Steamworks SDK を組まず、`-language` 引数を読む軽量経路にする。
+既存の `internal/steam` に言語取得を足す。build tag `steam` の実装が `go-steamworks` の `GetCurrentGameLanguage()` を呼び、タグ無しの実装は空を返す。`Init` と同じ分離に乗るので、Steam ビルドだけが SDK を含み、開発と WASM は Steam 非依存のまま。go-steamworks は purego 経由で cgo を要さない。
 
 ```go
-// internal/steamlang（新規、または cmd 内の小関数）
-// FromArgs は Steam が付与する -language の値を対応言語コードへ正規化して返す。無ければ空。
-func FromArgs(args []string) string
+// internal/steam
+// GameLanguage は Steam でユーザが選んだ言語を対応言語コードで返す。取れなければ空。
+
+// steam_enabled.go   //go:build steam
+func GameLanguage() string {
+	return steamLangToCode[steamworks.SteamApps().GetCurrentGameLanguage()]
+}
+
+// steam_disabled.go  //go:build !steam
+func GameLanguage() string { return "" }
 ```
 
-Steam は言語を `"english"`/`"japanese"` という独自の言語名で渡す。BCP-47 でも `ja`/`en` でもない。Steam 語から内部コードへの対応表を1枚挟む。将来 `GetCurrentGameLanguage()` を使うときも同じ Steam 語なので、この対応表を共有できる。
+`GetCurrentGameLanguage()` は `"english"`/`"japanese"` という Steam 独自の言語名を返す。BCP-47 でも `ja`/`en` でもないので、Steam 語から内部コードへの対応表を1枚挟む。
 
 ```go
-// steamLangToCode は Steam の言語名を内部の言語コードへ写す。
+// steamLangToCode は Steam の言語名を内部の言語コードへ写す。対応言語を増やすたびに更新する。
 var steamLangToCode = map[string]string{
 	"english":  "en",
 	"japanese": "ja",
@@ -118,12 +127,12 @@ Makefile の各ターゲットが `-X github.com/kijimaD/ruins/internal/consts.D
 
 ```go
 // cmd のブートストラップ内
-func resolveInitialLang(explicit string, args []string) string {
+func resolveInitialLang(explicit string) string {
 	if explicit != "" {
 		return explicit // RUINS_LANGUAGE / toml
 	}
-	if lang := steamlang.FromArgs(args); lang != "" {
-		return lang // Steam の -language
+	if lang := steam.GameLanguage(); lang != "" {
+		return lang // Steam の game-language。非 Steam ビルドは空
 	}
 	if consts.DefaultLang != "" {
 		return consts.DefaultLang // 各ビルドの固定
@@ -142,7 +151,7 @@ func resolveInitialLang(explicit string, args []string) string {
 |---|---|
 | `internal/consts` | `DefaultLang` の ldflags 変数を追加する |
 | `internal/locale`（新規） | `Detect()` を native と wasm の build tag で実装する |
-| `internal/steamlang`（新規、または cmd 内） | Steam の `-language` を対応言語コードへ正規化する `FromArgs` を追加する |
+| `internal/steam` | `GameLanguage()` を追加する。`steam` タグ版は `GetCurrentGameLanguage()` を対応コードへ正規化し、タグ無し版は空を返す |
 | `internal/i18n` | `Match(preferred)` を `x/text/language` で追加する |
 | `internal/cmd` | 起動時に `resolveInitialLang` で `config.User.Language` を確定する |
 | `internal/config/config.go` | 既定 `en` は維持する。空を受けて解決結果を入れる受け口だけ調整する |
@@ -155,12 +164,12 @@ func resolveInitialLang(explicit string, args []string) string {
 - **既定を `"auto"` や空にする**。`DefaultUserConfig()` を使うテストが自動判定を踏み、golden が CI のロケール依存になる。既定 `en` を維持し、判定は `cmd` に限定する。
 - **world 初期化や `UserSettings` 生成で判定する**。テスト全体が判定を通り非決定的になる。入口に限定する。
 - **判定源をアプリ内の実行時分岐で選ぶ**。`if wasm` の分岐は syscall/js を全ビルドへ引き込む。build tag で分けるほうが依存が clean。
-- **今すぐ Steamworks SDK を組む**。cgo 依存が要る。実績やオーバーレイを入れる段で `GetCurrentGameLanguage()` へ差し替える。当面は `-language` 引数で足りる。
+- **Steam の `-language` 引数をパースする**。却下。`internal/steam` が go-steamworks を purego で既に統合しており、cgo なしで `GetCurrentGameLanguage()` を正規に呼べる。引数パースは launch オプション設定に依存して不確実で、新規パッケージも要る。既存 SDK の API を使うほうが確実で設計も減る。
 - **単純な prefix マッチ**。`ja`/`en` だけなら足りるが、`x/text` が依存済みでフォールバック連鎖に強いので採用する。
 
 ## コメント
 
-- Steamworks SDK 連携をいつ入れるか。`GetCurrentGameLanguage()` は正規の入口だが cgo を伴う。`-language` 引数で先に出し、SDK は実績やオーバーレイと同じ段で差し替える。Steam 配布の段取り自体は steam タグの doc に委ね、本 doc は言語解決に閉じる。
+- Steam の言語は `-tags steam` の製品ビルドでのみ効く。開発と WASM は `GameLanguage()` が空を返し、ホストロケール判定へ落ちる。Steam 配布の段取り自体は steam タグの doc に委ね、本 doc は言語解決に閉じる。
 - プレイヤーの明示選択の永続経路。native は toml へ書き戻すか、既存の save に持たせるか。判定の初期値決定とは別の永続の設計で、ここは開いておく。
 - Steam 語の対応表は対応言語を増やすたびに更新が要る。`SupportedLangs` と二重管理になりうるので、増設時に両方を触る手順を残す。
 
@@ -168,9 +177,8 @@ func resolveInitialLang(explicit string, args []string) string {
 
 - [ ] `internal/locale` に `Detect()` を native と wasm の build tag で追加する
 - [ ] `internal/i18n` に `Match(preferred)` を `x/text/language` で追加する
-- [ ] `internal/steamlang` に Steam の `-language` を正規化する `FromArgs` を追加する
+- [ ] `internal/steam` に `GameLanguage()` を追加する。`steam` タグ版は `GetCurrentGameLanguage()` を正規化、タグ無しは空
 - [ ] `internal/consts` に ldflags の `DefaultLang` を追加する
 - [ ] `cmd` の起動時に `resolveInitialLang` で初期言語を確定し、config へ入れる
 - [ ] テストと VRT が `en` 注入で判定を通らないことを確認し、golden 不変を担保する
 - [ ] Makefile に `-X consts.DefaultLang=` の口を足す。Steam ビルドは空にする
-- [ ] Steamworks SDK 連携で `GetCurrentGameLanguage()` へ差し替える

--- a/docs/design/260823004406.md
+++ b/docs/design/260823004406.md
@@ -1,0 +1,176 @@
+---
+status: draft # draft|accepted|in-progress|done|superseded|dropped
+tags: [ui, steam, save] # 領域ラベル
+auto: needs-decision # mechanical=無人着手可 / needs-decision=人の判断必須
+---
+
+# 初期言語をホストと Steam のロケールから決め、ビルドで固定できるようにする
+
+## 背景
+
+現状の表示言語は `config.User.Language` で、既定は `"en"` の固定値。`DefaultUserConfig()` が常に `en` を返し、`RUINS_LANGUAGE` env か toml で明示しない限り英語で起動する。プレイヤーの PC やブラウザの言語設定を尊重しない。
+
+配布は Steam を主軸に据える。Steam ではユーザがゲームごとに言語を選び、その言語が起動時にゲームへ渡る。ここで**言語別にビルドを分けるのは主流でなく、むしろアンチパターン**になる。言語を切り替えるのに再インストールが要り、Steam の言語ドロップダウンと噛み合わず、保守も配信も言語ぶん倍になる。重い言語資産のためには言語別 depot があるが、これは実行ファイルの分割ではない。ruins はテキスト中心で重い言語資産が無いので、depot 分割すら不要。
+
+そこで**単一ビルドのまま、初期言語を実行時にホスト環境から決める**。Steam なら Steam の game-language、素の native なら OS、WASM ならブラウザのロケール。加えてビルドごとに初期言語を固定できる口も持つ。プレイヤーが設定画面で選んだ言語は従来どおり最優先で残す。
+
+言語のマスタ機構は既にある。対応言語は `i18n.SupportedLangs`(`ja`/`en`)、現在言語は ECS シングルトン `UserSettings.Language` が持ち、`query.T` が訳を引く。本 doc が足すのは、その初期値をどう決めるかの1点だけ。
+
+## 要件
+
+**Hard**
+
+- 初期言語をホスト環境から決める。Steam は game-language、native は OS、WASM はブラウザ。
+- 明示設定 `RUINS_LANGUAGE` env / toml と、プレイヤーが設定画面で選んだ言語は最優先で尊重する。
+- ビルドごとに初期言語を固定できる。`AppVersion` と同じ ldflags 注入に乗せる。
+- 判定結果は対応言語 `i18n.SupportedLangs` へ寄せ、未対応は `en` へフォールバックする。
+- 判定はアプリ起動の入口 `cmd` だけで行う。テストと VRT は config に言語を直接注入して判定を通さず、golden を不変に保つ。
+- 単一ビルドを配布する。言語別ビルドはしない。
+
+**Soft**
+
+- Steamworks SDK を組まなくても Steam の `-language` 引数で機能する。将来 `GetCurrentGameLanguage()` へ差し替えられる形にする。
+
+**Anti**
+
+- world 初期化や `UserSettings` 生成で判定しない。テスト全体が判定を通り golden がロケール依存になる。
+- 言語別ビルド、言語別 depot の分割をしない。単一ビルド単一 depot にする。
+- 判定結果を toml へ書き戻さない。別ロケールのマシンへ移ったら再判定させる。書き戻すのはプレイヤーの明示選択だけ。
+
+## 設計
+
+### 初期言語の優先順位
+
+プレイヤーがまだ明示選択していないときの初期言語を、次の順で決める。上ほど優先。
+
+1. **明示設定** `RUINS_LANGUAGE` env / toml `language`。運用とテストの固定。
+2. **Steam の game-language**。Steam 起動時に渡る `-language` 引数。
+3. **ビルド時固定** `consts.DefaultLang`。ldflags で空でなければこれ。
+4. **ホストロケール**。native は OS の `LANG`/`LC_*`、WASM はブラウザの `navigator.languages`。
+5. **フォールバック** `en`。
+
+Steam を主軸にするので 2 を 3 より上に置く。Steam でユーザが選んだ言語は、ビルド固定より優先されるべき。ビルド固定 3 は非 Steam の市場別配布や検証用の保険。
+
+### 判定源のプラットフォーム分離
+
+判定源は新パッケージ `internal/locale` に build tag で分ける。GOOS=js のビルドだけがブラウザ判定を、それ以外が OS 判定を含む。
+
+```go
+// internal/locale/locale.go
+// Detect はホストの優先言語を BCP-47 の順序付きで返す。判定源はビルドで変わる。
+
+// locale_native.go   //go:build !js
+//   LANG / LC_ALL / LC_MESSAGES を読み "ja_JP.UTF-8" → "ja-JP" へ正規化する
+func Detect() []string
+
+// locale_wasm.go     //go:build js
+//   navigator.languages を順に取り、無ければ navigator.language を使う
+func Detect() []string
+```
+
+### Steam の言語受け取り
+
+Steam は起動時に選択言語を渡す。当面は Steamworks SDK を組まず、`-language` 引数を読む軽量経路にする。
+
+```go
+// internal/steamlang（新規、または cmd 内の小関数）
+// FromArgs は Steam が付与する -language の値を対応言語コードへ正規化して返す。無ければ空。
+func FromArgs(args []string) string
+```
+
+Steam は言語を `"english"`/`"japanese"` という独自の言語名で渡す。BCP-47 でも `ja`/`en` でもない。Steam 語から内部コードへの対応表を1枚挟む。将来 `GetCurrentGameLanguage()` を使うときも同じ Steam 語なので、この対応表を共有できる。
+
+```go
+// steamLangToCode は Steam の言語名を内部の言語コードへ写す。
+var steamLangToCode = map[string]string{
+	"english":  "en",
+	"japanese": "ja",
+}
+```
+
+### 対応言語へのマッチ
+
+判定タグ列を対応言語へ寄せる関数を、`SupportedLangs` を持つ `i18n` に置く。
+
+```go
+// internal/i18n
+// Match は優先タグ列を対応言語へ最良マッチさせる。無ければ源泉言語 en を返す。
+func Match(preferred []string) string
+```
+
+`golang.org/x/text/language`(既に依存にある)の `NewMatcher` で、`ja-JP → ja`、未対応 `fr-FR → en` を頑健に畳む。
+
+### ビルド時固定
+
+`AppVersion` と同じ ldflags 注入に乗せる。
+
+```go
+// internal/consts
+// DefaultLang はビルド時に固定する初期言語。空ならホストと Steam のロケールを自動判定する。
+var DefaultLang = ""
+```
+
+Makefile の各ターゲットが `-X github.com/kijimaD/ruins/internal/consts.DefaultLang=ja` のように設定でき、空なら自動判定。Steam ビルドは空にして Steam の game-language を活かす。
+
+### 解決の実行位置
+
+判定は `internal/cmd` のアプリ起動時だけで行う。config を組み立てる前に初期言語を確定し、`config.User.Language` へ入れてから検証へ渡す。
+
+```go
+// cmd のブートストラップ内
+func resolveInitialLang(explicit string, args []string) string {
+	if explicit != "" {
+		return explicit // RUINS_LANGUAGE / toml
+	}
+	if lang := steamlang.FromArgs(args); lang != "" {
+		return lang // Steam の -language
+	}
+	if consts.DefaultLang != "" {
+		return consts.DefaultLang // 各ビルドの固定
+	}
+	return i18n.Match(locale.Detect()) // OS / ブラウザ
+}
+```
+
+- `config.DefaultUserConfig()` の既定は `en` のまま。テストと VRT は config を直接構築して `en` を注入するので判定を通らず、**golden は不変**。判定が走るのは実アプリの起動経路だけ。
+- 判定結果は toml へ書き戻さない。プレイヤーが設定画面で明示選択したときだけ、既存の設定永続経路に乗せて保存する。
+- WASM は体験版でセーブ無効の方針なので、明示選択は永続せず毎起動で再判定になる。トライアルでは許容する。
+
+## 変更箇所
+
+| ファイル | 変更内容 |
+|---|---|
+| `internal/consts` | `DefaultLang` の ldflags 変数を追加する |
+| `internal/locale`（新規） | `Detect()` を native と wasm の build tag で実装する |
+| `internal/steamlang`（新規、または cmd 内） | Steam の `-language` を対応言語コードへ正規化する `FromArgs` を追加する |
+| `internal/i18n` | `Match(preferred)` を `x/text/language` で追加する |
+| `internal/cmd` | 起動時に `resolveInitialLang` で `config.User.Language` を確定する |
+| `internal/config/config.go` | 既定 `en` は維持する。空を受けて解決結果を入れる受け口だけ調整する |
+| `Makefile` | 各ビルドで `-X consts.DefaultLang=`（既定は空）を通す口を足す |
+
+## 採用しなかった方法
+
+- **言語別ビルド**。Steam の言語ドロップダウンと噛み合わず、切り替えに再インストールが要り、保守と配信が言語ぶん倍になる。単一ビルドに実行時選択を載せる。
+- **言語別 depot でビルドを分ける**。depot 分割は重い言語資産のための仕組みで、ruins はテキスト中心なので不要。単一 depot にする。
+- **既定を `"auto"` や空にする**。`DefaultUserConfig()` を使うテストが自動判定を踏み、golden が CI のロケール依存になる。既定 `en` を維持し、判定は `cmd` に限定する。
+- **world 初期化や `UserSettings` 生成で判定する**。テスト全体が判定を通り非決定的になる。入口に限定する。
+- **判定源をアプリ内の実行時分岐で選ぶ**。`if wasm` の分岐は syscall/js を全ビルドへ引き込む。build tag で分けるほうが依存が clean。
+- **今すぐ Steamworks SDK を組む**。cgo 依存が要る。実績やオーバーレイを入れる段で `GetCurrentGameLanguage()` へ差し替える。当面は `-language` 引数で足りる。
+- **単純な prefix マッチ**。`ja`/`en` だけなら足りるが、`x/text` が依存済みでフォールバック連鎖に強いので採用する。
+
+## コメント
+
+- Steamworks SDK 連携をいつ入れるか。`GetCurrentGameLanguage()` は正規の入口だが cgo を伴う。`-language` 引数で先に出し、SDK は実績やオーバーレイと同じ段で差し替える。Steam 配布の段取り自体は steam タグの doc に委ね、本 doc は言語解決に閉じる。
+- プレイヤーの明示選択の永続経路。native は toml へ書き戻すか、既存の save に持たせるか。判定の初期値決定とは別の永続の設計で、ここは開いておく。
+- Steam 語の対応表は対応言語を増やすたびに更新が要る。`SupportedLangs` と二重管理になりうるので、増設時に両方を触る手順を残す。
+
+## 進捗
+
+- [ ] `internal/locale` に `Detect()` を native と wasm の build tag で追加する
+- [ ] `internal/i18n` に `Match(preferred)` を `x/text/language` で追加する
+- [ ] `internal/steamlang` に Steam の `-language` を正規化する `FromArgs` を追加する
+- [ ] `internal/consts` に ldflags の `DefaultLang` を追加する
+- [ ] `cmd` の起動時に `resolveInitialLang` で初期言語を確定し、config へ入れる
+- [ ] テストと VRT が `en` 注入で判定を通らないことを確認し、golden 不変を担保する
+- [ ] Makefile に `-X consts.DefaultLang=` の口を足す。Steam ビルドは空にする
+- [ ] Steamworks SDK 連携で `GetCurrentGameLanguage()` へ差し替える

--- a/docs/design/260823004406.md
+++ b/docs/design/260823004406.md
@@ -4,15 +4,17 @@ tags: [ui, steam, save] # 領域ラベル
 auto: needs-decision # mechanical=無人着手可 / needs-decision=人の判断必須
 ---
 
-# 初期言語をホストと Steam のロケールから決め、ビルドで固定できるようにする
+# 初期言語を Steam のロケールから決め、ビルドで固定できるようにする
 
 ## 背景
 
-現状の表示言語は `config.User.Language` で、既定は `"en"` の固定値。`DefaultUserConfig()` が常に `en` を返し、`RUINS_LANGUAGE` env か toml で明示しない限り英語で起動する。プレイヤーの PC やブラウザの言語設定を尊重しない。
+現状の表示言語は `config.User.Language` で、既定は `"en"` の固定値。`DefaultUserConfig()` が常に `en` を返し、`RUINS_LANGUAGE` env か toml で明示しない限り英語で起動する。プレイヤーが選んだ言語を初期値に反映しない。
 
 配布は Steam を主軸に据える。Steam ではユーザがゲームごとに言語を選び、その言語が起動時にゲームへ渡る。ここで**言語別にビルドを分けるのは主流でなく、むしろアンチパターン**になる。言語を切り替えるのに再インストールが要り、Steam の言語ドロップダウンと噛み合わず、保守も配信も言語ぶん倍になる。重い言語資産のためには言語別 depot があるが、これは実行ファイルの分割ではない。ruins はテキスト中心で重い言語資産が無いので、depot 分割すら不要。
 
-そこで**単一ビルドのまま、初期言語を実行時にホスト環境から決める**。Steam なら Steam の game-language、素の native なら OS、WASM ならブラウザのロケール。加えてビルドごとに初期言語を固定できる口も持つ。プレイヤーが設定画面で選んだ言語は従来どおり最優先で残す。
+そこで**単一ビルドのまま、Steam でユーザが選んだ言語を初期値に反映する**。プレイヤーの言語選好は Steam クライアントの言語設定に表れ、それが game-language として起動時に渡る。加えてビルドごとに初期言語を固定できる口も持つ。プレイヤーが設定画面で選んだ言語は従来どおり最優先で残す。
+
+**Steam 以外のビルドではホストロケールの判定はしない。** 開発ビルドと WASM 体験版は、ビルド固定 `consts.DefaultLang` があればそれ、無ければ `en` で起動する。OS や ブラウザのロケールを読む仕組みは持たない。自動判定は Steam の game-language に一本化し、非 Steam は固定値で足りるとする。
 
 言語のマスタ機構は既にある。対応言語は `i18n.SupportedLangs`(`ja`/`en`)、現在言語は ECS シングルトン `UserSettings.Language` が持ち、`query.T` が訳を引く。本 doc が足すのは、その初期値をどう決めるかの1点だけ。
 
@@ -22,22 +24,19 @@ Steam 連携も既にある。`internal/steam` が `github.com/hajimehoshi/go-st
 
 **Hard**
 
-- 初期言語をホスト環境から決める。Steam は game-language、native は OS、WASM はブラウザ。
+- 初期言語を Steam の game-language から決める。既存の `internal/steam` から取る。
 - 明示設定 `RUINS_LANGUAGE` env / toml と、プレイヤーが設定画面で選んだ言語は最優先で尊重する。
 - ビルドごとに初期言語を固定できる。`AppVersion` と同じ ldflags 注入に乗せる。
-- 判定結果は対応言語 `i18n.SupportedLangs` へ寄せ、未対応は `en` へフォールバックする。
-- 判定はアプリ起動の入口 `cmd` だけで行う。テストと VRT は config に言語を直接注入して判定を通さず、golden を不変に保つ。
+- Steam の言語は対応言語 `i18n.SupportedLangs` へ寄せ、未対応や取得不能は最終的に `en` へフォールバックする。
+- 判定はアプリ起動の入口だけで行う。テストと VRT は config に言語を直接注入して判定を通さず、golden を不変に保つ。
 - 単一ビルドを配布する。言語別ビルドはしない。
-
-**Soft**
-
-- Steam の言語は既存の `internal/steam` の `GetCurrentGameLanguage()` から取る。`-tags steam` のビルドでのみ効き、非 Steam ビルドでは no-op になる。
 
 **Anti**
 
+- Steam 以外でホストロケール(OS / ブラウザ)を判定しない。非 Steam は固定値か `en` で足りる。判定源を増やして複雑にしない。
 - world 初期化や `UserSettings` 生成で判定しない。テスト全体が判定を通り golden がロケール依存になる。
 - 言語別ビルド、言語別 depot の分割をしない。単一ビルド単一 depot にする。
-- 判定結果を toml へ書き戻さない。別ロケールのマシンへ移ったら再判定させる。書き戻すのはプレイヤーの明示選択だけ。
+- 判定結果を toml へ書き戻さない。書き戻すのはプレイヤーの明示選択だけ。
 
 ## 設計
 
@@ -46,33 +45,15 @@ Steam 連携も既にある。`internal/steam` が `github.com/hajimehoshi/go-st
 プレイヤーがまだ明示選択していないときの初期言語を、次の順で決める。上ほど優先。
 
 1. **明示設定** `RUINS_LANGUAGE` env / toml `language`。運用とテストの固定。
-2. **Steam の game-language**。`internal/steam` の `GetCurrentGameLanguage()`。`-tags steam` のみ非空。
+2. **Steam の game-language**。`internal/steam` の `GameLanguage()`。`-tags steam` のみ非空。
 3. **ビルド時固定** `consts.DefaultLang`。ldflags で空でなければこれ。
-4. **ホストロケール**。native は OS の `LANG`/`LC_*`、WASM はブラウザの `navigator.languages`。
-5. **フォールバック** `en`。
+4. **フォールバック** `en`。
 
-Steam を主軸にするので 2 を 3 より上に置く。Steam でユーザが選んだ言語は、ビルド固定より優先されるべき。ビルド固定 3 は非 Steam の市場別配布や検証用の保険。
-
-### 判定源のプラットフォーム分離
-
-判定源は新パッケージ `internal/locale` に build tag で分ける。GOOS=js のビルドだけがブラウザ判定を、それ以外が OS 判定を含む。
-
-```go
-// internal/locale/locale.go
-// Detect はホストの優先言語を BCP-47 の順序付きで返す。判定源はビルドで変わる。
-
-// locale_native.go   //go:build !js
-//   LANG / LC_ALL / LC_MESSAGES を読み "ja_JP.UTF-8" → "ja-JP" へ正規化する
-func Detect() []string
-
-// locale_wasm.go     //go:build js
-//   navigator.languages を順に取り、無ければ navigator.language を使う
-func Detect() []string
-```
+Steam を主軸にするので 2 を 3 より上に置く。Steam でユーザが選んだ言語は、ビルド固定より優先されるべき。ビルド固定 3 は非 Steam の市場別配布や検証用の保険。ホストロケール判定は段に持たない。
 
 ### Steam の言語受け取り
 
-既存の `internal/steam` に言語取得を足す。build tag `steam` の実装が `go-steamworks` の `GetCurrentGameLanguage()` を呼び、タグ無しの実装は空を返す。`Init` と同じ分離に乗るので、Steam ビルドだけが SDK を含み、開発と WASM は Steam 非依存のまま。go-steamworks は purego 経由で cgo を要さない。
+既存の `internal/steam` に言語取得を足す。build tag `steam` の実装が `go-steamworks` の `GetCurrentGameLanguage()` を呼び対応コードへ寄せ、タグ無しの実装は空を返す。`Init` と同じ分離に乗るので、Steam ビルドだけが SDK を含み、開発と WASM は Steam 非依存のまま。go-steamworks は purego 経由で cgo を要さない。
 
 ```go
 // internal/steam
@@ -87,7 +68,7 @@ func GameLanguage() string {
 func GameLanguage() string { return "" }
 ```
 
-`GetCurrentGameLanguage()` は `"english"`/`"japanese"` という Steam 独自の言語名を返す。BCP-47 でも `ja`/`en` でもないので、Steam 語から内部コードへの対応表を1枚挟む。
+`GetCurrentGameLanguage()` は `"english"`/`"japanese"` という Steam 独自の言語名を返す。BCP-47 でも `ja`/`en` でもないので、Steam 語から内部コードへの対応表を1枚挟む。対応表に無い Steam 語は空を返し、優先順位の下段へ落とす。
 
 ```go
 // steamLangToCode は Steam の言語名を内部の言語コードへ写す。対応言語を増やすたびに更新する。
@@ -97,33 +78,21 @@ var steamLangToCode = map[string]string{
 }
 ```
 
-### 対応言語へのマッチ
-
-判定タグ列を対応言語へ寄せる関数を、`SupportedLangs` を持つ `i18n` に置く。
-
-```go
-// internal/i18n
-// Match は優先タグ列を対応言語へ最良マッチさせる。無ければ源泉言語 en を返す。
-func Match(preferred []string) string
-```
-
-`golang.org/x/text/language`(既に依存にある)の `NewMatcher` で、`ja-JP → ja`、未対応 `fr-FR → en` を頑健に畳む。
-
 ### ビルド時固定
 
 `AppVersion` と同じ ldflags 注入に乗せる。
 
 ```go
 // internal/consts
-// DefaultLang はビルド時に固定する初期言語。空ならホストと Steam のロケールを自動判定する。
+// DefaultLang はビルド時に固定する初期言語。空なら Steam の game-language に委ね、それも無ければ en。
 var DefaultLang = ""
 ```
 
-Makefile の各ターゲットが `-X github.com/kijimaD/ruins/internal/consts.DefaultLang=ja` のように設定でき、空なら自動判定。Steam ビルドは空にして Steam の game-language を活かす。
+Makefile の各ターゲットが `-X github.com/kijimaD/ruins/internal/consts.DefaultLang=ja` のように設定できる。Steam ビルドは空にして Steam の game-language を活かす。非 Steam の市場別配布で言語を固定したいときだけ値を入れる。
 
 ### 解決の実行位置と明示設定の判定
 
-判定は `config.Load()` の中だけで行う。`Load` は toml と env を読んだあと、言語が**明示されていなければ**自動判定へ進み、確定値を `config.User.Language` へ入れてから検証へ渡す。
+判定は `config.Load()` の中だけで行う。`Load` は toml と env を読んだあと、言語が**明示されていなければ**優先順位で確定し、`config.User.Language` へ入れてから検証へ渡す。
 
 「明示された」の判定は源泉の有無で見る。既定値 `en` と明示された `en` を区別する必要があるため、値の中身でなく設定の有無で判定する。
 
@@ -142,50 +111,45 @@ func resolveInitialLang(explicit string, hasExplicit bool) string {
 	if consts.DefaultLang != "" {
 		return consts.DefaultLang // 各ビルドの固定
 	}
-	return i18n.Match(locale.Detect()) // OS / ブラウザ
+	return "en" // 源泉言語へフォールバック
 }
 ```
 
 - `hasExplicit` は `os.LookupEnv("RUINS_LANGUAGE")` の存在と toml の `IsDefined("language")` の論理和。`explicit` はそのとき読めた値。
-- `config.DefaultUserConfig()` の既定は `en` のまま。テストと VRT は config を直接構築して `en` を注入し、`Load` を通らないので自動判定も走らず、**golden は不変**。判定が走るのは実アプリの `Load` 経路だけ。`consts.DefaultLang` のゼロ値 `""` と `DefaultUserConfig` の `en` の役割は別で、前者は「ビルド固定が無い」印、後者は直接構築時の終端フォールバック。
+- `config.DefaultUserConfig()` の既定は `en` のまま。テストと VRT は config を直接構築して `en` を注入し、`Load` を通らないので Steam 判定も走らず、**golden は不変**。判定が走るのは実アプリの `Load` 経路だけ。`consts.DefaultLang` のゼロ値 `""` と `DefaultUserConfig` の `en` の役割は別で、前者は「ビルド固定が無い」印、後者は直接構築時の終端フォールバック。
 - 判定結果は toml へ書き戻さない。プレイヤーが設定画面で明示選択したときだけ、既存の設定永続経路に乗せて `settings.toml` へ保存する。`settings.toml` はマシンごとで Steam Cloud に載せない。よって言語の明示選択もマシンごとに閉じ、別マシンでは再判定される。
-- WASM は体験版でセーブ無効の方針なので、明示選択は永続せず毎起動で再判定になる。トライアルでは許容する。
+- WASM は体験版でセーブ無効かつ非 Steam なので、常に `consts.DefaultLang` か `en` で起動する。
 
 ## 変更箇所
 
 | ファイル | 変更内容 |
 |---|---|
 | `internal/consts` | `DefaultLang` の ldflags 変数を追加する |
-| `internal/locale`（新規） | `Detect()` を native と wasm の build tag で実装する |
 | `internal/steam` | `GameLanguage()` を追加する。`steam` タグ版は `GetCurrentGameLanguage()` を対応コードへ正規化し、タグ無し版は空を返す |
-| `internal/i18n` | `Match(preferred)` を `x/text/language` で追加する |
-| `internal/cmd` | 起動時に `resolveInitialLang` で `config.User.Language` を確定する |
+| `internal/cmd` または `internal/config` | 起動時に `resolveInitialLang` で `config.User.Language` を確定する |
 | `internal/config/config.go` | 既定 `en` は維持する。空を受けて解決結果を入れる受け口だけ調整する |
 | `Makefile` | 各ビルドで `-X consts.DefaultLang=`（既定は空）を通す口を足す |
 
 ## 採用しなかった方法
 
+- **Steam 以外でホストロケールを判定する**。却下。OS の `LANG`/`LC_*` や ブラウザの `navigator.languages` を読む `internal/locale` を build tag で分ける案だったが、判定源とパッケージが増え、`x/text` のマッチも要る。配布の主軸は Steam で、Steam の game-language がユーザの言語選好を運ぶ。非 Steam は開発と体験版に限られ、固定値か `en` で足りる。自動判定を Steam に一本化して設計を減らす。
 - **言語別ビルド**。Steam の言語ドロップダウンと噛み合わず、切り替えに再インストールが要り、保守と配信が言語ぶん倍になる。単一ビルドに実行時選択を載せる。
 - **言語別 depot でビルドを分ける**。depot 分割は重い言語資産のための仕組みで、ruins はテキスト中心なので不要。単一 depot にする。
-- **既定を `"auto"` や空にする**。`DefaultUserConfig()` を使うテストが自動判定を踏み、golden が CI のロケール依存になる。既定 `en` を維持し、判定は `cmd` に限定する。
+- **既定を `"auto"` や空にする**。`DefaultUserConfig()` を使うテストが判定を踏み、golden が CI 環境依存になる。既定 `en` を維持し、判定は起動の入口に限定する。
 - **world 初期化や `UserSettings` 生成で判定する**。テスト全体が判定を通り非決定的になる。入口に限定する。
-- **判定源をアプリ内の実行時分岐で選ぶ**。`if wasm` の分岐は syscall/js を全ビルドへ引き込む。build tag で分けるほうが依存が clean。
 - **Steam の `-language` 引数をパースする**。却下。`internal/steam` が go-steamworks を purego で既に統合しており、cgo なしで `GetCurrentGameLanguage()` を正規に呼べる。引数パースは launch オプション設定に依存して不確実で、新規パッケージも要る。既存 SDK の API を使うほうが確実で設計も減る。
-- **単純な prefix マッチ**。`ja`/`en` だけなら足りるが、`x/text` が依存済みでフォールバック連鎖に強いので採用する。
 
 ## コメント
 
-- Steam の言語は `-tags steam` の製品ビルドでのみ効く。開発と WASM は `GameLanguage()` が空を返し、ホストロケール判定へ落ちる。Steam 配布の段取り自体は steam タグの doc に委ね、本 doc は言語解決に閉じる。
+- Steam の言語は `-tags steam` の製品ビルドでのみ効く。開発と WASM は `GameLanguage()` が空を返し、`consts.DefaultLang` か `en` へ落ちる。Steam 配布の段取り自体は steam タグの doc に委ね、本 doc は言語解決に閉じる。
 - プレイヤーの明示選択は既存の `SaveUserConfig` で `settings.toml` へ永続する。`settings.toml` はマシンごととし、Steam Cloud には載せない。セーブデータは Cloud に載せる。言語は `settings.toml` にあるのでマシンごとに閉じ、Steam の機器ごとの game-language と衝突しない。Steam Cloud の Auto-Cloud はセーブファイルだけを対象にし、`settings.toml` は含めない。セーブの Cloud 設定自体は save の設計に属し、本 doc では方針だけを記す。
 - Steam 語の対応表 `steamLangToCode` と `SupportedLangs` の二重管理を、手順でなくテストで固定する。`SupportedLangs` の各コードが `steamLangToCode` の値に現れることを検査するテストを置き、増設時のドリフトを機械的に弾く。
 
 ## 進捗
 
-- [ ] `internal/locale` に `Detect()` を native と wasm の build tag で追加する
-- [ ] `internal/i18n` に `Match(preferred)` を `x/text/language` で追加する
-- [ ] `internal/steam` に `GameLanguage()` を追加する。`steam` タグ版は `GetCurrentGameLanguage()` を正規化、タグ無しは空
+- [ ] `internal/steam` に `GameLanguage()` を追加する。`steam` タグ版は `GetCurrentGameLanguage()` を対応コードへ正規化、タグ無しは空
 - [ ] `internal/consts` に ldflags の `DefaultLang` を追加する
-- [ ] `cmd` の起動時に `resolveInitialLang` で初期言語を確定し、config へ入れる
+- [ ] 起動時に `resolveInitialLang` で初期言語を確定し、config へ入れる
 - [ ] テストと VRT が `en` 注入で判定を通らないことを確認し、golden 不変を担保する
 - [ ] `steamLangToCode` と `SupportedLangs` の整合をテストで固定し、対応言語増設時のドリフトを弾く
 - [ ] Makefile に `-X consts.DefaultLang=` の口を足す。Steam ビルドは空にする


### PR DESCRIPTION
設計ドキュメント `docs/design/260823004406.md` を追加する。実装は含まない設計提案。

## 提案の骨子

現状 `config.User.Language` は既定 `"en"` 固定。配布は Steam を主軸に据えるので、**単一ビルドのまま Steam でユーザが選んだ言語を初期値に反映する**。言語別ビルドはしない。

### 初期言語の優先順位

1. 明示設定 `RUINS_LANGUAGE` env / toml、プレイヤーの設定画面での選択
2. Steam の game-language（`internal/steam` の `GameLanguage()`、`-tags steam` のみ非空）
3. ビルド時固定 `consts.DefaultLang`（ldflags）
4. フォールバック `en`

### Steam 以外はロケール判定不要

自動判定は Steam の game-language に一本化する。開発ビルドと WASM 体験版は非 Steam で、ビルド固定 `consts.DefaultLang` か `en` で起動する。OS や ブラウザのロケールを読む仕組みは持たない。当初案の `internal/locale`（build tag での OS/browser 判定）と `i18n.Match`(x/text) は廃し、設計を減らした。

### Steam 連携は既存資産を使う

`internal/steam` が `hajimehoshi/go-steamworks` を build tag `steam` で統合済み。purego 経由で cgo を要さない。`GetCurrentGameLanguage()` を `internal/steam.GameLanguage()` として公開し、`steam` タグ版は Steam 語を対応コードへ正規化、タグ無し版は空を返す。

### 主な設計判断

- 判定はアプリ起動の入口だけで行う。テストと VRT は config に `en` を注入して判定を通さず、**golden を不変**に保つ。
- 明示設定の有無は値でなく `os.LookupEnv` と toml `MetaData.IsDefined` で見る。既定 `en` と明示 `en` を区別する。
- 永続は `settings.toml`(マシンごと、Steam Cloud 非対象)。セーブは Cloud。言語は機器ごとの Steam 言語と衝突しない。

## ステータス

`draft / needs-decision`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)