### PR TITLE
test(vrt): カバレッジ増強

### DIFF
--- a/internal/vrt/golden_internal_test.go
+++ b/internal/vrt/golden_internal_test.go
@@ -1,6 +1,10 @@
 package vrt
 
 import (
+	"bytes"
+	"image"
+	"image/color"
+	"image/png"
 	"math"
 	"testing"
 
@@ -43,5 +47,159 @@ func TestToleranceForSize(t *testing.T) {
 		// 係数を緩めすぎると実変化が静かに素通りするので、上限を仕込んで気づけるようにする
 		got := toleranceForSize(960, 720)
 		require.Less(t, got, 0.0825/100/2, "メニュー行の変化を見逃さない比率であること")
+	})
+}
+
+// TestAbsDiffU32 はどちらが大きくても差の絶対値を返すことを固定する
+func TestAbsDiffU32(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		a    uint32
+		b    uint32
+		want uint32
+	}{
+		{"aがbより大きい", 10, 3, 7},
+		{"bがaより大きい", 3, 10, 7},
+		{"aとbが等しい", 5, 5, 0},
+		{"どちらもゼロ", 0, 0, 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, absDiffU32(tt.a, tt.b))
+		})
+	}
+}
+
+// TestIsGoldieUpdate はGOLDIE_UPDATEの値ごとの判定を固定する。t.Setenvを使うためt.Parallelは呼ばない
+func TestIsGoldieUpdate(t *testing.T) {
+	tests := []struct {
+		name  string
+		value string
+		want  bool
+	}{
+		{"1なら有効", "1", true},
+		{"trueなら有効", "true", true},
+		{"tなら有効", "t", true},
+		{"0なら無効", "0", false},
+		{"falseなら無効", "false", false},
+		{"未知の値は無効", "yes", false},
+		{"未設定は無効", "", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("GOLDIE_UPDATE", tt.value)
+			assert.Equal(t, tt.want, isGoldieUpdate())
+		})
+	}
+}
+
+// solidPNG は幅4の単色画像をPNGへエンコードして返す
+func solidPNG(t *testing.T, width int, c color.NRGBA) []byte {
+	t.Helper()
+	const height = 4
+	img := image.NewNRGBA(image.Rect(0, 0, width, height))
+	for y := range height {
+		for x := range width {
+			img.SetNRGBA(x, y, c)
+		}
+	}
+	var buf bytes.Buffer
+	require.NoError(t, png.Encode(&buf, img))
+	return buf.Bytes()
+}
+
+// TestPngPixelEqualFn はPNGバイト列のピクセル単位比較の各分岐を固定する
+func TestPngPixelEqualFn(t *testing.T) {
+	t.Parallel()
+
+	white := color.NRGBA{R: 255, G: 255, B: 255, A: 255}
+	black := color.NRGBA{R: 0, G: 0, B: 0, A: 255}
+
+	t.Run("actualが不正なPNGなら不一致", func(t *testing.T) {
+		t.Parallel()
+		expected := solidPNG(t, 4, white)
+		eq := pngPixelEqualFn(1.0)
+		assert.False(t, eq([]byte("not a png"), expected))
+	})
+
+	t.Run("expectedが不正なPNGなら不一致", func(t *testing.T) {
+		t.Parallel()
+		actual := solidPNG(t, 4, white)
+		eq := pngPixelEqualFn(1.0)
+		assert.False(t, eq(actual, []byte("not a png")))
+	})
+
+	t.Run("サイズが異なれば不一致", func(t *testing.T) {
+		t.Parallel()
+		actual := solidPNG(t, 4, white)
+		expected := solidPNG(t, 5, white)
+		eq := pngPixelEqualFn(1.0)
+		assert.False(t, eq(actual, expected))
+	})
+
+	t.Run("完全に同一画像なら一致", func(t *testing.T) {
+		t.Parallel()
+		actual := solidPNG(t, 4, white)
+		expected := solidPNG(t, 4, white)
+		eq := pngPixelEqualFn(0)
+		assert.True(t, eq(actual, expected))
+	})
+
+	t.Run("許容振幅内の差分は同一とみなす", func(t *testing.T) {
+		t.Parallel()
+		// 8bit差5は16bit換算で5*257=1285、channelTolerance16の4112を下回るのでノイズ扱いになる
+		actual := solidPNG(t, 4, color.NRGBA{R: 250, G: 250, B: 250, A: 255})
+		expected := solidPNG(t, 4, white)
+		eq := pngPixelEqualFn(0)
+		assert.True(t, eq(actual, expected))
+	})
+
+	t.Run("許容振幅を超える差分ピクセル数が比率以下なら一致", func(t *testing.T) {
+		t.Parallel()
+		// 4x4=16画素中9画素を黒にする。比率0.6の上限は int(16*0.6)=9 なので9画素までは許容される
+		expectedImg := image.NewNRGBA(image.Rect(0, 0, 4, 4))
+		actualImg := image.NewNRGBA(image.Rect(0, 0, 4, 4))
+		for y := range 4 {
+			for x := range 4 {
+				expectedImg.SetNRGBA(x, y, white)
+				if y*4+x < 9 {
+					actualImg.SetNRGBA(x, y, black)
+				} else {
+					actualImg.SetNRGBA(x, y, white)
+				}
+			}
+		}
+		var actualBuf, expectedBuf bytes.Buffer
+		require.NoError(t, png.Encode(&actualBuf, actualImg))
+		require.NoError(t, png.Encode(&expectedBuf, expectedImg))
+
+		eq := pngPixelEqualFn(0.6)
+		assert.True(t, eq(actualBuf.Bytes(), expectedBuf.Bytes()))
+	})
+
+	t.Run("許容振幅を超える差分ピクセル数が比率を超えれば不一致", func(t *testing.T) {
+		t.Parallel()
+		// 4x4=16画素中10画素を黒にする。比率0.5の上限は int(16*0.5)=8 を超えるので不一致になる
+		expectedImg := image.NewNRGBA(image.Rect(0, 0, 4, 4))
+		actualImg := image.NewNRGBA(image.Rect(0, 0, 4, 4))
+		for y := range 4 {
+			for x := range 4 {
+				expectedImg.SetNRGBA(x, y, white)
+				if y*4+x < 10 {
+					actualImg.SetNRGBA(x, y, black)
+				} else {
+					actualImg.SetNRGBA(x, y, white)
+				}
+			}
+		}
+		var actualBuf, expectedBuf bytes.Buffer
+		require.NoError(t, png.Encode(&actualBuf, actualImg))
+		require.NoError(t, png.Encode(&expectedBuf, expectedImg))
+
+		eq := pngPixelEqualFn(0.5)
+		assert.False(t, eq(actualBuf.Bytes(), expectedBuf.Bytes()))
 	})
 }


