### PR TITLE
VRT の ebiten 画像操作をゲームスレッドへ寄せ race-check の flaky を断つ

### DIFF
--- a/internal/states/golden_replay_test.go
+++ b/internal/states/golden_replay_test.go
@@ -2,6 +2,7 @@ package states_test
 
 import (
 	"fmt"
+	"image"
 	"testing"
 
 	gc "github.com/kijimaD/ruins/internal/components"
@@ -19,7 +20,6 @@ import (
 	"github.com/kijimaD/ruins/internal/world/lifecycle"
 	"github.com/kijimaD/ruins/internal/world/query"
 
-	"github.com/hajimehoshi/ebiten/v2"
 	"github.com/stretchr/testify/require"
 )
 
@@ -476,7 +476,7 @@ func TestGolden(t *testing.T) {
 					return built
 				},
 				actions,
-				func(frame int, _ w.World, screen *ebiten.Image) {
+				func(frame int, _ w.World, img *image.NRGBA) {
 					// フレーム f は steps[f] の action を適用した直後の画。カーソル移動や
 					// タブ送りは同一フレームで効くのでその手で撮る。state を push する手は
 					// 次フレームで反映されるので、末尾に待ち手を足してそこで撮る。
@@ -488,7 +488,7 @@ func TestGolden(t *testing.T) {
 					if suffix := tc.steps[frame].suffix; suffix != "" {
 						name += "_" + suffix
 					}
-					vrt.AssertFrameGolden(t, name, screen)
+					vrt.AssertFrameGolden(t, name, img)
 				},
 			)
 		})

--- a/internal/vrt/golden.go
+++ b/internal/vrt/golden.go
@@ -30,6 +30,31 @@ func WithUILock(fn func()) {
 	fn()
 }
 
