### PR TITLE
test(world/query): カバレッジ増強

### DIFF
--- a/internal/world/query/auction_test.go
+++ b/internal/world/query/auction_test.go
@@ -22,7 +22,6 @@ func TestAuctionShippingCost_重量に比例した送料を返す(t *testing.T) 
 	t.Parallel()
 	world := testutil.InitTestWorld(t)
 
-	// 2kgの品。1kgあたり25なので送料は50
 	item := world.ECS.NewEntity()
 	world.Components.Weight.Add(item, &gc.Weight{Milligram: consts.Milligram(2 * consts.MilligramPerKg)})
 
@@ -44,7 +43,6 @@ func TestAuctionOpeningBid_基準価値の分散範囲内に収まる(t *testing
 	item := world.ECS.NewEntity()
 	world.Components.Value.Add(item, &gc.Value{Value: 1000})
 
-	// 基準価値1000 * 0.4 = 400。分散は0.8〜1.2倍なので320〜480に収まる
 	for range 20 {
 		bid := AuctionOpeningBid(world, item)
 		assert.GreaterOrEqual(t, bid, consts.Currency(320))
@@ -61,7 +59,6 @@ func TestAuctionRaise(t *testing.T) {
 		item := world.ECS.NewEntity()
 		world.Components.Value.Add(item, &gc.Value{Value: 1000})
 
-		// 基準価値1000 * 0.15 = 150。分散は0.8〜1.2倍なので120〜180に収まる
 		for range 20 {
 			raise := AuctionRaise(world, item)
 			assert.GreaterOrEqual(t, raise, consts.Currency(120))

--- a/internal/world/query/auction_test.go
+++ b/internal/world/query/auction_test.go
@@ -1,0 +1,238 @@
+package query
+
+import (
+	"testing"
+
+	gc "github.com/kijimaD/ruins/internal/components"
+	"github.com/kijimaD/ruins/internal/consts"
+	"github.com/kijimaD/ruins/internal/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAuctionFee_落札額に比例した手数料を返す(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, consts.Currency(0), AuctionFee(0), "落札額0なら手数料も0")
+	assert.Equal(t, consts.Currency(12), AuctionFee(100), "12%の手数料")
+	assert.Equal(t, consts.Currency(120), AuctionFee(1000))
+}
+
+func TestAuctionShippingCost_重量に比例した送料を返す(t *testing.T) {
+	t.Parallel()
+	world := testutil.InitTestWorld(t)
+
+	// 2kgの品。1kgあたり25なので送料は50
+	item := world.ECS.NewEntity()
+	world.Components.Weight.Add(item, &gc.Weight{Milligram: consts.Milligram(2 * consts.MilligramPerKg)})
+
+	assert.Equal(t, consts.Currency(50), AuctionShippingCost(world, item))
+}
+
+func TestAuctionShippingCost_重量が無ければ送料0(t *testing.T) {
+	t.Parallel()
+	world := testutil.InitTestWorld(t)
+
+	item := world.ECS.NewEntity()
+	assert.Equal(t, consts.Currency(0), AuctionShippingCost(world, item))
+}
+
+func TestAuctionOpeningBid_基準価値の分散範囲内に収まる(t *testing.T) {
+	t.Parallel()
+	world := testutil.InitTestWorld(t)
+
+	item := world.ECS.NewEntity()
+	world.Components.Value.Add(item, &gc.Value{Value: 1000})
+
+	// 基準価値1000 * 0.4 = 400。分散は0.8〜1.2倍なので320〜480に収まる
+	for range 20 {
+		bid := AuctionOpeningBid(world, item)
+		assert.GreaterOrEqual(t, bid, consts.Currency(320))
+		assert.LessOrEqual(t, bid, consts.Currency(480))
+	}
+}
+
+func TestAuctionRaise(t *testing.T) {
+	t.Parallel()
+	world := testutil.InitTestWorld(t)
+
+	t.Run("基準価値が大きい場合は分散範囲内", func(t *testing.T) {
+		t.Parallel()
+		item := world.ECS.NewEntity()
+		world.Components.Value.Add(item, &gc.Value{Value: 1000})
+
+		// 基準価値1000 * 0.15 = 150。分散は0.8〜1.2倍なので120〜180に収まる
+		for range 20 {
+			raise := AuctionRaise(world, item)
+			assert.GreaterOrEqual(t, raise, consts.Currency(120))
+			assert.LessOrEqual(t, raise, consts.Currency(180))
+		}
+	})
+
+	t.Run("基準価値が0でも最低1を保証する", func(t *testing.T) {
+		t.Parallel()
+		item := world.ECS.NewEntity()
+
+		raise := AuctionRaise(world, item)
+		assert.Equal(t, consts.Currency(1), raise, "価値0でも上げ幅は最低1")
+	})
+}
+
+func TestGetAuctionHistory_InitWorldで初期状態を取得できる(t *testing.T) {
+	t.Parallel()
+	world := testutil.InitTestWorld(t)
+
+	history := GetAuctionHistory(world)
+	require.NotNil(t, history)
+	assert.Equal(t, 0, history.NextNumber)
+	assert.Empty(t, history.Entries)
+	assert.Empty(t, history.Records)
+}
+
+func TestStartAuctionListing_採番して開始入札のタグを貼る(t *testing.T) {
+	t.Parallel()
+	world := testutil.InitTestWorld(t)
+
+	item1 := world.ECS.NewEntity()
+	world.Components.Value.Add(item1, &gc.Value{Value: 100})
+	item2 := world.ECS.NewEntity()
+	world.Components.Value.Add(item2, &gc.Value{Value: 100})
+
+	number1 := StartAuctionListing(world, item1, 10)
+	number2 := StartAuctionListing(world, item2, 20)
+
+	assert.Equal(t, 1, number1, "最初の出品は1番")
+	assert.Equal(t, 2, number2, "2件目は連番で2番")
+
+	require.True(t, world.Components.AuctionListing.Has(item1))
+	listing1 := world.Components.AuctionListing.Get(item1)
+	assert.Equal(t, 1, listing1.Number)
+	assert.Equal(t, 10, listing1.LastTurn)
+	assert.Positive(t, listing1.CurrentBid, "開始入札は正の額")
+
+	assert.Equal(t, 2, GetAuctionHistory(world).NextNumber, "履歴の採番カウンタも進む")
+}
+
+func TestCollectStagedItems_積荷が空なら何も集荷しない(t *testing.T) {
+	t.Parallel()
+	world := testutil.InitTestWorld(t)
+
+	station := world.ECS.NewEntity()
+
+	collected, receipts := CollectStagedItems(world, station)
+
+	assert.Equal(t, 0, collected)
+	assert.Equal(t, 0, receipts)
+	assert.Empty(t, GetAuctionHistory(world).Entries, "明細も増えない")
+}
+
+func TestCollectStagedItems_落札済みと未落札を集荷して明細をためる(t *testing.T) {
+	t.Parallel()
+	world := testutil.InitTestWorld(t)
+
+	station := world.ECS.NewEntity()
+
+	// 落札済みの品。受取金の明細を1件生む
+	sold := world.ECS.NewEntity()
+	world.Components.Name.Add(sold, &gc.Name{Name: "落札品"})
+	world.Components.LocationInStorage.Add(sold, &gc.LocationInStorage{Owner: station})
+	world.Components.AuctionSold.Add(sold, &gc.AuctionSold{Number: 1, Bid: 1000})
+
+	// 未落札のまま積荷にある品。明細を生まず、ただ手放される
+	unsold := world.ECS.NewEntity()
+	world.Components.LocationInStorage.Add(unsold, &gc.LocationInStorage{Owner: station})
+
+	collected, receipts := CollectStagedItems(world, station)
+
+	assert.Equal(t, 2, collected, "積荷2件をまとめて集荷")
+	assert.Equal(t, 1, receipts, "受取金の明細は落札済みの1件だけ")
+	assert.False(t, world.ECS.Alive(sold), "集荷した品は消える")
+	assert.False(t, world.ECS.Alive(unsold), "未落札の品も消える")
+
+	history := GetAuctionHistory(world)
+	require.Len(t, history.Entries, 2, "受取金1件+集荷料金の請求1件")
+	assert.Equal(t, gc.AuctionEntryReceipt, history.Entries[0].Kind)
+	assert.Equal(t, consts.Currency(1000), history.Entries[0].Bid)
+	assert.Equal(t, gc.AuctionEntryInvoice, history.Entries[1].Kind)
+	assert.Equal(t, AuctionPickupFee, history.Entries[1].Amount, "集荷料金は集荷1回につき定額")
+}
+
+func TestSettleAuctionEntry(t *testing.T) {
+	t.Parallel()
+	world := testutil.InitTestWorld(t)
+
+	player := world.ECS.NewEntity()
+	world.Components.Wallet.Add(player, &gc.Wallet{Currency: 0})
+
+	t.Run("負のインデックス", func(t *testing.T) {
+		t.Parallel()
+		_, ok := SettleAuctionEntry(world, player, -1, 0)
+		assert.False(t, ok)
+	})
+
+	t.Run("要素数以上のインデックス", func(t *testing.T) {
+		t.Parallel()
+		_, ok := SettleAuctionEntry(world, player, 0, 0)
+		assert.False(t, ok, "明細が空なので0番目も範囲外")
+	})
+}
+
+func TestSettleAuctionEntry_受取金は所持金へ加え実績へ移す(t *testing.T) {
+	t.Parallel()
+	world := testutil.InitTestWorld(t)
+
+	player := world.ECS.NewEntity()
+	world.Components.Wallet.Add(player, &gc.Wallet{Currency: 100})
+
+	history := GetAuctionHistory(world)
+	history.Entries = append(history.Entries, gc.AuctionEntry{
+		Kind: gc.AuctionEntryReceipt, Number: 1, Name: "売れた品", Amount: 500, Bid: 600, Ship: 50, Fee: 50,
+	})
+
+	entry, ok := SettleAuctionEntry(world, player, 0, 42)
+
+	require.True(t, ok)
+	assert.Equal(t, consts.Currency(500), entry.Amount)
+	assert.Equal(t, consts.Currency(600), GetCurrency(world, player), "受取金が所持金へ加わる")
+	assert.Empty(t, history.Entries, "精算した明細は取り除かれる")
+	require.Len(t, history.Records, 1, "出荷実績へ1件移る")
+	assert.Equal(t, 42, history.Records[0].Turn)
+	assert.Equal(t, consts.Currency(500), history.Records[0].Net)
+}
+
+func TestSettleAuctionEntry_請求は所持金から引く(t *testing.T) {
+	t.Parallel()
+	world := testutil.InitTestWorld(t)
+
+	player := world.ECS.NewEntity()
+	world.Components.Wallet.Add(player, &gc.Wallet{Currency: 300})
+
+	history := GetAuctionHistory(world)
+	history.Entries = append(history.Entries, gc.AuctionEntry{
+		Kind: gc.AuctionEntryInvoice, Name: "集荷料金", Amount: AuctionPickupFee,
+	})
+
+	_, ok := SettleAuctionEntry(world, player, 0, 1)
+
+	require.True(t, ok)
+	assert.Equal(t, consts.Currency(200), GetCurrency(world, player), "請求額が所持金から引かれる")
+	assert.Empty(t, history.Entries)
+	assert.Empty(t, history.Records, "請求は出荷実績に残らない")
+}
+
+func TestSettleAuctionEntry_Walletが無ければ失敗し明細は残る(t *testing.T) {
+	t.Parallel()
+	world := testutil.InitTestWorld(t)
+
+	playerWithoutWallet := world.ECS.NewEntity()
+
+	history := GetAuctionHistory(world)
+	history.Entries = append(history.Entries, gc.AuctionEntry{
+		Kind: gc.AuctionEntryReceipt, Amount: 100,
+	})
+
+	_, ok := SettleAuctionEntry(world, playerWithoutWallet, 0, 0)
+
+	assert.False(t, ok)
+	assert.Len(t, history.Entries, 1, "精算に失敗した明細は取り除かれない")
+}

--- a/internal/world/query/auction_test.go
+++ b/internal/world/query/auction_test.go
@@ -132,13 +132,11 @@ func TestCollectStagedItems_落札済みと未落札を集荷して明細をた�
 
 	station := world.ECS.NewEntity()
 
-	// 落札済みの品。受取金の明細を1件生む
 	sold := world.ECS.NewEntity()
 	world.Components.Name.Add(sold, &gc.Name{Name: "落札品"})
 	world.Components.LocationInStorage.Add(sold, &gc.LocationInStorage{Owner: station})
 	world.Components.AuctionSold.Add(sold, &gc.AuctionSold{Number: 1, Bid: 1000})
 
-	// 未落札のまま積荷にある品。明細を生まず、ただ手放される
 	unsold := world.ECS.NewEntity()
 	world.Components.LocationInStorage.Add(unsold, &gc.LocationInStorage{Owner: station})
 

--- a/internal/world/query/auction_test.go
+++ b/internal/world/query/auction_test.go
@@ -151,10 +151,18 @@ func TestCollectStagedItems_落札済みと未落札を集荷して明細をた�
 
 	history := GetAuctionHistory(world)
 	require.Len(t, history.Entries, 2, "受取金1件+集荷料金の請求1件")
-	assert.Equal(t, gc.AuctionEntryReceipt, history.Entries[0].Kind)
-	assert.Equal(t, consts.Currency(1000), history.Entries[0].Bid)
-	assert.Equal(t, gc.AuctionEntryInvoice, history.Entries[1].Kind)
-	assert.Equal(t, AuctionPickupFee, history.Entries[1].Amount, "集荷料金は集荷1回につき定額")
+
+	var receipt, invoice gc.AuctionEntry
+	for _, e := range history.Entries {
+		switch e.Kind {
+		case gc.AuctionEntryReceipt:
+			receipt = e
+		case gc.AuctionEntryInvoice:
+			invoice = e
+		}
+	}
+	assert.Equal(t, consts.Currency(1000), receipt.Bid)
+	assert.Equal(t, AuctionPickupFee, invoice.Amount, "集荷料金は集荷1回につき定額")
 }
 
 func TestSettleAuctionEntry(t *testing.T) {
@@ -198,6 +206,7 @@ func TestSettleAuctionEntry_受取金は所持金へ加え実績へ移す(t *tes
 	require.Len(t, history.Records, 1, "出荷実績へ1件移る")
 	assert.Equal(t, 42, history.Records[0].Turn)
 	assert.Equal(t, consts.Currency(500), history.Records[0].Net)
+	assert.Equal(t, consts.Currency(500), GetRunStats(world).SalesTotal, "受取金が売上実績へ加わる")
 }
 
 func TestSettleAuctionEntry_請求は所持金から引く(t *testing.T) {

--- a/internal/world/query/danger_test.go
+++ b/internal/world/query/danger_test.go
@@ -3,31 +3,46 @@ package query
 import (
 	"testing"
 
+	"github.com/kijimaD/ruins/internal/testutil"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestDangerLevel(t *testing.T) {
 	t.Parallel()
 
-	t.Run("危険度は1始まりで最小は1", func(t *testing.T) {
+	t.Run("0日目は最小の1", func(t *testing.T) {
 		t.Parallel()
 		assert.Equal(t, 1, dangerLevel(0))
-		assert.Equal(t, 1, dangerLevel(dangerDaysPerLevel-1))
 	})
 
-	t.Run("1段ぶんの日数で危険度が1上がる", func(t *testing.T) {
-		t.Parallel()
-		assert.Equal(t, 2, dangerLevel(dangerDaysPerLevel))
-		assert.Equal(t, 3, dangerLevel(dangerDaysPerLevel*2))
-	})
-
-	t.Run("日数が増えると危険度は下がらない", func(t *testing.T) {
-		t.Parallel()
-		assert.Greater(t, dangerLevel(dangerDaysPerLevel*4), dangerLevel(1))
-	})
-
-	t.Run("負の入力は最小の1を返す", func(t *testing.T) {
+	t.Run("負の日数も1に丸める", func(t *testing.T) {
 		t.Parallel()
 		assert.Equal(t, 1, dangerLevel(-5))
 	})
+
+	t.Run("dangerDaysPerLevel未満はまだ1段目", func(t *testing.T) {
+		t.Parallel()
+		assert.Equal(t, 1, dangerLevel(dangerDaysPerLevel-1))
+	})
+
+	t.Run("dangerDaysPerLevel経過でちょうど1段上がる", func(t *testing.T) {
+		t.Parallel()
+		assert.Equal(t, 2, dangerLevel(dangerDaysPerLevel))
+	})
+
+	t.Run("複数段の経過も比例して上がる", func(t *testing.T) {
+		t.Parallel()
+		assert.Equal(t, 4, dangerLevel(dangerDaysPerLevel*3))
+	})
+}
+
+func TestDangerLevelAt_worldのゲーム内時間から危険度を求める(t *testing.T) {
+	t.Parallel()
+	world := testutil.InitTestWorld(t)
+
+	assert.Equal(t, 1, DangerLevelAt(world), "初期状態は1日目で危険度1")
+
+	// 2500ターン経過は3日目。dangerLevel(3) = 1 + 3/dangerDaysPerLevel = 2
+	GetGameTime(world).TotalTurns = 2500
+	assert.Equal(t, 2, DangerLevelAt(world), "3日目は危険度2")
 }

--- a/internal/world/query/danger_test.go
+++ b/internal/world/query/danger_test.go
@@ -42,7 +42,6 @@ func TestDangerLevelAt_worldのゲーム内時間から危険度を求める(t *
 
 	assert.Equal(t, 1, DangerLevelAt(world), "初期状態は1日目で危険度1")
 
-	// 2500ターン経過は3日目。dangerLevel(3) = 1 + 3/dangerDaysPerLevel = 2
 	GetGameTime(world).TotalTurns = 2500
 	assert.Equal(t, 2, DangerLevelAt(world), "3日目は危険度2")
 }

--- a/internal/world/query/equipment_test.go
+++ b/internal/world/query/equipment_test.go
@@ -12,6 +12,33 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestIsWeapon(t *testing.T) {
+	t.Parallel()
+
+	t.Run("近接コンポーネントを持てば武器", func(t *testing.T) {
+		t.Parallel()
+		world := testutil.InitTestWorld(t)
+		e := world.ECS.NewEntity()
+		world.Components.Melee.Add(e, &gc.Melee{Accuracy: 80, Damage: 5})
+		assert.True(t, query.IsWeapon(world, e))
+	})
+
+	t.Run("射撃コンポーネントを持てば武器", func(t *testing.T) {
+		t.Parallel()
+		world := testutil.InitTestWorld(t)
+		e := world.ECS.NewEntity()
+		world.Components.Fire.Add(e, &gc.Fire{Accuracy: 80, Damage: 5})
+		assert.True(t, query.IsWeapon(world, e))
+	})
+
+	t.Run("どちらも持たなければ武器でない", func(t *testing.T) {
+		t.Parallel()
+		world := testutil.InitTestWorld(t)
+		e := world.ECS.NewEntity()
+		assert.False(t, query.IsWeapon(world, e))
+	})
+}
+
 func TestGetWeapons_Empty(t *testing.T) {
 	t.Parallel()
 

--- a/internal/world/query/name_test.go
+++ b/internal/world/query/name_test.go
@@ -1,0 +1,61 @@
+package query
+
+import (
+	"testing"
+
+	gc "github.com/kijimaD/ruins/internal/components"
+	"github.com/kijimaD/ruins/internal/gamelog"
+	"github.com/kijimaD/ruins/internal/testutil"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetEntityID(t *testing.T) {
+	t.Parallel()
+	world := testutil.InitTestWorld(t)
+
+	t.Run("RawIDを持てばそのIDを返す", func(t *testing.T) {
+		t.Parallel()
+		e := world.ECS.NewEntity()
+		world.Components.RawID.Add(e, &gc.RawID{ID: "sword"})
+		assert.Equal(t, "sword", GetEntityID(e, world))
+	})
+
+	t.Run("RawIDを持たなければ空文字", func(t *testing.T) {
+		t.Parallel()
+		e := world.ECS.NewEntity()
+		assert.Empty(t, GetEntityID(e, world))
+	})
+
+	t.Run("死亡エンティティは空文字", func(t *testing.T) {
+		t.Parallel()
+		e := world.ECS.NewEntity()
+		world.Components.RawID.Add(e, &gc.RawID{ID: "sword"})
+		world.ECS.RemoveEntity(e)
+		assert.Empty(t, GetEntityID(e, world))
+	})
+}
+
+func TestNameMarkup(t *testing.T) {
+	t.Parallel()
+	world := testutil.InitTestWorld(t)
+
+	t.Run("プレイヤーはplayerタグ", func(t *testing.T) {
+		t.Parallel()
+		e := world.ECS.NewEntity()
+		world.Components.Player.Add(e, &gc.Player{})
+		assert.Equal(t, gamelog.Tag("player", "アッシュ"), NameMarkup(e, "アッシュ", world))
+	})
+
+	t.Run("NPCはnpcタグ", func(t *testing.T) {
+		t.Parallel()
+		e := world.ECS.NewEntity()
+		world.Components.SoloAI.Add(e, &gc.SoloAI{})
+		assert.Equal(t, gamelog.Tag("npc", "ゴブリン"), NameMarkup(e, "ゴブリン", world))
+	})
+
+	t.Run("それ以外は裸のテキスト", func(t *testing.T) {
+		t.Parallel()
+		e := world.ECS.NewEntity()
+		assert.Equal(t, "木の板", NameMarkup(e, "木の板", world))
+	})
+}

--- a/internal/world/query/query_test.go
+++ b/internal/world/query/query_test.go
@@ -166,3 +166,47 @@ func TestGetEntitiesAt(t *testing.T) {
 	empty := GetEntitiesAt(world, consts.Tile(99), consts.Tile(99))
 	assert.Empty(t, empty)
 }
+
+func TestPickablesAt_拾得可能なエンティティだけを返す(t *testing.T) {
+	t.Parallel()
+	world := testutil.InitTestWorld(t)
+	tile := consts.Coord[consts.Tile]{X: 3, Y: 4}
+
+	pickable := world.ECS.NewEntity()
+	world.Components.GridElement.Add(pickable, &gc.GridElement{Coord: tile})
+	world.Components.LocationOnField.Add(pickable, &gc.LocationOnField{})
+
+	fixedProp := world.ECS.NewEntity()
+	world.Components.GridElement.Add(fixedProp, &gc.GridElement{Coord: tile})
+	world.Components.LocationOnField.Add(fixedProp, &gc.LocationOnField{})
+	world.Components.Fixed.Add(fixedProp, &gc.Fixed{})
+
+	otherTile := world.ECS.NewEntity()
+	world.Components.GridElement.Add(otherTile, &gc.GridElement{Coord: consts.Coord[consts.Tile]{X: 9, Y: 9}})
+	world.Components.LocationOnField.Add(otherTile, &gc.LocationOnField{})
+
+	result := PickablesAt(world, tile)
+
+	require.Len(t, result, 1, "同タイルの拾得可能な1件だけ")
+	assert.Equal(t, pickable, result[0])
+}
+
+func TestGetPlayerCamera(t *testing.T) {
+	t.Parallel()
+
+	t.Run("カメラが存在すれば返す", func(t *testing.T) {
+		t.Parallel()
+		world := testutil.InitTestWorld(t)
+		camEntity := world.ECS.NewEntity()
+		world.Components.Camera.Add(camEntity, &gc.Camera{})
+
+		assert.NotNil(t, GetPlayerCamera(world))
+	})
+
+	t.Run("カメラが無ければnil", func(t *testing.T) {
+		t.Parallel()
+		world := testutil.InitTestWorld(t)
+
+		assert.Nil(t, GetPlayerCamera(world))
+	})
+}

--- a/internal/world/query/singleton_test.go
+++ b/internal/world/query/singleton_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	gc "github.com/kijimaD/ruins/internal/components"
+	"github.com/kijimaD/ruins/internal/consts"
 	"github.com/kijimaD/ruins/internal/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -71,4 +72,50 @@ func TestGetWeaponSelection(t *testing.T) {
 
 	ws.Slot = 3
 	assert.Equal(t, 3, GetWeaponSelection(world).Slot, "更新がシングルトンに反映される")
+}
+
+func TestGetRunStats_InitWorldで初期状態を取得できる(t *testing.T) {
+	t.Parallel()
+	world := testutil.InitTestWorld(t)
+
+	stats := GetRunStats(world)
+	require.NotNil(t, stats)
+	assert.Equal(t, 0, stats.EnemiesKilled)
+
+	stats.EnemiesKilled = 5
+	assert.Equal(t, 5, GetRunStats(world).EnemiesKilled, "更新がシングルトンに反映される")
+}
+
+func TestGetSeamlessBand_帯データの有無で結果が変わる(t *testing.T) {
+	t.Parallel()
+	world := testutil.InitTestWorld(t)
+	d := GetDungeon(world)
+	d.CurrentStage = gc.NewOverworldStage()
+
+	assert.Nil(t, GetSeamlessBand(world), "帯データを確保する前はnil")
+
+	EnsureSeamlessBand(world)
+	assert.NotNil(t, GetSeamlessBand(world), "確保した後は取得できる")
+}
+
+func TestEnsureStageField_同じキーなら既存のエンティティを再利用する(t *testing.T) {
+	t.Parallel()
+	world := testutil.InitTestWorld(t)
+	key := gc.NewDungeonStage("テスト遺跡", 1)
+
+	first := EnsureStageField(world, key)
+	require.NotNil(t, first)
+	first.Level.TileWidth = consts.Tile(99)
+
+	second := EnsureStageField(world, key)
+	assert.Equal(t, consts.Tile(99), second.Level.TileWidth, "2回目は既存のエンティティを返す")
+}
+
+func TestGetCurrentStageField_未生成のステージはnilを返す(t *testing.T) {
+	t.Parallel()
+	world := testutil.InitTestWorld(t)
+	d := GetDungeon(world)
+	d.CurrentStage = gc.NewDungeonStage("未生成の遺跡", 1)
+
+	assert.Nil(t, GetCurrentStageField(world), "StageFieldを生成していないステージはnil")
 }

--- a/internal/world/query/stackkey_test.go
+++ b/internal/world/query/stackkey_test.go
@@ -252,6 +252,33 @@ func TestBackpackStacks_収集と整列と束ねを1口で行う(t *testing.T) {
 	assert.Equal(t, 2, stacks[1].Count, "同一スタックは束ねられる")
 }
 
+// TestStorageStacks_収集と整列と束ねを1口で行う は BackpackStacks の収納版であることを固定する。
+func TestStorageStacks_収集と整列と束ねを1口で行う(t *testing.T) {
+	t.Parallel()
+	world := testutil.InitTestWorld(t)
+
+	storage := world.ECS.NewEntity()
+	otherStorage := world.ECS.NewEntity()
+	mk := func(s ecs.Entity, id string, name string) {
+		e := world.ECS.NewEntity()
+		world.Components.RawID.Add(e, &gc.RawID{ID: id})
+		world.Components.Name.Add(e, &gc.Name{Name: name})
+		world.Components.LocationInStorage.Add(e, &gc.LocationInStorage{Owner: s})
+	}
+	mk(storage, "zebra", "Zebra")
+	mk(storage, "zebra", "Zebra")
+	mk(storage, "alpha", "Alpha")
+	mk(otherStorage, "alpha", "Alpha")
+
+	stacks := StorageStacks(world, storage)
+
+	require.Len(t, stacks, 2, "この収納の2品種だけが束になる")
+	assert.Equal(t, "Alpha", world.Components.Name.Get(stacks[0].Rep).Name, "名前順で並ぶ")
+	assert.Equal(t, 1, stacks[0].Count)
+	assert.Equal(t, "Zebra", world.Components.Name.Get(stacks[1].Rep).Name)
+	assert.Equal(t, 2, stacks[1].Count, "同一スタックは束ねられる")
+}
+
 func TestGroupStacks_同一性キーで束ね初出順を保つ(t *testing.T) {
 	t.Parallel()
 	world := testutil.InitTestWorld(t)


### PR DESCRIPTION
## 概要

`internal/world/query` に未テストの関数のテストを追加する。本体コードの変更はなし。

カバレッジ: 83.9% → 93.7%

## 対象にした振る舞い

- `auction.go`: `AuctionFee`・`AuctionOpeningBid`・`AuctionRaise`・`AuctionShippingCost` の計算、`GetAuctionHistory`・`StartAuctionListing`・`CollectStagedItems`・`SettleAuctionEntry` のオークション精算フロー。範囲外インデックス・Wallet無しの失敗パスも含む
- `danger.go`: `dangerLevel`・`DangerLevelAt` の危険度計算。負数・境界値の丸め
- `equipment.go`: `IsWeapon` の近接/射撃判定
- `name.go`: `GetEntityID`・`NameMarkup` のID取得・種別タグ付け
- `query.go`: `PickablesAt`・`GetPlayerCamera` の抽出ロジック
- `singleton.go`: `GetRunStats`・`GetSeamlessBand`・`EnsureStageField`・`GetCurrentStageField` のシングルトン取得・境界ケース
- `stackkey.go`: `StorageStacks` の収納内スタック集計

## 検証

- `make test`: 全パッケージ通過。対象パッケージのカバレッジ 93.7%
- `go test -race ./internal/world/query/...`: 通過
- `golangci-lint run ./internal/world/query/...`: 0 issues
- `go build ./...`: 通過

---

Co-Authored-By: Claude <noreply@anthropic.com>


---
_Generated by [Claude Code](https://claude.ai/code/session_011rMrkLZukNXyn2oARLtPy9)_