### PR DESCRIPTION
## 概要

`internal/vrt` パッケージへテストを追加し、カバレッジを増強する。

- Before: 1.49%
- After: 12.3%

## 対象にした振る舞い

`internal/vrt/golden.go` のうち、ebiten の表示に依存しない純粋な比較・判定ロジックにテストを追加した。

- `absDiffU32`: 2値の差の絶対値を返す。aとbの大小が入れ替わっても正しく差分を返すことを固定する
- `isGoldieUpdate`: `GOLDIE_UPDATE` 環境変数の値ごとの有効/無効判定を固定する
- `pngPixelEqualFn`: PNGバイト列をピクセル単位で比較するクロージャ。不正なPNG・サイズ不一致・完全一致・許容振幅内の差分・許容比率の境界内外、の各分岐を固定する

`WithUILock` や `AssertScreenGolden` などの ebiten 描画・ebitenui グローバル状態に触れる関数は対象外にした。表示や widget の組み立てが要り、テストしやすさの観点で今回のスコープ外とした。

## 検証

- `make test`: 通過
- `golangci-lint run ./...`: 0 issues
- `go build ./...`: 通過

`make lint` 内の `go tool govulncheck` はサンドボックス環境のネットワーク制限で `vuln.go.dev` への到達が拒否され未検証。本PRの差分とは無関係な既存の環境依存の失敗。

---
Co-Authored-By: Claude <noreply@anthropic.com>

---
_Generated by [Claude Code](https://claude.ai/code/session_011JsWJrS7MV9AwP7gnU2oHM)_