### PR TITLE
設計: すべての地物・施設を役割テンプレ骨格と content スロットで生成する

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ $ make help
 | draft | [身体の不調: 少数部位の負傷と、まとめて配る手当て](docs/design/260821232324.md) | 0/11 | gamedesign, combat, item, ecs |
 | draft | [温度モデル: 前線を廃し、屋外の底冷えと屋内退避を持つ](docs/design/260822220253.md) | 0/12 | gamedesign, worldgen, ecs |
 | draft | [初期言語を Steam のロケールから決める](docs/design/260823004406.md) | 5/5 | ui, steam, save |
-| draft | [すべての地物・施設の生成を content システムに一本化する](docs/design/260823165936.md) | 0/6 | worldgen, refactor, gamedesign |
+| draft | [すべての地物・施設を役割テンプレ骨格と content スロットで生成する](docs/design/260823165936.md) | 0/9 | worldgen, refactor, gamedesign |
 
 
 ## Reference

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ $ make help
 | draft | [身体の不調: 少数部位の負傷と、まとめて配る手当て](docs/design/260821232324.md) | 0/11 | gamedesign, combat, item, ecs |
 | draft | [温度モデル: 前線を廃し、屋外の底冷えと屋内退避を持つ](docs/design/260822220253.md) | 0/12 | gamedesign, worldgen, ecs |
 | draft | [初期言語を Steam のロケールから決める](docs/design/260823004406.md) | 5/5 | ui, steam, save |
-| draft | [すべての地物・施設を役割テンプレ骨格と content スロットで生成する](docs/design/260823165936.md) | 0/9 | worldgen, refactor, gamedesign |
+| draft | [すべての地物・施設を役割テンプレ骨格と content スロットで生成する](docs/design/260823165936.md) | 0/8 | worldgen, refactor, gamedesign |
 
 
 ## Reference

--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ $ make help
 | draft | [身体の不調: 少数部位の負傷と、まとめて配る手当て](docs/design/260821232324.md) | 0/11 | gamedesign, combat, item, ecs |
 | draft | [温度モデル: 前線を廃し、屋外の底冷えと屋内退避を持つ](docs/design/260822220253.md) | 0/12 | gamedesign, worldgen, ecs |
 | draft | [初期言語を Steam のロケールから決める](docs/design/260823004406.md) | 5/5 | ui, steam, save |
+| draft | [点在ランドマークと集落をテーマ駆動の content システムへ寄せる](docs/design/260823165936.md) | 0/5（見送り1） | worldgen, refactor, gamedesign |
 
 
 ## Reference

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ $ make help
 | draft | [身体の不調: 少数部位の負傷と、まとめて配る手当て](docs/design/260821232324.md) | 0/11 | gamedesign, combat, item, ecs |
 | draft | [温度モデル: 前線を廃し、屋外の底冷えと屋内退避を持つ](docs/design/260822220253.md) | 0/12 | gamedesign, worldgen, ecs |
 | draft | [初期言語を Steam のロケールから決める](docs/design/260823004406.md) | 5/5 | ui, steam, save |
-| draft | [点在ランドマークと集落をテーマ駆動の content システムへ寄せる](docs/design/260823165936.md) | 0/5（見送り1） | worldgen, refactor, gamedesign |
+| draft | [すべての地物・施設の生成を content システムに一本化する](docs/design/260823165936.md) | 0/6 | worldgen, refactor, gamedesign |
 
 
 ## Reference

--- a/docs/design/260823165936.md
+++ b/docs/design/260823165936.md
@@ -23,7 +23,7 @@ auto: needs-decision # mechanical=無人着手可 / needs-decision=人の判断�
 
 ### 固定レイアウトとも純 content とも違う、二層が要る
 
-生成の失敗は両極にある。**固定レイアウトはワンパターン**、同じ種別がどれも同じに見える。逆に**純粋な content 抽選は意味が破綻する**、部屋の役割を知らないまま密度場で置くので「タルだらけの家」が出る。後者は今のコードにも実在し、`content_catalog.go` の `genericContent`(未分類施設)は「空き箱にならないよう樽と観葉だけ置く」とし樽を積み、奥室も「全部同じ樽の物置になる単調さ」を抱えている。`interior` は配置から役割を逆推定する `classifyRoom` を持つが、役割から content を割り当てる RoomReq 照合は `doc.go` のとおり未実装で、意味づけを保証できない。
+生成の失敗は両極にある。**固定レイアウトはワンパターン**、同じ種別がどれも同じに見える。逆に**純粋な content 抽選は意味が破綻する**、部屋の役割を知らないまま密度場で置くので「タルだらけの家」が出る。後者は今のコードにも実在し、`content_catalog.go` の `genericContent`(未分類施設)は「空き箱にならないよう樽と観葉だけ置く」とし樽を積み、奥室も「全部同じ樽の物置になる単調さ」を抱えている。役割から content を引く `roleContent`(main→roomCatalog→houseRoomContents→backRoomContent の4段)は既にあるが、未対応の役割や施設種は `backRoomContent`/`genericContent` の樽へ落ち、意味づけを取りこぼす。`interior` は配置から役割を逆推定する `classifyRoom` の検証も持つ。骨格は既にあり、足りないのは樽フォールバックを塞ぐ役割別 content の充実である。
 
 CDDA が 24×24 を人手で描く(prefab)うえに palette/group で風味を載せているのは、この二層が要るからである。**prefab または役割テンプレが空間的・意味的な整合を保証し、content がその上で多様性を与える。** 本 doc はこの二層を全施設へ広げる。content は prefab を置き換えるのでなく、prefab 骨格のスロットを埋める。
 
@@ -32,7 +32,7 @@ CDDA が 24×24 を人手で描く(prefab)うえに palette/group で風味を�
 **Hard**
 
 - **すべての地物・施設を「役割テンプレ骨格＋content スロット」で生成する。** 街の建物・ランドマーク・集落を含め、固定レイアウトや固定リストをやめる。意味の強い施設は役割を持つテンプレ骨格を持ち、content はそのスロットを埋める。ad-hoc な直書き生成も、純 content だけで意味を出す試みも残さない。
-- **意味の強い施設は役割テンプレを持ち、content を役割でスロットへ割り当てる。** 寝室には寝具の content、台所には食料の content、と役割マッチで流す。RoomReq 照合を実装し、樽フォールバックのような意味の破綻を防ぐ。
+- **意味の強い施設は役割テンプレを持ち、content を役割でスロットへ割り当てる。** 寝室には寝具の content、台所には食料の content、と役割マッチで流す。既存の `roleContent` を拡張し、未対応役割が樽の `backRoomContent`/`genericContent` へ落ちる経路を役割別 content で塞ぐ。
 - ランドマークの各種別を固定レイアウトでなく、テーマ = content 仕様から生成する。同じ種別でも訪れるたびに中身が変わりつつ、廃屋らしさ・農家跡らしさは保証枠で担保する。
 - 集落の村・一軒家も固定 NPC/prop リストをやめ、テーマ = content 仕様から生成する。content は家具・戦利品・敵・装飾を置く既存の器なので、NPC も同じ抽選・配置へ載せる。
 - 既存の `interior` の content 層を再利用する。抽選・配置・束・Archetype・Age を作り直さない。
@@ -57,7 +57,7 @@ CDDA が 24×24 を人手で描く(prefab)うえに palette/group で風味を�
 
 肝は content が骨格を**置き換えない**こと。骨格がスロットの意味を与え、content がスロット内の変化を与える。これで「固定=ワンパターン」と「純 content=意味の破綻」の両方を避ける。
 
-**役割マッチ(RoomReq)を実装する。** 今は content をどの部屋へ流すかが役割駆動でなく、未分類は樽へ落ちる。テンプレの各部屋に役割タグを持たせ、`contentFor` を役割で引いて流す。寝室→寝具 content、台所→食料 content。`classifyRoom` の逆推定を検証に使い、役割どおりに見えるかを golden の前に機械検出する。`genericContent` の樽フォールバックは、役割テンプレと役割別 content で置き換えて廃止する。
+**既存の役割マッチ `roleContent` を拡張する。** 役割→content の割当自体は既にあり、`roleContent` が main→roomCatalog→houseRoomContents→backRoomContent と辿る。問題は未対応の役割・施設種が末尾の `backRoomContent`(奥室の樽)や `genericContent` へ落ちること。ここを役割別 content で充実させ、樽フォールバックを塞ぐ。`classifyRoom` の逆推定を検証に使い、役割どおりに見えるかを golden の前に機械検出する。新しい `RoomReq` 型をゼロから作るのでなく、既存の4段フォールバックの取りこぼしを埋めるのが実体。
 
 露天の地物(祠・キャンプ跡・集落)も骨格を持つ。違いは壁が無いことだけで、**矩形ゾーンを割り当てて同じ充填を通す**。`interior` の placement は壁タイルでなく部屋矩形 `Rect` の幾何で決まる。`PlaceWall` は `nextToPerimeter(Rect, t)`(矩形外周に隣接するか)、`PlaceCenter` は `Rect.center()`。だから壁が無くても、ゾーンの縁に沿って・中央に寄せて、という配置がそのまま効く。壁・扉・戸口からの到達性ガードは建物だけが持つ属性で、屋外ゾーンはこれらを描かない。小さな露天は単一ゾーン、大きめのキャンプ跡や集落は炊事・就寝といった sub-zone を割ってもよい。
 