+// uiJobs は ebiten の画像操作をゲームループの goroutine へ渡すキュー。testHostGame.Update が
+// 毎フレーム drain する。ebiten は画像操作をフレーム同期の内側でのみ安全に扱えるため、テスト
+// goroutine から直接 NewImage/Draw/ReadPixels/Deallocate を呼ぶと ebiten の描画スレッドと競合する。
+var uiJobs = make(chan func())
+
+// RunOnGameThread は fn をゲームループの goroutine で実行し、完了を待つ。ebiten の画像操作を
+// フレーム同期の内側へ寄せ、描画スレッドとのデータレースを構造的に無くす。
+//
+// fn には ebiten の画像操作だけを入れる。require や t.Fatal のような runtime.Goexit する処理を
+// 入れてはならない。Goexit はゲームループの goroutine を殺し RunGame ごと落とす。検証は呼び出し側の
+// テスト goroutine で行う。fn の panic は回収してテスト goroutine 側で再送出する。
+//
+// WithUILock 区間の中から呼ぶこと。ebitenui グローバルに触れる描画は、呼び出し側が保持する
+// ebitenuiMu で他テストと直列化される。fn の中で RunOnGameThread を再帰呼び出ししてはならない。
+func RunOnGameThread(fn func()) {
+	done := make(chan any, 1)
+	uiJobs <- func() {
+		defer func() { done <- recover() }()
+		fn()
+	}
+	if p := <-done; p != nil {
+		panic(p)
+	}
+}
+
 // readScreen はebiten.Imageのピクセルデータを読み取りimage.NRGBAとして返す。解放はしない。
 // 呼び出し側が所有する画像を渡されるときはこちらを使う
 func readScreen(screen *ebiten.Image) *image.NRGBA {
@@ -57,16 +82,18 @@ func AssertContainerGolden(t *testing.T, buildFn func() *widget.Container, width
 	var img *image.NRGBA
 	WithUILock(func() {
 		root := buildFn()
-		ui := &ebitenui.UI{Container: root}
-		screen := ebiten.NewImage(width, height)
-
-		// レイアウト確定のため数フレーム回す
-		for range 3 {
-			ui.Update()
-		}
-		ui.Draw(screen)
-
-		img = captureScreen(screen)
+		// 画像操作はゲームループのスレッドで行う。widget 構築は ebitenuiMu 下のこのテスト
+		// スレッドで済ませ、描画と読み取りだけを寄せる
+		RunOnGameThread(func() {
+			ui := &ebitenui.UI{Container: root}
+			screen := ebiten.NewImage(width, height)
+			// レイアウト確定のため数フレーム回す
+			for range 3 {
+				ui.Update()
+			}
+			ui.Draw(screen)
+			img = captureScreen(screen)
+		})
 	})
 
 	pngData := encodePNG(t, img)
@@ -82,23 +109,38 @@ func AssertScreenGolden(t *testing.T, setupFn func() func(screen *ebiten.Image),
 	var img *image.NRGBA
 	WithUILock(func() {
 		drawFn := setupFn()
-		screen := ebiten.NewImage(width, height)
-		drawFn(screen)
-		img = captureScreen(screen)
+		RunOnGameThread(func() {
+			screen := ebiten.NewImage(width, height)
+			drawFn(screen)
+			img = captureScreen(screen)
+		})
 	})
 
 	pngData := encodePNG(t, img)
 	assertPNGGolden(t, t.Name(), pngData)
 }
 
-// AssertFrameGolden は描画済みの screen を name のゴールデン画像 testdata/name.png と比較する。
-// 再生ドライバが各フレームで撮った画をそのまま渡す用途で、レイアウトも描画も呼び出し側が済ませている。
-// state の組み立てと駆動は replay.PlayScenario が担う。GOLDIE_UPDATE=1 で更新する。
-//
-// screen は読むだけで解放しない。所有権は渡した側にある
-func AssertFrameGolden(t *testing.T, name string, screen *ebiten.Image) {
+// AssertFrameGolden は読み取り済みの画像を name のゴールデン画像 testdata/name.png と比較する。
+// 再生ドライバが各フレームでゲームスレッド上で読み取った画をそのまま渡す用途。ebiten 画像の
+// 読み取りは PlayScenario がゲームスレッドで済ませ、このヘルパはエンコードと比較だけを行う。
+// GOLDIE_UPDATE=1 で更新する。
+func AssertFrameGolden(t *testing.T, name string, img *image.NRGBA) {
 	t.Helper()
-	assertPNGGolden(t, name, encodePNG(t, readScreen(screen)))
+	assertPNGGolden(t, name, encodePNG(t, img))
+}
+
+// CaptureFrame は width×height の画像を作り draw で描いて画素を読み取り image.NRGBA で返す。
+// NewImage・描画・ReadPixels・Deallocate をゲームループのスレッドで行い、ebiten の描画スレッドとの
+// データレースを避ける。返す画像は plain な画素データなので、比較・検証は呼び出し側のテスト
+// goroutine で安全に行える。WithUILock 区間の中から呼ぶこと。
+func CaptureFrame(width, height int, draw func(screen *ebiten.Image)) *image.NRGBA {
+	var img *image.NRGBA
+	RunOnGameThread(func() {
+		screen := ebiten.NewImage(width, height)
+		draw(screen)
+		img = captureScreen(screen)
+	})
+	return img
 }
 
 // encodePNG はimage.Imageをpngバイト列にエンコードする

--- a/internal/vrt/replay/main_test.go
+++ b/internal/vrt/replay/main_test.go
@@ -1,0 +1,15 @@
+package replay_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/kijimaD/ruins/internal/vrt"
+)
+
+// TestMain は ebiten ゲームループの中で replay パッケージのテストを走らせる。PlayScenario は
+// フレームを描いて画素を読むため ebiten の描画コンテキストが要り、画像操作を vrt.RunOnGameThread で
+// ゲームループのスレッドへ寄せる。ループが無いと RunOnGameThread が drain されずデッドロックする。
+func TestMain(m *testing.M) {
+	os.Exit(vrt.RunTestMain(m))
+}

--- a/internal/vrt/replay/replay.go
+++ b/internal/vrt/replay/replay.go
@@ -7,6 +7,7 @@
 package replay
 
 import (
+	"image"
 	"testing"
 
 	"github.com/hajimehoshi/ebiten/v2"
@@ -37,7 +38,7 @@ func PlayScenario(
 	t *testing.T,
 	buildStates func(w.World) []es.State[w.World],
 	actions []inputmapper.ActionID,
-	capture func(frame int, world w.World, screen *ebiten.Image),
+	capture func(frame int, world w.World, img *image.NRGBA),
 ) *maingame.MainGame {
 	t.Helper()
 	world := vrt.InitVRTWorld(t)
@@ -61,10 +62,10 @@ func PlayScenario(
 			if capture == nil {
 				continue
 			}
-			screen := ebiten.NewImage(consts.GameWidth, consts.GameHeight)
-			game.Draw(screen)
-			capture(frame, world, screen)
-			screen.Deallocate()
+			// 画像操作はゲームスレッドで行って読み取った画を capture へ渡す。capture はテスト
+			// goroutine で走るので require 等の検証を安全に行える
+			img := vrt.CaptureFrame(consts.GameWidth, consts.GameHeight, game.Draw)
+			capture(frame, world, img)
 		}
 	})
 	return game

--- a/internal/vrt/replay/replay_test.go
+++ b/internal/vrt/replay/replay_test.go
@@ -1,9 +1,9 @@
 package replay_test
 
 import (
+	"image"
 	"testing"
 
-	"github.com/hajimehoshi/ebiten/v2"
 	"github.com/kijimaD/ruins/internal/dungeon"
 	es "github.com/kijimaD/ruins/internal/engine/states"
 	"github.com/kijimaD/ruins/internal/inputmapper"
@@ -52,9 +52,9 @@ func TestPlayScenario_captureが各フレームで呼ばれる(t *testing.T) {
 			inputmapper.ActionMenuDown,
 			inputmapper.ActionMenuUp,
 		},
-		func(frame int, _ w.World, screen *ebiten.Image) {
+		func(frame int, _ w.World, img *image.NRGBA) {
 			assert.Equal(t, frames, frame, "frame は0起点で連番")
-			assert.NotNil(t, screen, "描画先が渡る")
+			assert.NotNil(t, img, "読み取った画が渡る")
 			frames++
 		},
 	)

--- a/internal/vrt/state.go
+++ b/internal/vrt/state.go
@@ -44,9 +44,12 @@ func renderStates(t *testing.T, buildStates func(w.World) []es.State[w.World]) *
 		sm := SetupStateMachine(t, world, buildStates)
 		game, err := maingame.NewMainGame(world, sm)
 		require.NoError(t, err)
-		screen := ebiten.NewImage(consts.GameWidth, consts.GameHeight)
-		game.Draw(screen)
-		out = captureScreen(screen)
+		// 画像操作はゲームループのスレッドで行い、描画スレッドとのレースを避ける
+		RunOnGameThread(func() {
+			screen := ebiten.NewImage(consts.GameWidth, consts.GameHeight)
+			game.Draw(screen)
+			out = captureScreen(screen)
+		})
 	})
 	return out
 }