@@ -112,8 +112,9 @@ func abandonedHutContent() Content {
 
 ```go
 // landmark.go の廃屋・農家跡ケース
-footprint := interior.Rect{X: int(ox), Y: int(oy), W: int(hw), H: int(hh)}
-door := interior.Vec{X: int(doorX), Y: int(oy + hh - 1)}
+// ox/oy/hw/hh は consts.Tile。Rect も Vec(=consts.Coord[consts.Tile]) も同じ Tile 型なのでキャスト不要
+footprint := interior.Rect{X: ox, Y: oy, W: hw, H: hh}
+door := interior.Vec{X: doorX, Y: oy + hh - 1}
 _, placed := interior.FurnishByTheme(seed, footprint, door, themeAbandonedHut)
 // placed を prop として spawn する
 ```
@@ -150,16 +151,16 @@ _, placed := interior.FurnishByTheme(seed, zone, interior.Unwalled, themeShrine)
 
 `needs-decision` の具体は次の3点。実装着手前に interior 保守者と擦り合わせる。
 
-- **外殻の乱数と content の seed の整理**。`drawHut` は今 `*rand.Rand` を受けて南辺の扉 X を引く。content 充填は seed の `uint64` を受ける口になるので、外殻の扉抽選も `childSeed` から導いた seed へ寄せ、乱数器の持ち回りをやめる。外殻と内装で seed 分岐をどう割るかを決める。
+- **外殻の乱数全体を content の seed へ寄せる**。`landmark.go` の `place` は今 `*rand.Rand` を1つ作り、原点オフセット `ox`/`oy` と `drawHut` の扉 X を**同じ rng から連続して**引く。扉だけを移すと引く順が変わり過去 seed との一致が崩れる。よって扉だけでなく `ox`/`oy` を含む乱数消費すべてを `childSeed` 由来の seed へ移すか、逆にオフセットは rng のまま扉だけ移す混在にするかを決める。決めた側に統一し、乱数器の持ち回りをやめる。
 - **公開境界**。`FurnishByTheme` を公開するなら `Theme` 型も公開になる。テーマ定数を interior 側に置いて公開するか、landmark 側が content を interior へ登録するかを決める。`contentFor` を内部に留めるなら landmark からテーマをどう指すかも合わせて決める。
-- **Age の damage をテーマで制御する**。`Age` の強度は `buildingProfile.damage` で決まり、`rollProfile` が seed から無作為に引く。廃屋テーマを渡しても毎回 `dmgMajor` にならないので、テーマが profile の damage を上書きできるようにするか、テーマ別に damage 下限を持たせるかを決める。
+- **Age の damage をテーマで制御する**。`Age` の強度は `buildingProfile.damage` で決まり、`rollProfile` が seed から無作為に引くので、廃屋テーマを渡しても毎回 `dmgMajor` にならない。ただし `rollProfile` には既に `varAbandoned` variant があり、`damage = dmgMajor` と `clutter` の下限を強制する。**最小の解は「廃屋テーマは `rollVariant` が常に `varAbandoned` を返す、または `rollProfile` にテーマを渡して variant を固定する」**。新しいフィールドや上書き機構を足さず既存の variant 軸を使う。この案を第一候補に、テーマ別 damage 下限を持たせる案と比べて決める。
 
 ## 変更箇所
 
 | ファイル | 変更内容 |
 |---|---|
-| `internal/mapplanner/interior/content_catalog.go` | `FacilityKind` 引きの content 分岐を `Theme` 引きへ一般化する。`contentFor(Theme)` を追加し、既存の施設別 content をテーマとして束ねる。`genericContent` の樽フォールバックを役割別 content で置き換えて廃止する |
-| `internal/mapplanner/interior/furnish.go` の役割割当 | テンプレの各部屋に役割タグを持たせ、RoomReq 照合で役割別 content を流す。寝室→寝具、台所→食料。未分類が樽へ落ちる経路を断つ |
+| `internal/mapplanner/interior/content_catalog.go` | `FacilityKind` 引きの content 分岐を `Theme` 引きへ一般化する。`contentFor(Theme)` を追加し既存の施設別 content をテーマとして束ねる。役割別 content(`roomCatalog`/`houseRoomContents`)を施設・役割ぶん充実させ、`genericContent`/`backRoomContent` の樽へ落ちる取りこぼしを塞ぐ |
+| `internal/mapplanner/interior/furnish.go` の `roleContent` | 既存の4段フォールバック(main→roomCatalog→houseRoomContents→backRoomContent)を拡張し、未対応役割・施設種が樽の `backRoomContent` へ落ちないよう役割別 content を引き当てる |
 | `internal/mapplanner/interior/furnish.go` | テーマを受ける `FurnishByTheme` を公開する。既存 `FurnishBuilding` はテーマの一種として薄く包む |
 | `internal/mapplanner/interior/furnish.go` の壁分岐 | `FurnishByTheme` に「壁を描くか」の分岐を持たせる。建物は外殻・扉・到達性を足し、露天は壁の無いゾーンとして同じ `Rect` 充填を通す。露天専用の配置経路は作らない |
 | `internal/overworld/landmark.go` | 廃屋・農家跡は `drawHut` の外殻＋テーマ content 充填へ。祠・キャンプ跡は壁の無いゾーンへ同じ充填を通す。固定 prop リストを撤去する |
@@ -181,6 +182,7 @@ _, placed := interior.FurnishByTheme(seed, zone, interior.Unwalled, themeShrine)
 - 本 doc の芯は新機構でなく、`interior` の既存の骨格層(役割テンプレ)と風味層(content)を全施設へ配線し直すことにある。深さの非対称、街は二層生成・原野は固定描画、を解消する。
 - 骨格層と風味層の責務を混ぜない。骨格が部屋の役割と空間を保証し、風味がスロットの変化を与える。片方だけだとワンパターンか意味の破綻に倒れる。RoomReq の役割マッチが二層をつなぐ要。
 - 建物と露天の違いは壁の有無だけにする。どちらも矩形ゾーンを割り当て同じ `Rect` 充填を通し、建物は壁・扉・到達性を足す。placement が壁でなく矩形の幾何で書かれているのでこれが成り立つ。露天専用の配置経路は作らない。
+- `FurnishByTheme` は第2段の時点でゾーンと壁の有無を受けるシグネチャで設計する。第3段で壁分岐を後付けすると第2段で書いた `landmark.go` の呼び出しを再修正することになるので、破壊的変更を段をまたいで持ち込まない。
 - 段階で切る。第1段で骨格の役割マッチと樽フォールバック廃止、第2段でテーマ一般化と小屋の部屋充填、第3段で露天の scene、第4段で集落を同じ scene 経路へ。各段で golden を撮り直し、決定性テストを課す。最終的に固定生成の直書きは残さない。
 - 着手は人の判断が要る。content 層の公開境界をどこに引くか、NPC を content の抽選へどう載せるかは、実装前に interior の保守方針と擦り合わせる。
 
@@ -188,8 +190,7 @@ _, placed := interior.FurnishByTheme(seed, zone, interior.Unwalled, themeShrine)
 
 第1段 骨格の役割マッチと樽フォールバック廃止
 
-- [ ] テンプレの各部屋に役割タグを持たせ、RoomReq 照合で役割別 content を流す
-- [ ] `genericContent` の樽フォールバックを役割別 content で置き換えて廃止する
+- [ ] 既存 `roleContent` を拡張し、未対応役割・施設種が樽の `backRoomContent`/`genericContent` へ落ちる取りこぼしを役割別 content で塞ぐ
 - [ ] `classifyRoom` の逆推定で役割どおりに見えるかを golden 前に検証する
 
 第2段 テーマ一般化と小屋の部屋充填

--- a/docs/design/260823165936.md
+++ b/docs/design/260823165936.md
@@ -41,8 +41,8 @@ CDDA が 24×24 を人手で描く(prefab)うえに palette/group で風味を�
 
 **Anti**
 
-- 露天の地物、祠・キャンプ跡・集落、を多部屋 BSP や施設別間取りテンプレへ通さない。footprint を持たない露天に間取り生成は過剰。
-- `interior` の全機構を露天へ持ち込まない。footprint を持たない地物へ部屋充填を強制せず、抽選と Satellites だけを使う。
+- 露天のゾーンに壁・扉・戸口からの到達性ガードを描かない。これらは建物だけの属性。屋外は壁の無いゾーンとして充填する。
+- 小さな露天へ多部屋 BSP や施設別間取りテンプレを強制しない。単一ゾーンで足りる。大きめのゾーンだけ sub-zone を割る。露天専用の別配置アルゴリズムは作らず、建物と同じ `Rect` 充填を使う。
 - テーマデータをコードから分離した外部 DSL や新パッケージを増やさない。既存 content 仕様の書き方に揃える。
 - 生成結果をセーブへ焼き込まない。オーバーワールドは seed から都度再生成する現状を維持する。
 
@@ -59,7 +59,7 @@ CDDA が 24×24 を人手で描く(prefab)うえに palette/group で風味を�
 
 **役割マッチ(RoomReq)を実装する。** 今は content をどの部屋へ流すかが役割駆動でなく、未分類は樽へ落ちる。テンプレの各部屋に役割タグを持たせ、`contentFor` を役割で引いて流す。寝室→寝具 content、台所→食料 content。`classifyRoom` の逆推定を検証に使い、役割どおりに見えるかを golden の前に機械検出する。`genericContent` の樽フォールバックは、役割テンプレと役割別 content で置き換えて廃止する。
 
-露天の地物(祠・キャンプ跡・集落)は部屋も役割も持たないので骨格層を持たず、風味層だけで生成する。ここは純 content が正しく、意味の破綻も起きない。
+露天の地物(祠・キャンプ跡・集落)も骨格を持つ。違いは壁が無いことだけで、**矩形ゾーンを割り当てて同じ充填を通す**。`interior` の placement は壁タイルでなく部屋矩形 `Rect` の幾何で決まる。`PlaceWall` は `nextToPerimeter(Rect, t)`(矩形外周に隣接するか)、`PlaceCenter` は `Rect.center()`。だから壁が無くても、ゾーンの縁に沿って・中央に寄せて、という配置がそのまま効く。壁・扉・戸口からの到達性ガードは建物だけが持つ属性で、屋外ゾーンはこれらを描かない。小さな露天は単一ゾーン、大きめのキャンプ跡や集落は炊事・就寝といった sub-zone を割ってもよい。
 
 ### content 層を「テーマ」で引けるようにする
 
@@ -120,22 +120,19 @@ _, placed := interior.FurnishByTheme(seed, footprint, door, themeAbandonedHut)
 
 これで小屋は Age も掛かり、廃屋なら略奪・廃墟化の層が乗って「打ち捨てられた」見た目になる。
 
-### 露天は Satellites の scene で埋める
+### 露天は壁の無いゾーンとして同じ充填を通す
 
-祠とキャンプ跡は footprint も扉も持たない露天で、部屋充填は通さない。interior の flavor machine が持つ **scene = Satellites の束**、「蝋燭の輪のような scene を束で置く」、を露天テーマとして使う。anchor を基準に相対 prop を束ねる考え方は、今の `relSpot` の固定並びの上位互換になる。
+祠・キャンプ跡・集落は、専用の scene 経路を作らず**壁の無い矩形ゾーン**として建物と同じ充填へ通す。屋外に矩形の `Rect` を割り当て、`FurnishByTheme` にゾーンとテーマを渡す。違いは建物が持つ壁描画・扉・到達性ガードを行わない点だけ。
 
-ただし既存の `Satellite`(`content.go`) は `FillRoom` の文脈内で anchor を解決する型で、外から座標を渡す口を持たない。露天は `Room` を持たないので、そのまま使えない。**露天用に、anchor 座標と Satellites 仕様を受けて `[]Placed` を返す薄い関数を新設する**。入力と出力の型を明示する。
+これが成り立つのは placement が `Rect` の純幾何で書かれているため。祠なら中央に石柱、その周りに蝋燭、キャンプ跡なら中央に焚き火、縁に crate と bench、といった配置が `PlaceCenter`/`PlaceWall` でそのまま出る。既存の `Satellite`(机に椅子を従える束)もゾーン内でそのまま使え、焚き火に薪と椅子を従える束として機能する。
 
 ```go
-// interior に新設する露天用の配置口。footprint も Room も持たず、origin を anchor 基準として
-// Satellites 仕様を抽選・配置し Placed を返す。到達性ガードや部屋分割は通さない。
-func FurnishScene(seed uint64, origin Vec, theme Theme) []Placed
-
-// 祠テーマの scene 仕様。石柱を anchor に蝋燭・供物を相対配置する束。数と向きを seed で揺らす。
-// 仕様の型は既存 content の抽選語彙(Group/Stuff)に合わせ、露天では Room 配置でなく origin 相対で解決する。
+// 露天は壁を描かず、同じ充填口へゾーンを渡す。建物は walled=true で外殻・扉・到達性を足す。
+zone := interior.Rect{X: ox, Y: oy, W: zw, H: zh}
+_, placed := interior.FurnishByTheme(seed, zone, interior.Unwalled, themeShrine)
 ```
 
-露天は到達性ガードや部屋分割を要さないので、content 層のうち抽選と相対配置だけを使う。`FurnishScene` の具体的な内部型と、既存 `Satellite` を露天へ流用するか新型を足すかは実装前に interior 保守者と決める。
+新設が要るのは「壁を描くか」の分岐だけで、露天専用の配置アルゴリズムや新しい入出力型は要らない。`FurnishByTheme` にゾーンと壁の有無を渡す口を1つ持たせれば、建物と露天が同じ充填を共有する。
 
 ### 決定性と分類の維持
 
@@ -145,7 +142,7 @@ func FurnishScene(seed uint64, origin Vec, theme Theme) []Placed
 
 ### 集落
 
-村と一軒家の固定 NPC/prop リストも同じテーマ→content の枠で生成する。集落は建物でなく NPC 配置が主だが、content システムは doc.go のとおり「家具・戦利品・敵・装飾」を置く器で、既にエンティティを扱える。NPC もこの抽選・配置へ載せ、村は全サービスの NPC を保証枠に、行商の一軒家は商人だけを保証枠にし、生活感の prop を風味で揺らす。集落は建物のように有界の footprint を持たないので、露天ランドマークと同じく Satellites の scene で中心から相対配置する。
+村と一軒家の固定 NPC/prop リストも同じテーマ→content の枠で生成する。集落は建物でなく NPC 配置が主だが、content システムは doc.go のとおり「家具・戦利品・敵・装飾」を置く器で、既にエンティティを扱える。NPC もこの抽選・配置へ載せ、村は全サービスの NPC を保証枠に、行商の一軒家は商人だけを保証枠にし、生活感の prop を風味で揺らす。集落も露天ランドマークと同じく**壁の無い矩形ゾーン**を割り当て、そのゾーンへ同じ充填を通す。NPC は中央寄り、生活の prop は縁沿い、と placement で配れる。大きな村はゾーンを sub-zone に割り、広場・軒先などの役割を持たせてもよい。
 
 これで街の建物・ランドマーク・集落が同じ content パイプラインを共有し、固定生成は残らない。
 
@@ -164,15 +161,15 @@ func FurnishScene(seed uint64, origin Vec, theme Theme) []Placed
 | `internal/mapplanner/interior/content_catalog.go` | `FacilityKind` 引きの content 分岐を `Theme` 引きへ一般化する。`contentFor(Theme)` を追加し、既存の施設別 content をテーマとして束ねる。`genericContent` の樽フォールバックを役割別 content で置き換えて廃止する |
 | `internal/mapplanner/interior/furnish.go` の役割割当 | テンプレの各部屋に役割タグを持たせ、RoomReq 照合で役割別 content を流す。寝室→寝具、台所→食料。未分類が樽へ落ちる経路を断つ |
 | `internal/mapplanner/interior/furnish.go` | テーマを受ける `FurnishByTheme` を公開する。既存 `FurnishBuilding` はテーマの一種として薄く包む |
-| `internal/mapplanner/interior/content.go` | 露天向けに `FurnishScene(seed, origin, theme) []Placed` を足す。Room を持たず origin 相対で抽選・配置し、部屋充填を通さない |
-| `internal/overworld/landmark.go` | 廃屋・農家跡は `drawHut` の外殻＋テーマ content 充填へ。祠・キャンプ跡は scene 束へ。固定 prop リストを撤去する |
-| `internal/overworld/settlement.go` | 村・一軒家の固定 NPC/prop リストを撤去し、テーマ content の scene 束から NPC と prop を配置する |
+| `internal/mapplanner/interior/furnish.go` の壁分岐 | `FurnishByTheme` に「壁を描くか」の分岐を持たせる。建物は外殻・扉・到達性を足し、露天は壁の無いゾーンとして同じ `Rect` 充填を通す。露天専用の配置経路は作らない |
+| `internal/overworld/landmark.go` | 廃屋・農家跡は `drawHut` の外殻＋テーマ content 充填へ。祠・キャンプ跡は壁の無いゾーンへ同じ充填を通す。固定 prop リストを撤去する |
+| `internal/overworld/settlement.go` | 村・一軒家の固定 NPC/prop リストを撤去し、壁の無いゾーンへテーマ content を通して NPC と prop を配置する |
 | `internal/overworld/landmark_test.go` | 内装が変動しても同一 seed で一致する決定性テストを課す |
 
 ## 採用しなかった方法
 
 - **landmark 独自の抽選器を書く**。却下。interior が抽選・配置・束・Age・flavor を既に持ち、doc.go が「散布殺し」として設計している。二重実装は保守が割れ、街と原野で生成の質がばらつく。既存の器へ寄せる。
-- **全ランドマークを `FurnishBuilding` へ通す**。却下。祠・キャンプ跡は footprint を持たない露天で、部屋分割・到達性ガード・間取りテンプレが無意味。有界の小屋にだけ部屋充填を使い、露天は Satellites の scene に留める。
+- **露天専用の配置経路(Room を持たない scene 関数)を新設する**。却下。placement は `Rect` の純幾何で書かれ、壁タイルに依存しない。露天も矩形ゾーンを割り当てれば同じ充填が通る。専用経路は二重実装になるので、壁を描くかの分岐1つで建物と露天を同じ充填へ寄せる。
 - **テーマを外部ファイルの DSL にする**。却下。既存 content は Go 関数で `Content` を返す書き方に統一されている。原野のためだけに別記法を足すと二重管理になる。content 仕様は Go で書く現状に揃える。
 - **生成結果をセーブへ焼き込む**。却下。オーバーワールドは seed から都度再生成し、決定性で再訪一致を保証している。焼き込みは serde 対象を増やし整合を壊す。seed 固定の再生成を維持する。
 - **純 content 抽選だけで部屋の意味を出す**。却下。部屋の役割を知らないまま密度場で置くと「タルだらけの家」になる。今の `genericContent` の樽フォールバックがその実例。意味の強い施設は役割テンプレを骨格に持ち、content はスロットを埋める二層にする。抽選だけで整合を出そうとしない。
@@ -183,7 +180,7 @@ func FurnishScene(seed uint64, origin Vec, theme Theme) []Placed
 
 - 本 doc の芯は新機構でなく、`interior` の既存の骨格層(役割テンプレ)と風味層(content)を全施設へ配線し直すことにある。深さの非対称、街は二層生成・原野は固定描画、を解消する。
 - 骨格層と風味層の責務を混ぜない。骨格が部屋の役割と空間を保証し、風味がスロットの変化を与える。片方だけだとワンパターンか意味の破綻に倒れる。RoomReq の役割マッチが二層をつなぐ要。
-- 有界の建物と露天で使う機構を分ける。建物は骨格層＋部屋充填、露天のランドマーク・集落は骨格を持たず風味層(抽選と Satellites)だけ。過剰適用を避ける線引きが設計の要。
+- 建物と露天の違いは壁の有無だけにする。どちらも矩形ゾーンを割り当て同じ `Rect` 充填を通し、建物は壁・扉・到達性を足す。placement が壁でなく矩形の幾何で書かれているのでこれが成り立つ。露天専用の配置経路は作らない。
 - 段階で切る。第1段で骨格の役割マッチと樽フォールバック廃止、第2段でテーマ一般化と小屋の部屋充填、第3段で露天の scene、第4段で集落を同じ scene 経路へ。各段で golden を撮り直し、決定性テストを課す。最終的に固定生成の直書きは残さない。
 - 着手は人の判断が要る。content 層の公開境界をどこに引くか、NPC を content の抽選へどう載せるかは、実装前に interior の保守方針と擦り合わせる。
 
@@ -204,7 +201,7 @@ func FurnishScene(seed uint64, origin Vec, theme Theme) []Placed
 
 第3段 露天の scene 経路
 
-- [ ] 露天向けの `FurnishScene` を足し、祠・キャンプ跡を scene へ差し替える
+- [ ] `FurnishByTheme` に壁の有無の分岐を足し、祠・キャンプ跡を壁の無いゾーン充填へ差し替える
 
 第4段 集落
 

--- a/docs/design/260823165936.md
+++ b/docs/design/260823165936.md
@@ -4,7 +4,7 @@ tags: [worldgen, refactor, gamedesign] # 領域ラベル
 auto: needs-decision # mechanical=無人着手可 / needs-decision=人の判断必須
 ---
 
-# 点在ランドマークと集落をテーマ駆動の content システムへ寄せる
+# すべての地物・施設の生成を content システムに一本化する
 
 ## 背景
 
@@ -25,15 +25,17 @@ auto: needs-decision # mechanical=無人着手可 / needs-decision=人の判断�
 
 **Hard**
 
+- **すべての地物・施設を content システムで生成する。** 街の建物・ランドマーク・集落を含め、構造物を置くものは固定レイアウトや固定リストをやめ、テーマ = content 仕様から生成する。ad-hoc な直書き生成を残さない。
 - ランドマークの各種別を固定レイアウトでなく、テーマ = content 仕様から生成する。同じ種別でも訪れるたびに中身が変わりつつ、廃屋らしさ・農家跡らしさは保証枠で担保する。
+- 集落の村・一軒家も固定 NPC/prop リストをやめ、テーマ = content 仕様から生成する。content は家具・戦利品・敵・装飾を置く既存の器なので、NPC も同じ抽選・配置へ載せる。
 - 既存の `interior` の content 層を再利用する。抽選・配置・束・Archetype・Age を作り直さない。
 - 決定性を保つ。再訪で完全一致し serde 安全であること。抽選は有界インスタンスの seed 固定に閉じ、`childSeed` で分岐する。
 - 地図の記号と実体の対応を壊さない。`chunkTypeAt` と `landmarkKindAt` を唯一の分類源に保つ。
 
 **Anti**
 
-- 露天のランドマーク、祠・キャンプ跡、を多部屋 BSP や施設別間取りテンプレへ通さない。単室・露天に間取り生成は過剰。
-- `interior` の全機構をランドマークへ持ち込まない。footprint を持たない露天へ部屋充填を強制しない。
+- 露天の地物、祠・キャンプ跡・集落、を多部屋 BSP や施設別間取りテンプレへ通さない。footprint を持たない露天に間取り生成は過剰。
+- `interior` の全機構を露天へ持ち込まない。footprint を持たない地物へ部屋充填を強制せず、抽選と Satellites だけを使う。
 - テーマデータをコードから分離した外部 DSL や新パッケージを増やさない。既存 content 仕様の書き方に揃える。
 - 生成結果をセーブへ焼き込まない。オーバーワールドは seed から都度再生成する現状を維持する。
 
@@ -120,9 +122,11 @@ func shrineScene() []Satellite {
 - 種別の決定は `landmarkKindAt` のまま。テーマは種別から一意に定まる。地図の `ChunkPlace` は従来どおり `landmarkKindAt` → `landmarkPlaceType` で記号を引き、内装の変動は記号に影響しない。
 - 内装が変動しても同一 seed では完全一致する。既存の「同 seed 2回生成が一致する」テストをランドマークにも課す。
 
-### 集落への波及
+### 集落
 
-村と一軒家の固定 NPC/prop リストも、同じテーマ→content の枠へ寄せられる。ただし集落は建物でなく NPC 配置が主で、content システムは prop 中心に作られている。NPC 抽選まで content へ載せるかは別途の判断が要るので、本 doc の第一段はランドマークに絞り、集落は後段の候補として要件だけ残す。
+村と一軒家の固定 NPC/prop リストも同じテーマ→content の枠で生成する。集落は建物でなく NPC 配置が主だが、content システムは doc.go のとおり「家具・戦利品・敵・装飾」を置く器で、既にエンティティを扱える。NPC もこの抽選・配置へ載せ、村は全サービスの NPC を保証枠に、行商の一軒家は商人だけを保証枠にし、生活感の prop を風味で揺らす。集落は建物のように有界の footprint を持たないので、露天ランドマークと同じく Satellites の scene で中心から相対配置する。
+
+これで街の建物・ランドマーク・集落が同じ content パイプラインを共有し、固定生成は残らない。
 
 ## 変更箇所
 
@@ -132,6 +136,7 @@ func shrineScene() []Satellite {
 | `internal/mapplanner/interior/furnish.go` | テーマを受ける `FurnishByTheme` を公開する。既存 `FurnishBuilding` はテーマの一種として薄く包む |
 | `internal/mapplanner/interior/content.go` | 露天向けに Satellites だけを使う薄い scene 配置経路を足す。部屋充填を要さない |
 | `internal/overworld/landmark.go` | 廃屋・農家跡は `drawHut` の外殻＋テーマ content 充填へ。祠・キャンプ跡は scene 束へ。固定 prop リストを撤去する |
+| `internal/overworld/settlement.go` | 村・一軒家の固定 NPC/prop リストを撤去し、テーマ content の scene 束から NPC と prop を配置する |
 | `internal/overworld/landmark_test.go` | 内装が変動しても同一 seed で一致する決定性テストを課す |
 
 ## 採用しなかった方法
@@ -140,14 +145,14 @@ func shrineScene() []Satellite {
 - **全ランドマークを `FurnishBuilding` へ通す**。却下。祠・キャンプ跡は footprint を持たない露天で、部屋分割・到達性ガード・間取りテンプレが無意味。有界の小屋にだけ部屋充填を使い、露天は Satellites の scene に留める。
 - **テーマを外部ファイルの DSL にする**。却下。既存 content は Go 関数で `Content` を返す書き方に統一されている。原野のためだけに別記法を足すと二重管理になる。content 仕様は Go で書く現状に揃える。
 - **生成結果をセーブへ焼き込む**。却下。オーバーワールドは seed から都度再生成し、決定性で再訪一致を保証している。焼き込みは serde 対象を増やし整合を壊す。seed 固定の再生成を維持する。
-- **集落も同時に移行する**。見送り。集落は NPC 配置が主で、prop 中心の content システムとの噛み合わせに別途の判断が要る。第一段はランドマークに絞り、集落は要件に残して後段で扱う。
+- **集落は固定 NPC/prop リストのまま残す**。却下。集落は世界に点在し面積の印象を左右するので、ここだけ固定生成だと content システムへ寄せた意味が薄れる。content は敵・エンティティを既に扱えるので NPC も載る。全施設を1つのパイプラインへ寄せ、固定生成を残さない。
 
 ## コメント
 
-- 本 doc の芯は新機構でなく、`interior` の既存 content 層をランドマークへ配線し直すことにある。深さの非対称、街は content システム・原野は固定描画、を解消する。
-- 有界の小屋と露天の scene で使う機構を分ける。小屋は部屋充填の全段、露天は抽選と Satellites だけ。過剰適用を避ける線引きが設計の要。
-- 段階で切る。第一段でテーマの一般化と小屋の部屋充填、第二段で露天の scene、第三段で集落の検討。各段で golden を撮り直し、決定性テストを課す。
-- 着手は人の判断が要る。content 層の公開境界をどこに引くか、露天 scene をどこまで content に載せるかは、実装前に interior の保守方針と擦り合わせる。
+- 本 doc の芯は新機構でなく、`interior` の既存 content 層を全施設へ配線し直すことにある。深さの非対称、街は content システム・原野は固定描画、を解消し、生成経路を1つに畳む。
+- 有界の建物と露天の scene で使う機構を分ける。建物は部屋充填の全段、露天のランドマーク・集落は抽選と Satellites だけ。過剰適用を避ける線引きが設計の要。
+- 段階で切る。第一段でテーマの一般化と小屋の部屋充填、第二段で露天の scene、第三段で集落を同じ scene 経路へ。各段で golden を撮り直し、決定性テストを課す。最終的に固定生成の直書きは残さない。
+- 着手は人の判断が要る。content 層の公開境界をどこに引くか、NPC を content の抽選へどう載せるかは、実装前に interior の保守方針と擦り合わせる。
 
 ## 進捗
 
@@ -156,4 +161,4 @@ func shrineScene() []Satellite {
 - [ ] 廃屋・農家跡テーマの `Content` 仕様を書き、`drawHut` の外殻＋content 充填へ差し替える
 - [ ] 露天向けの Satellites scene 経路を足し、祠・キャンプ跡を scene 束へ差し替える
 - [ ] ランドマークに同一 seed 一致の決定性テストを課し、golden を撮り直す
-- [~] 集落の村/一軒家を content テーマへ寄せる。第一段では見送り、後段で判断する
+- [ ] 集落の村/一軒家の固定 NPC/prop リストを撤去し、テーマ content の scene 束へ寄せる

--- a/docs/design/260823165936.md
+++ b/docs/design/260823165936.md
@@ -1,0 +1,159 @@
+---
+status: draft # draft|accepted|in-progress|done|superseded|dropped
+tags: [worldgen, refactor, gamedesign] # 領域ラベル
+auto: needs-decision # mechanical=無人着手可 / needs-decision=人の判断必須
+---
+
+# 点在ランドマークと集落をテーマ駆動の content システムへ寄せる
+
+## 背景
+
+原野の点在ランドマーク `internal/overworld/landmark.go` は種別ごとに固定レイアウトを1つ描くだけになっている。廃屋は `drawHut(6,5,[bed,closet])`、農家跡は `drawHut(7,5,[barrel,crate])`、祠とキャンプ跡は固定の3prop。原点のジッターだけが変わり、中身・並び・数は毎回同じで、同じ種別のランドマークはどれも見分けがつかない。集落 `settlement.go` も同様で、村と一軒家は `villageNPCs`/`hamletProps` のような固定リストを撒くだけになっている。
+
+一方、街の建物は `internal/mapplanner/interior` の content システムで生成している。ここは「どの prefab か」でなく「どういう部屋が要るか」を要件で宣言し、保証セットと風味を分けて抽選する。散布をやめ「設計されたもの」に見せるための器が既にある。主な機構は次のとおり。
+
+- **抽選** `Content` / `Group` / `GroupStyle`。`PickEach` で施設を施設たらしめる物を必ず置き、`PickOne`/`PickN` で風味だけ揺らす。
+- **配置** 中央・壁際・奥・入口近くといった密度場と、戸口から全床への到達性ガード。
+- **束(Satellites)** 机を anchor に椅子を相対配置する。散布殺しの主装置。
+- **Archetype** 家具型が自分の既定配置を知り、レシピは Ref と個数だけ言えばよい。
+- **時間の層(Age)・flavor machine** 略奪・生活痕・廃墟化を掛け、空き部屋へ character を足す。
+- **充填** `FurnishBuilding(seed, footprint, door, facility) (Site, []Placed)` が外殻を施設別に埋めて配置を返す。
+
+つまり「テーマを決めて生成する」仕組みは既にあるが、`FacilityKind` すなわち街の建物にしか配線されていない。ランドマークと集落はこの器を迂回して固定生成している。世界の広い面積を占めるのは原野のランドマークと点在する集落なので、ここがワンパターンだと世界全体が「設計されていない」印象になる。
+
+## 要件
+
+**Hard**
+
+- ランドマークの各種別を固定レイアウトでなく、テーマ = content 仕様から生成する。同じ種別でも訪れるたびに中身が変わりつつ、廃屋らしさ・農家跡らしさは保証枠で担保する。
+- 既存の `interior` の content 層を再利用する。抽選・配置・束・Archetype・Age を作り直さない。
+- 決定性を保つ。再訪で完全一致し serde 安全であること。抽選は有界インスタンスの seed 固定に閉じ、`childSeed` で分岐する。
+- 地図の記号と実体の対応を壊さない。`chunkTypeAt` と `landmarkKindAt` を唯一の分類源に保つ。
+
+**Anti**
+
+- 露天のランドマーク、祠・キャンプ跡、を多部屋 BSP や施設別間取りテンプレへ通さない。単室・露天に間取り生成は過剰。
+- `interior` の全機構をランドマークへ持ち込まない。footprint を持たない露天へ部屋充填を強制しない。
+- テーマデータをコードから分離した外部 DSL や新パッケージを増やさない。既存 content 仕様の書き方に揃える。
+- 生成結果をセーブへ焼き込まない。オーバーワールドは seed から都度再生成する現状を維持する。
+
+## 設計
+
+### content 層を「テーマ」で引けるようにする
+
+現状 `interior` は content を `FacilityKind` で引く。`content_catalog.go` が `houseContent()`・`storeContent()` のように施設別 `Content` を返し、`FurnishBuilding` が `facility FacilityKind` を受ける。これを「テーマ」という上位概念へ一般化し、街の施設もランドマークも同じ口で content を引けるようにする。
+
+テーマは content 仕様を選ぶキーにすぎない。`FacilityKind` はテーマの一種になる。
+
+```go
+// interior パッケージ
+
+// Theme は content 仕様を選ぶキー。街の施設もランドマークも同じ抽選・配置・Age の
+// パイプラインを共有し、違いはこのテーマが指す Content だけになる。
+type Theme string
+
+// contentFor はテーマに対応する Content を返す。施設別 content 関数を集約した既存の
+// 分岐を、テーマ単位へ広げたもの。未知テーマは genericContent へ落とす。
+func contentFor(t Theme) Content
+```
+
+ランドマークのテーマは landmark 側で宣言し、interior へ登録する。廃屋テーマの content 仕様は例えば次の形になる。既存の施設 content と同じ `Content`/`Group`/`Stuff` で書く。
+
+```go
+// 廃屋テーマの content。保証枠に生活痕を必ず置き、風味を抽選する。固定の [bed,closet] を
+// やめ、寝具・収納・生活雑貨から揺らして毎回違う廃屋にする。
+func abandonedHutContent() Content {
+	return Content{
+		Groups: []Group{
+			{Style: PickEach, Items: []Stuff{ // 廃屋を廃屋たらしめる保証枠
+				{Ref: "bed", Chance: 70},
+				{Ref: "closet", Chance: 60},
+			}},
+			{Style: PickN, Pick: 2, Items: []Stuff{ // 生活の残骸を2つ抽選
+				{Ref: "barrel", Weight: 2},
+				{Ref: "crate", Weight: 2},
+				{Ref: "candle", Weight: 1},
+				{Ref: "bench", Weight: 1},
+			}},
+		},
+	}
+}
+```
+
+### 有界の小屋は部屋充填を再利用する
+
+廃屋と農家跡は `drawHut` が外殻と南辺の扉を作る有界の小屋で、interior の「部屋」概念にそのまま嵌る。`drawHut` は外殻だけを描き、内装は content パイプラインへ委ねる。
+
+`FurnishBuilding` は既に `(seed, footprint Rect, door Vec, ...)` を受けるので、小屋の footprint と扉を渡せば埋まる。テーマ対応後は施設種の代わりにランドマークテーマを渡す。
+
+```go
+// landmark.go の廃屋・農家跡ケース
+footprint := interior.Rect{X: int(ox), Y: int(oy), W: int(hw), H: int(hh)}
+door := interior.Vec{X: int(doorX), Y: int(oy + hh - 1)}
+_, placed := interior.FurnishByTheme(seed, footprint, door, themeAbandonedHut)
+// placed を prop として spawn する
+```
+
+これで小屋は Age も掛かり、廃屋なら略奪・廃墟化の層が乗って「打ち捨てられた」見た目になる。
+
+### 露天は Satellites の scene で埋める
+
+祠とキャンプ跡は footprint も扉も持たない露天で、部屋充填は通さない。interior の flavor machine が持つ **scene = Satellites の束**、「蝋燭の輪のような scene を束で置く」、を露天テーマとして使う。anchor を基準に相対 prop を束ねる Satellite は、今の `relSpot` の固定並びの上位互換になる。
+
+```go
+// 祠テーマの scene。石柱を anchor に蝋燭を相対配置する束。数と向きを seed で揺らす。
+func shrineScene() []Satellite {
+	return []Satellite{
+		{Anchor: "stone_pillar", Around: []Stuff{
+			{Ref: "candle", Weight: 2},
+			{Ref: "offering", Weight: 1},
+		}},
+	}
+}
+```
+
+露天は到達性ガードや部屋分割を要さないので、content 層のうち抽選と Satellites 配置だけを使う薄い経路を通す。
+
+### 決定性と分類の維持
+
+- 抽選 seed は `ChunkSeed2D(runSeed^landmarkSalt, c.X, c.Y)` を親に `childSeed` で分岐する。可変乱数器を持ち回らない。
+- 種別の決定は `landmarkKindAt` のまま。テーマは種別から一意に定まる。地図の `ChunkPlace` は従来どおり `landmarkKindAt` → `landmarkPlaceType` で記号を引き、内装の変動は記号に影響しない。
+- 内装が変動しても同一 seed では完全一致する。既存の「同 seed 2回生成が一致する」テストをランドマークにも課す。
+
+### 集落への波及
+
+村と一軒家の固定 NPC/prop リストも、同じテーマ→content の枠へ寄せられる。ただし集落は建物でなく NPC 配置が主で、content システムは prop 中心に作られている。NPC 抽選まで content へ載せるかは別途の判断が要るので、本 doc の第一段はランドマークに絞り、集落は後段の候補として要件だけ残す。
+
+## 変更箇所
+
+| ファイル | 変更内容 |
+|---|---|
+| `internal/mapplanner/interior/content_catalog.go` | `FacilityKind` 引きの content 分岐を `Theme` 引きへ一般化する。`contentFor(Theme)` を追加し、既存の施設別 content をテーマとして束ねる |
+| `internal/mapplanner/interior/furnish.go` | テーマを受ける `FurnishByTheme` を公開する。既存 `FurnishBuilding` はテーマの一種として薄く包む |
+| `internal/mapplanner/interior/content.go` | 露天向けに Satellites だけを使う薄い scene 配置経路を足す。部屋充填を要さない |
+| `internal/overworld/landmark.go` | 廃屋・農家跡は `drawHut` の外殻＋テーマ content 充填へ。祠・キャンプ跡は scene 束へ。固定 prop リストを撤去する |
+| `internal/overworld/landmark_test.go` | 内装が変動しても同一 seed で一致する決定性テストを課す |
+
+## 採用しなかった方法
+
+- **landmark 独自の抽選器を書く**。却下。interior が抽選・配置・束・Age・flavor を既に持ち、doc.go が「散布殺し」として設計している。二重実装は保守が割れ、街と原野で生成の質がばらつく。既存の器へ寄せる。
+- **全ランドマークを `FurnishBuilding` へ通す**。却下。祠・キャンプ跡は footprint を持たない露天で、部屋分割・到達性ガード・間取りテンプレが無意味。有界の小屋にだけ部屋充填を使い、露天は Satellites の scene に留める。
+- **テーマを外部ファイルの DSL にする**。却下。既存 content は Go 関数で `Content` を返す書き方に統一されている。原野のためだけに別記法を足すと二重管理になる。content 仕様は Go で書く現状に揃える。
+- **生成結果をセーブへ焼き込む**。却下。オーバーワールドは seed から都度再生成し、決定性で再訪一致を保証している。焼き込みは serde 対象を増やし整合を壊す。seed 固定の再生成を維持する。
+- **集落も同時に移行する**。見送り。集落は NPC 配置が主で、prop 中心の content システムとの噛み合わせに別途の判断が要る。第一段はランドマークに絞り、集落は要件に残して後段で扱う。
+
+## コメント
+
+- 本 doc の芯は新機構でなく、`interior` の既存 content 層をランドマークへ配線し直すことにある。深さの非対称、街は content システム・原野は固定描画、を解消する。
+- 有界の小屋と露天の scene で使う機構を分ける。小屋は部屋充填の全段、露天は抽選と Satellites だけ。過剰適用を避ける線引きが設計の要。
+- 段階で切る。第一段でテーマの一般化と小屋の部屋充填、第二段で露天の scene、第三段で集落の検討。各段で golden を撮り直し、決定性テストを課す。
+- 着手は人の判断が要る。content 層の公開境界をどこに引くか、露天 scene をどこまで content に載せるかは、実装前に interior の保守方針と擦り合わせる。
+
+## 進捗
+
+- [ ] `interior` の content 引きを `Theme` へ一般化し、`contentFor(Theme)` と `FurnishByTheme` を公開する
+- [ ] 既存 `FurnishBuilding` を `FurnishByTheme` の薄い包みへ寄せ、施設生成の挙動を不変に保つ
+- [ ] 廃屋・農家跡テーマの `Content` 仕様を書き、`drawHut` の外殻＋content 充填へ差し替える
+- [ ] 露天向けの Satellites scene 経路を足し、祠・キャンプ跡を scene 束へ差し替える
+- [ ] ランドマークに同一 seed 一致の決定性テストを課し、golden を撮り直す
+- [~] 集落の村/一軒家を content テーマへ寄せる。第一段では見送り、後段で判断する

--- a/docs/design/260823165936.md
+++ b/docs/design/260823165936.md
@@ -4,7 +4,7 @@ tags: [worldgen, refactor, gamedesign] # 領域ラベル
 auto: needs-decision # mechanical=無人着手可 / needs-decision=人の判断必須
 ---
 
-# すべての地物・施設の生成を content システムに一本化する
+# すべての地物・施設を役割テンプレ骨格と content スロットで生成する
 
 ## 背景
 
@@ -21,11 +21,18 @@ auto: needs-decision # mechanical=無人着手可 / needs-decision=人の判断�
 
 つまり「テーマを決めて生成する」仕組みは既にあるが、`FacilityKind` すなわち街の建物にしか配線されていない。ランドマークと集落はこの器を迂回して固定生成している。世界の広い面積を占めるのは原野のランドマークと点在する集落なので、ここがワンパターンだと世界全体が「設計されていない」印象になる。
 
+### 固定レイアウトとも純 content とも違う、二層が要る
+
+生成の失敗は両極にある。**固定レイアウトはワンパターン**、同じ種別がどれも同じに見える。逆に**純粋な content 抽選は意味が破綻する**、部屋の役割を知らないまま密度場で置くので「タルだらけの家」が出る。後者は今のコードにも実在し、`content_catalog.go` の `genericContent`(未分類施設)は「空き箱にならないよう樽と観葉だけ置く」とし樽を積み、奥室も「全部同じ樽の物置になる単調さ」を抱えている。`interior` は配置から役割を逆推定する `classifyRoom` を持つが、役割から content を割り当てる RoomReq 照合は `doc.go` のとおり未実装で、意味づけを保証できない。
+
+CDDA が 24×24 を人手で描く(prefab)うえに palette/group で風味を載せているのは、この二層が要るからである。**prefab または役割テンプレが空間的・意味的な整合を保証し、content がその上で多様性を与える。** 本 doc はこの二層を全施設へ広げる。content は prefab を置き換えるのでなく、prefab 骨格のスロットを埋める。
+
 ## 要件
 
 **Hard**
 
-- **すべての地物・施設を content システムで生成する。** 街の建物・ランドマーク・集落を含め、構造物を置くものは固定レイアウトや固定リストをやめ、テーマ = content 仕様から生成する。ad-hoc な直書き生成を残さない。
+- **すべての地物・施設を「役割テンプレ骨格＋content スロット」で生成する。** 街の建物・ランドマーク・集落を含め、固定レイアウトや固定リストをやめる。意味の強い施設は役割を持つテンプレ骨格を持ち、content はそのスロットを埋める。ad-hoc な直書き生成も、純 content だけで意味を出す試みも残さない。
+- **意味の強い施設は役割テンプレを持ち、content を役割でスロットへ割り当てる。** 寝室には寝具の content、台所には食料の content、と役割マッチで流す。RoomReq 照合を実装し、樽フォールバックのような意味の破綻を防ぐ。
 - ランドマークの各種別を固定レイアウトでなく、テーマ = content 仕様から生成する。同じ種別でも訪れるたびに中身が変わりつつ、廃屋らしさ・農家跡らしさは保証枠で担保する。
 - 集落の村・一軒家も固定 NPC/prop リストをやめ、テーマ = content 仕様から生成する。content は家具・戦利品・敵・装飾を置く既存の器なので、NPC も同じ抽選・配置へ載せる。
 - 既存の `interior` の content 層を再利用する。抽選・配置・束・Archetype・Age を作り直さない。
@@ -40,6 +47,19 @@ auto: needs-decision # mechanical=無人着手可 / needs-decision=人の判断�
 - 生成結果をセーブへ焼き込まない。オーバーワールドは seed から都度再生成する現状を維持する。
 
 ## 設計
+
+### 骨格は役割テンプレ、風味は content の二層にする
+
+生成を2つの層に分ける。責務を混ぜない。
+
+- **骨格層(prefab / 役割テンプレ)**: 部屋の形と役割を決める。家なら寝室・台所・居間、店なら売場・レジ前・バックヤード。空間的・意味的な整合はここが保証する。ruins は既に `PlanHouse`/`PlanStore`/`PlanClinic` の役割テンプレを持ち、露天でない施設はこれを骨格に使う。
+- **風味層(content)**: 骨格が用意した役割スロットを content で埋める。同じ寝室でも寝具・小物の種類と数を抽選で揺らし、ワンパターンを崩す。
+
+肝は content が骨格を**置き換えない**こと。骨格がスロットの意味を与え、content がスロット内の変化を与える。これで「固定=ワンパターン」と「純 content=意味の破綻」の両方を避ける。
+
+**役割マッチ(RoomReq)を実装する。** 今は content をどの部屋へ流すかが役割駆動でなく、未分類は樽へ落ちる。テンプレの各部屋に役割タグを持たせ、`contentFor` を役割で引いて流す。寝室→寝具 content、台所→食料 content。`classifyRoom` の逆推定を検証に使い、役割どおりに見えるかを golden の前に機械検出する。`genericContent` の樽フォールバックは、役割テンプレと役割別 content で置き換えて廃止する。
+
+露天の地物(祠・キャンプ跡・集落)は部屋も役割も持たないので骨格層を持たず、風味層だけで生成する。ここは純 content が正しく、意味の破綻も起きない。
 
 ### content 層を「テーマ」で引けるようにする
 
@@ -141,7 +161,8 @@ func FurnishScene(seed uint64, origin Vec, theme Theme) []Placed
 
 | ファイル | 変更内容 |
 |---|---|
-| `internal/mapplanner/interior/content_catalog.go` | `FacilityKind` 引きの content 分岐を `Theme` 引きへ一般化する。`contentFor(Theme)` を追加し、既存の施設別 content をテーマとして束ねる |
+| `internal/mapplanner/interior/content_catalog.go` | `FacilityKind` 引きの content 分岐を `Theme` 引きへ一般化する。`contentFor(Theme)` を追加し、既存の施設別 content をテーマとして束ねる。`genericContent` の樽フォールバックを役割別 content で置き換えて廃止する |
+| `internal/mapplanner/interior/furnish.go` の役割割当 | テンプレの各部屋に役割タグを持たせ、RoomReq 照合で役割別 content を流す。寝室→寝具、台所→食料。未分類が樽へ落ちる経路を断つ |
 | `internal/mapplanner/interior/furnish.go` | テーマを受ける `FurnishByTheme` を公開する。既存 `FurnishBuilding` はテーマの一種として薄く包む |
 | `internal/mapplanner/interior/content.go` | 露天向けに `FurnishScene(seed, origin, theme) []Placed` を足す。Room を持たず origin 相対で抽選・配置し、部屋充填を通さない |
 | `internal/overworld/landmark.go` | 廃屋・農家跡は `drawHut` の外殻＋テーマ content 充填へ。祠・キャンプ跡は scene 束へ。固定 prop リストを撤去する |
@@ -154,28 +175,37 @@ func FurnishScene(seed uint64, origin Vec, theme Theme) []Placed
 - **全ランドマークを `FurnishBuilding` へ通す**。却下。祠・キャンプ跡は footprint を持たない露天で、部屋分割・到達性ガード・間取りテンプレが無意味。有界の小屋にだけ部屋充填を使い、露天は Satellites の scene に留める。
 - **テーマを外部ファイルの DSL にする**。却下。既存 content は Go 関数で `Content` を返す書き方に統一されている。原野のためだけに別記法を足すと二重管理になる。content 仕様は Go で書く現状に揃える。
 - **生成結果をセーブへ焼き込む**。却下。オーバーワールドは seed から都度再生成し、決定性で再訪一致を保証している。焼き込みは serde 対象を増やし整合を壊す。seed 固定の再生成を維持する。
+- **純 content 抽選だけで部屋の意味を出す**。却下。部屋の役割を知らないまま密度場で置くと「タルだらけの家」になる。今の `genericContent` の樽フォールバックがその実例。意味の強い施設は役割テンプレを骨格に持ち、content はスロットを埋める二層にする。抽選だけで整合を出そうとしない。
+- **prefab / 役割テンプレを全廃して content 一本にする**。却下。prefab でしか表現できない空間的・意味的整合がある。テンプレは骨格として残し、content と補完させる。固定レイアウトの直書きだけをやめ、テンプレそのものは捨てない。
 - **集落は固定 NPC/prop リストのまま残す**。却下。集落は世界に点在し面積の印象を左右するので、ここだけ固定生成だと content システムへ寄せた意味が薄れる。content は敵・エンティティを既に扱えるので NPC も載る。全施設を1つのパイプラインへ寄せ、固定生成を残さない。
 
 ## コメント
 
-- 本 doc の芯は新機構でなく、`interior` の既存 content 層を全施設へ配線し直すことにある。深さの非対称、街は content システム・原野は固定描画、を解消し、生成経路を1つに畳む。
-- 有界の建物と露天の scene で使う機構を分ける。建物は部屋充填の全段、露天のランドマーク・集落は抽選と Satellites だけ。過剰適用を避ける線引きが設計の要。
-- 段階で切る。第一段でテーマの一般化と小屋の部屋充填、第二段で露天の scene、第三段で集落を同じ scene 経路へ。各段で golden を撮り直し、決定性テストを課す。最終的に固定生成の直書きは残さない。
+- 本 doc の芯は新機構でなく、`interior` の既存の骨格層(役割テンプレ)と風味層(content)を全施設へ配線し直すことにある。深さの非対称、街は二層生成・原野は固定描画、を解消する。
+- 骨格層と風味層の責務を混ぜない。骨格が部屋の役割と空間を保証し、風味がスロットの変化を与える。片方だけだとワンパターンか意味の破綻に倒れる。RoomReq の役割マッチが二層をつなぐ要。
+- 有界の建物と露天で使う機構を分ける。建物は骨格層＋部屋充填、露天のランドマーク・集落は骨格を持たず風味層(抽選と Satellites)だけ。過剰適用を避ける線引きが設計の要。
+- 段階で切る。第1段で骨格の役割マッチと樽フォールバック廃止、第2段でテーマ一般化と小屋の部屋充填、第3段で露天の scene、第4段で集落を同じ scene 経路へ。各段で golden を撮り直し、決定性テストを課す。最終的に固定生成の直書きは残さない。
 - 着手は人の判断が要る。content 層の公開境界をどこに引くか、NPC を content の抽選へどう載せるかは、実装前に interior の保守方針と擦り合わせる。
 
 ## 進捗
 
-第1段 テーマ一般化と小屋の部屋充填
+第1段 骨格の役割マッチと樽フォールバック廃止
+
+- [ ] テンプレの各部屋に役割タグを持たせ、RoomReq 照合で役割別 content を流す
+- [ ] `genericContent` の樽フォールバックを役割別 content で置き換えて廃止する
+- [ ] `classifyRoom` の逆推定で役割どおりに見えるかを golden 前に検証する
+
+第2段 テーマ一般化と小屋の部屋充填
 
 - [ ] `interior` の content 引きを `Theme` へ一般化し、`contentFor(Theme)` と `FurnishByTheme` を公開する
 - [ ] 既存 `FurnishBuilding` を `FurnishByTheme` の薄い包みへ寄せ、施設生成の挙動を不変に保つ
 - [ ] 廃屋・農家跡テーマの `Content` 仕様を書き、`drawHut` の外殻＋content 充填へ差し替える
 - [ ] ランドマークに同一 seed 一致の決定性テストを課し、golden を撮り直す
 
-第2段 露天の scene 経路
+第3段 露天の scene 経路
 
 - [ ] 露天向けの `FurnishScene` を足し、祠・キャンプ跡を scene へ差し替える
 
-第3段 集落
+第4段 集落
 
 - [ ] 集落の村/一軒家の固定 NPC/prop リストを撤去し、同じ scene 経路へ寄せる

--- a/docs/design/260823165936.md
+++ b/docs/design/260823165936.md
@@ -67,9 +67,9 @@ func contentFor(t Theme) Content
 func abandonedHutContent() Content {
 	return Content{
 		Groups: []Group{
-			{Style: PickEach, Items: []Stuff{ // 廃屋を廃屋たらしめる保証枠
-				{Ref: "bed", Chance: 70},
-				{Ref: "closet", Chance: 60},
+			{Style: PickEach, Items: []Stuff{ // 廃屋を廃屋たらしめる保証枠。Chance 0 は常置
+				{Ref: "bed", Chance: 0},
+				{Ref: "closet", Chance: 0},
 			}},
 			{Style: PickN, Pick: 2, Items: []Stuff{ // 生活の残骸を2つ抽選
 				{Ref: "barrel", Weight: 2},
@@ -81,6 +81,8 @@ func abandonedHutContent() Content {
 	}
 }
 ```
+
+保証枠は `Chance: 0` の常置にし、廃屋らしさを確実に担保する。`PickEach` の `Chance` は 0..100 の欠落確率なので、ここに確率を入れると保証にならない。家具が失われた廃墟感は `Chance` でなく後段の Age の層で表現し、保証枠と廃墟化の責務を分ける。
 
 ### 有界の小屋は部屋充填を再利用する
 
@@ -100,21 +102,20 @@ _, placed := interior.FurnishByTheme(seed, footprint, door, themeAbandonedHut)
 
 ### 露天は Satellites の scene で埋める
 
-祠とキャンプ跡は footprint も扉も持たない露天で、部屋充填は通さない。interior の flavor machine が持つ **scene = Satellites の束**、「蝋燭の輪のような scene を束で置く」、を露天テーマとして使う。anchor を基準に相対 prop を束ねる Satellite は、今の `relSpot` の固定並びの上位互換になる。
+祠とキャンプ跡は footprint も扉も持たない露天で、部屋充填は通さない。interior の flavor machine が持つ **scene = Satellites の束**、「蝋燭の輪のような scene を束で置く」、を露天テーマとして使う。anchor を基準に相対 prop を束ねる考え方は、今の `relSpot` の固定並びの上位互換になる。
+
+ただし既存の `Satellite`(`content.go`) は `FillRoom` の文脈内で anchor を解決する型で、外から座標を渡す口を持たない。露天は `Room` を持たないので、そのまま使えない。**露天用に、anchor 座標と Satellites 仕様を受けて `[]Placed` を返す薄い関数を新設する**。入力と出力の型を明示する。
 
 ```go
-// 祠テーマの scene。石柱を anchor に蝋燭を相対配置する束。数と向きを seed で揺らす。
-func shrineScene() []Satellite {
-	return []Satellite{
-		{Anchor: "stone_pillar", Around: []Stuff{
-			{Ref: "candle", Weight: 2},
-			{Ref: "offering", Weight: 1},
-		}},
-	}
-}
+// interior に新設する露天用の配置口。footprint も Room も持たず、origin を anchor 基準として
+// Satellites 仕様を抽選・配置し Placed を返す。到達性ガードや部屋分割は通さない。
+func FurnishScene(seed uint64, origin Vec, theme Theme) []Placed
+
+// 祠テーマの scene 仕様。石柱を anchor に蝋燭・供物を相対配置する束。数と向きを seed で揺らす。
+// 仕様の型は既存 content の抽選語彙(Group/Stuff)に合わせ、露天では Room 配置でなく origin 相対で解決する。
 ```
 
-露天は到達性ガードや部屋分割を要さないので、content 層のうち抽選と Satellites 配置だけを使う薄い経路を通す。
+露天は到達性ガードや部屋分割を要さないので、content 層のうち抽選と相対配置だけを使う。`FurnishScene` の具体的な内部型と、既存 `Satellite` を露天へ流用するか新型を足すかは実装前に interior 保守者と決める。
 
 ### 決定性と分類の維持
 
@@ -128,13 +129,21 @@ func shrineScene() []Satellite {
 
 これで街の建物・ランドマーク・集落が同じ content パイプラインを共有し、固定生成は残らない。
 
+### 実装前に決める点
+
+`needs-decision` の具体は次の3点。実装着手前に interior 保守者と擦り合わせる。
+
+- **外殻の乱数と content の seed の整理**。`drawHut` は今 `*rand.Rand` を受けて南辺の扉 X を引く。content 充填は seed の `uint64` を受ける口になるので、外殻の扉抽選も `childSeed` から導いた seed へ寄せ、乱数器の持ち回りをやめる。外殻と内装で seed 分岐をどう割るかを決める。
+- **公開境界**。`FurnishByTheme` を公開するなら `Theme` 型も公開になる。テーマ定数を interior 側に置いて公開するか、landmark 側が content を interior へ登録するかを決める。`contentFor` を内部に留めるなら landmark からテーマをどう指すかも合わせて決める。
+- **Age の damage をテーマで制御する**。`Age` の強度は `buildingProfile.damage` で決まり、`rollProfile` が seed から無作為に引く。廃屋テーマを渡しても毎回 `dmgMajor` にならないので、テーマが profile の damage を上書きできるようにするか、テーマ別に damage 下限を持たせるかを決める。
+
 ## 変更箇所
 
 | ファイル | 変更内容 |
 |---|---|
 | `internal/mapplanner/interior/content_catalog.go` | `FacilityKind` 引きの content 分岐を `Theme` 引きへ一般化する。`contentFor(Theme)` を追加し、既存の施設別 content をテーマとして束ねる |
 | `internal/mapplanner/interior/furnish.go` | テーマを受ける `FurnishByTheme` を公開する。既存 `FurnishBuilding` はテーマの一種として薄く包む |
-| `internal/mapplanner/interior/content.go` | 露天向けに Satellites だけを使う薄い scene 配置経路を足す。部屋充填を要さない |
+| `internal/mapplanner/interior/content.go` | 露天向けに `FurnishScene(seed, origin, theme) []Placed` を足す。Room を持たず origin 相対で抽選・配置し、部屋充填を通さない |
 | `internal/overworld/landmark.go` | 廃屋・農家跡は `drawHut` の外殻＋テーマ content 充填へ。祠・キャンプ跡は scene 束へ。固定 prop リストを撤去する |
 | `internal/overworld/settlement.go` | 村・一軒家の固定 NPC/prop リストを撤去し、テーマ content の scene 束から NPC と prop を配置する |
 | `internal/overworld/landmark_test.go` | 内装が変動しても同一 seed で一致する決定性テストを課す |
@@ -156,9 +165,17 @@ func shrineScene() []Satellite {
 
 ## 進捗
 
+第1段 テーマ一般化と小屋の部屋充填
+
 - [ ] `interior` の content 引きを `Theme` へ一般化し、`contentFor(Theme)` と `FurnishByTheme` を公開する
 - [ ] 既存 `FurnishBuilding` を `FurnishByTheme` の薄い包みへ寄せ、施設生成の挙動を不変に保つ
 - [ ] 廃屋・農家跡テーマの `Content` 仕様を書き、`drawHut` の外殻＋content 充填へ差し替える
-- [ ] 露天向けの Satellites scene 経路を足し、祠・キャンプ跡を scene 束へ差し替える
 - [ ] ランドマークに同一 seed 一致の決定性テストを課し、golden を撮り直す
-- [ ] 集落の村/一軒家の固定 NPC/prop リストを撤去し、テーマ content の scene 束へ寄せる
+
+第2段 露天の scene 経路
+
+- [ ] 露天向けの `FurnishScene` を足し、祠・キャンプ跡を scene へ差し替える
+
+第3段 集落
+
+- [ ] 集落の村/一軒家の固定 NPC/prop リストを撤去し、同じ scene 経路へ寄せる


### PR DESCRIPTION
## 概要

設計ドキュメント `docs/design/260823165936.md` を追加する。実装は含まない。

原野の点在ランドマーク `landmark.go` と集落 `settlement.go` が固定レイアウト・固定リストのワンパターンで生成される一方、街の建物は `internal/mapplanner/interior` の content システム、抽選 Content/Group/Style・placement・Satellites・Age・flavor、で「設計されたもの」として生成している。この深さの非対称を解消し、ランドマークと集落を既存の content システムへ寄せる方針を起こす。

## 設計の骨子

- content 引きを `FacilityKind` から `Theme` へ一般化し、`contentFor(Theme)` / `FurnishByTheme` を公開する。`FacilityKind` はテーマの一種になる。
- 有界の小屋、廃屋・農家跡、は `drawHut` の外殻＋部屋充填を再利用する。固定 `[bed,closet]` を保証枠＋風味抽選の `Content` へ置き換え、Age で廃墟化も掛かる。
- 露天、祠・キャンプ跡、は Satellites の scene 束を使う。部屋分割・間取りテンプレは通さない。
- 決定性は `childSeed` で担保し、同一 seed 一致テストを課す。
- 集落は第一段では見送り、後段の候補として要件に残す。

## 線引き

露天を BSP や間取りテンプレへ通さない、interior の全機構を持ち込まない、外部 DSL や新パッケージを増やさない、生成をセーブへ焼き込まない。過剰適用を避ける線引きを Anti 要件と採用しなかった方法に明記した。

## 状態

- `status: draft` / `auto: needs-decision`。content 層の公開境界と露天 scene の範囲は実装前に interior の保守方針と擦り合わせる必要がある。
- `make generate` 済み。README の設計ドキュメント一覧に反映。

🤖 Generated with [Claude Code](https://claude.com/claude-code)