--- a/internal/vrt/testmain.go
+++ b/internal/vrt/testmain.go
@@ -25,7 +25,17 @@ func (g *testHostGame) Update() error {
 			os.Exit(code)
 		}()
 	}
-	return nil
+	// テスト goroutine が積んだ ebiten 画像操作をこのフレームで実行する。ebiten の画像操作は
+	// フレーム同期の内側でのみ安全なので、RunOnGameThread がここへ寄せる。溜まっている分を
+	// すべて処理してから返す
+	for {
+		select {
+		case job := <-uiJobs:
+			job()
+		default:
+			return nil
+		}
+	}
 }
 
 func (g *testHostGame) Draw(_ *ebiten.Image) {}


### PR DESCRIPTION
## 背景

`race-check` ジョブが稀に data race で落ちていた。原因は VRT テストが**別 goroutine から ebiten の画像操作**（`NewImage`/`Draw`/`ReadPixels`/`Deallocate`）を呼び、ebiten の描画ループ（`RunGame` が回すスレッド）と atlas を並行アクセスしていたこと。`WithUILock` は ebitenui グローバルを直列化するだけで、ebiten の描画ループはゲートしない。

レーススタックは全フレームが `ebiten/v2/internal/atlas` と `internal/vrt` で、`atlas.allocate`(描画スレッドの `BeginFrame`) ↔ `atlas.Deallocate`(テスト goroutine) の競合だった。

## 修正

`RunOnGameThread` を追加し、ebiten の画像操作を **game ループの goroutine（フレーム同期の内側）** で実行する。ebiten は Update/Draw 内の画像操作を描画スレッドと同期するので、ここへ寄せれば競合が構造的に消える。

- `require`/`t.Fatal` は `runtime.Goexit` でループ goroutine を殺すため、テスト goroutine 側に残す。ゲームスレッドへ渡すのは純粋な画像操作だけ。
- `CaptureFrame` が NewImage→Draw→ReadPixels→Deallocate をゲームスレッドで行い、読み取り済み `image.NRGBA` を返す。`capture` コールバックと `AssertFrameGolden` は `*image.NRGBA` を受ける形へ。
- `renderStates`/`AssertContainerGolden`/`AssertScreenGolden`/`PlayScenario` の画像操作を `RunOnGameThread` 経由に。
- `internal/vrt/replay` は従来 GPU に触れず game ループを持たなかったが、`CaptureFrame` が `ReadPixels` を必須にしたため `TestMain`(`RunTestMain`) を追加。無いと `RunOnGameThread` が drain されずデッドロックする。

## 検証

100% は構造で担保し、実測で裏取りした。

- **構造**: 全 ebiten 画像操作がフレーム同期の内側で走るので、Deallocate↔allocate の競合経路が存在しない。
- **実測**: `-race -shuffle=on` を states golden 経路で **×6 反復 → 全緑・DATA RACE ゼロ**。全体 `make test RACE=-race`（race-check と同一）→ **exit 0**、`vrt/replay` は60分タイムアウトから19秒完走へ。
- `make check`（build・lint・test・脆弱性）exit 0。

🤖 Generated with [Claude Code](https://claude.com/claude-code)