### PR TITLE
test(widgets/uicore): カバレッジ増強

### DIFF
--- a/internal/widgets/uicore/container_deco_test.go
+++ b/internal/widgets/uicore/container_deco_test.go
@@ -1,0 +1,71 @@
+package uicore_test
+
+import (
+	"image"
+	"image/color"
+	"testing"
+
+	"github.com/hajimehoshi/ebiten/v2"
+	"github.com/kijimaD/ruins/internal/widgets/uicore"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestContainer_SetPadding_内側に余白を作る(t *testing.T) {
+	t.Parallel()
+	child := uicore.VBox(0)
+	child.SetStyle(uicore.BoxStyle{Fill: color.White})
+	parent := uicore.VBox(80, child)
+	parent.SetPadding(10)
+
+	parent.Layout(image.Rect(0, 0, 100, 100))
+	cv := &recordCanvas{}
+	parent.Draw(cv)
+
+	require.Len(t, cv.fills, 1)
+	assert.Equal(t, image.Pt(10, 10), cv.fills[0].Min, "paddingぶん内側から子が配置される")
+}
+
+func TestContainer_SetBackgroundNineSlice_背景画像を描く(t *testing.T) {
+	t.Parallel()
+	img := ebiten.NewImage(9, 9)
+	c := uicore.VBox(0)
+	c.SetBackgroundNineSlice(img, [3]int{3, 3, 3}, [3]int{3, 3, 3})
+
+	c.Layout(image.Rect(0, 0, 30, 30))
+	cv := &recordCanvas{}
+	c.Draw(cv)
+
+	assert.Len(t, cv.images, 1, "9スライス背景が描かれる")
+}
+
+func TestContainer_SetBottomLine_下端に線を敷く(t *testing.T) {
+	t.Parallel()
+	img := ebiten.NewImage(10, 2)
+	c := uicore.VBox(0)
+	c.SetBottomLine(img, color.White)
+
+	c.Layout(image.Rect(0, 0, 50, 20))
+	cv := &recordCanvas{}
+	c.Draw(cv)
+
+	require.Len(t, cv.images, 1)
+	assert.Equal(t, image.Pt(0, 18), cv.images[0], "線画像の高さぶん上げた位置、下端に敷かれる")
+}
+
+func TestContainer_Row_0幅の列は余り幅を均等に吸収する(t *testing.T) {
+	t.Parallel()
+	a := uicore.VBox(0)
+	a.SetStyle(uicore.BoxStyle{Fill: color.White})
+	b := uicore.VBox(0)
+	b.SetStyle(uicore.BoxStyle{Fill: color.White})
+	row := uicore.Row([]int{0, 0}, a, b)
+
+	row.Layout(image.Rect(0, 0, 100, 10))
+	cv := &recordCanvas{}
+	row.Draw(cv)
+
+	require.Len(t, cv.fills, 2)
+	assert.Equal(t, 50, cv.fills[0].Dx(), "1列目は余り幅を均等に吸収する")
+	assert.Equal(t, 50, cv.fills[1].Dx(), "2列目も同様に吸収する")
+}

--- a/internal/widgets/uicore/flex_column_test.go
+++ b/internal/widgets/uicore/flex_column_test.go
@@ -1,0 +1,38 @@
+package uicore_test
+
+import (
+	"image"
+	"image/color"
+	"testing"
+
+	"github.com/kijimaD/ruins/internal/widgets/uicore"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFlexColumn_Growの行が余り高さを吸収する(t *testing.T) {
+	t.Parallel()
+	header := uicore.VBox(0)
+	header.SetStyle(uicore.BoxStyle{Fill: color.White})
+	body := uicore.VBox(0)
+	body.SetStyle(uicore.BoxStyle{Fill: color.White})
+	footer := uicore.VBox(0)
+	footer.SetStyle(uicore.BoxStyle{Fill: color.White})
+
+	uicore.FlexColumn(image.Rect(0, 0, 50, 100), []uicore.FlexItem{
+		{W: header, Height: 20},
+		{W: body, Grow: true},
+		{W: footer, Height: 10},
+	})
+
+	cv := &recordCanvas{}
+	header.Draw(cv)
+	body.Draw(cv)
+	footer.Draw(cv)
+
+	require.Len(t, cv.fills, 3)
+	assert.Equal(t, 20, cv.fills[0].Dy(), "先頭行は固定高で確定する")
+	assert.Equal(t, 70, cv.fills[1].Dy(), "Growの行が余り高さを吸収する")
+	assert.Equal(t, 10, cv.fills[2].Dy(), "末尾行は固定高で確定する")
+	assert.Equal(t, 90, cv.fills[2].Min.Y, "末尾行は下端に押し付けられる")
+}

--- a/internal/widgets/uicore/flex_column_test.go
+++ b/internal/widgets/uicore/flex_column_test.go
@@ -30,6 +30,7 @@ func TestFlexColumn_Growの行が余り高さを吸収する(t *testing.T) {
 	body.Draw(cv)
 	footer.Draw(cv)
 
+	// header, body, footerの順でDrawしているのでcv.fillsも0:header 1:body 2:footerの順で積まれる
 	require.Len(t, cv.fills, 3)
 	assert.Equal(t, 20, cv.fills[0].Dy(), "先頭行は固定高で確定する")
 	assert.Equal(t, 70, cv.fills[1].Dy(), "Growの行が余り高さを吸収する")

--- a/internal/widgets/uicore/leaf_widget_test.go
+++ b/internal/widgets/uicore/leaf_widget_test.go
@@ -2,7 +2,6 @@ package uicore_test
 
 import (
 	"image"
-	"image/color"
 	"testing"
 
 	"github.com/hajimehoshi/ebiten/v2"
@@ -61,8 +60,8 @@ func TestNineSlice_画像が無ければ何も描かない(t *testing.T) {
 
 func TestGroup_子を配置し直さず順に描く(t *testing.T) {
 	t.Parallel()
-	a := uicore.NewText("a", nil, color.White)
-	b := uicore.NewText("b", nil, color.White)
+	a := label("a")
+	b := label("b")
 	g := uicore.NewGroup(a, b)
 
 	require.Equal(t, []uicore.Widget{a, b}, g.Children(), "渡した子をそのまま返す")

--- a/internal/widgets/uicore/leaf_widget_test.go
+++ b/internal/widgets/uicore/leaf_widget_test.go
@@ -1,0 +1,75 @@
+package uicore_test
+
+import (
+	"image"
+	"image/color"
+	"testing"
+
+	"github.com/hajimehoshi/ebiten/v2"
+	"github.com/kijimaD/ruins/internal/widgets/uicore"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGraphic_画像があれば描く(t *testing.T) {
+	t.Parallel()
+	img := ebiten.NewImage(4, 4)
+	g := uicore.NewGraphic(img)
+	g.Layout(image.Rect(0, 0, 20, 20))
+
+	cv := &recordCanvas{}
+	g.Draw(cv)
+
+	require.Len(t, cv.images, 1, "画像があれば描画呼び出しが1回起きる")
+	assert.Nil(t, g.Children(), "子は持たない")
+}
+
+func TestGraphic_画像が無ければ何も描かない(t *testing.T) {
+	t.Parallel()
+	g := uicore.NewGraphic(nil)
+	g.Layout(image.Rect(0, 0, 20, 20))
+
+	cv := &recordCanvas{}
+	g.Draw(cv)
+
+	assert.Empty(t, cv.images, "nil画像は描画呼び出しをしない")
+}
+
+func TestNineSlice_画像があれば描く(t *testing.T) {
+	t.Parallel()
+	img := ebiten.NewImage(9, 9)
+	n := uicore.NewNineSlice(img, [3]int{3, 3, 3}, [3]int{3, 3, 3})
+	n.Layout(image.Rect(0, 0, 30, 30))
+
+	cv := &recordCanvas{}
+	n.Draw(cv)
+
+	require.Len(t, cv.images, 1, "画像があれば描画呼び出しが1回起きる")
+	assert.Nil(t, n.Children(), "子は持たない")
+}
+
+func TestNineSlice_画像が無ければ何も描かない(t *testing.T) {
+	t.Parallel()
+	n := uicore.NewNineSlice(nil, [3]int{}, [3]int{})
+	n.Layout(image.Rect(0, 0, 30, 30))
+
+	cv := &recordCanvas{}
+	n.Draw(cv)
+
+	assert.Empty(t, cv.images, "nil画像は描画呼び出しをしない")
+}
+
+func TestGroup_子を配置し直さず順に描く(t *testing.T) {
+	t.Parallel()
+	a := uicore.NewText("a", nil, color.White)
+	b := uicore.NewText("b", nil, color.White)
+	g := uicore.NewGroup(a, b)
+
+	require.Equal(t, []uicore.Widget{a, b}, g.Children(), "渡した子をそのまま返す")
+
+	g.Layout(image.Rect(0, 0, 10, 10))
+	cv := &recordCanvas{}
+	g.Draw(cv)
+
+	assert.Equal(t, []string{"a", "b"}, cv.texts, "子を渡した順に描く")
+}

--- a/internal/widgets/uicore/measure_test.go
+++ b/internal/widgets/uicore/measure_test.go
@@ -34,7 +34,7 @@ func TestLineHeight_実フェイスでAgの高さを返す(t *testing.T) {
 	res := borrowRes()
 	defer facePool.Put(res)
 
+	// LineHeightはMeasureText("Ag", face)の高さを返す契約なので、それと一致することを検証する
 	_, wantH := uicore.MeasureText("Ag", res.Text.BodyFace)
 	assert.Equal(t, wantH, uicore.LineHeight(res.Text.BodyFace), "MeasureTextで測ったAgの高さと一致する")
-	assert.Positive(t, uicore.LineHeight(res.Text.BodyFace), "実フェイスなら正の高さになる")
 }

--- a/internal/widgets/uicore/measure_test.go
+++ b/internal/widgets/uicore/measure_test.go
@@ -1,0 +1,40 @@
+package uicore_test
+
+import (
+	"testing"
+
+	"github.com/kijimaD/ruins/internal/widgets/uicore"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFitWidth_中身が無ければ下限になる(t *testing.T) {
+	t.Parallel()
+	assert.Equal(t, 5, uicore.FitWidth(nil, 3, 5), "中身が無いときはlowerになる")
+}
+
+func TestFitWidth_最も広い中身にextraを足す(t *testing.T) {
+	t.Parallel()
+	assert.Equal(t, 13, uicore.FitWidth([]int{4, 10, 7}, 3, 5), "最大値にextraを足した値がlowerを上回るのでそちらを採る")
+}
+
+func TestFitWidth_下限を下回らせない(t *testing.T) {
+	t.Parallel()
+	assert.Equal(t, 20, uicore.FitWidth([]int{1, 2}, 3, 20), "widest+extraがlowerを下回るのでlowerになる")
+}
+
+func TestMeasureText_フェイスがnilなら0を返す(t *testing.T) {
+	t.Parallel()
+	w, h := uicore.MeasureText("hello", nil)
+	assert.Equal(t, 0, w, "フェイス無しは幅0")
+	assert.Equal(t, 0, h, "フェイス無しは高さ0")
+}
+
+func TestLineHeight_実フェイスでAgの高さを返す(t *testing.T) {
+	t.Parallel()
+	res := borrowRes()
+	defer facePool.Put(res)
+
+	_, wantH := uicore.MeasureText("Ag", res.Text.BodyFace)
+	assert.Equal(t, wantH, uicore.LineHeight(res.Text.BodyFace), "MeasureTextで測ったAgの高さと一致する")
+	assert.Positive(t, uicore.LineHeight(res.Text.BodyFace), "実フェイスなら正の高さになる")
+}

--- a/internal/widgets/uicore/placeable_test.go
+++ b/internal/widgets/uicore/placeable_test.go
@@ -35,6 +35,7 @@ func TestPlaceable_非Widgetは描画専用として包む(t *testing.T) {
 	assert.Nil(t, w.Children(), "包んだ葉は子を持たない")
 
 	w.Layout(image.Rect(0, 0, 10, 10))
+	// 委譲が起きることだけを検証する。recordDrawable.Draw は Canvas を参照しないので nil でよい
 	w.Draw(nil)
 	assert.Equal(t, 1, d.drawCount, "DrawはPlaceableで包んだ中身へ委譲される")
 }

--- a/internal/widgets/uicore/placeable_test.go
+++ b/internal/widgets/uicore/placeable_test.go
@@ -18,7 +18,7 @@ func (d *recordDrawable) Draw(_ uicore.Canvas) { d.drawCount++ }
 
 func TestPlaceable_Widget実装はそのまま通す(t *testing.T) {
 	t.Parallel()
-	w := uicore.NewText("a", nil, nil)
+	w := label("a")
 	out := uicore.Placeable([]uicore.Drawable{w})
 
 	require.Len(t, out, 1)

--- a/internal/widgets/uicore/placeable_test.go
+++ b/internal/widgets/uicore/placeable_test.go
@@ -1,0 +1,40 @@
+package uicore_test
+
+import (
+	"image"
+	"testing"
+
+	"github.com/kijimaD/ruins/internal/widgets/uicore"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// recordDrawable は Widget を実装しない Drawable。Placeable が包むことを確かめる。
+type recordDrawable struct {
+	drawCount int
+}
+
+func (d *recordDrawable) Draw(_ uicore.Canvas) { d.drawCount++ }
+
+func TestPlaceable_Widget実装はそのまま通す(t *testing.T) {
+	t.Parallel()
+	w := uicore.NewText("a", nil, nil)
+	out := uicore.Placeable([]uicore.Drawable{w})
+
+	require.Len(t, out, 1)
+	assert.Same(t, w, out[0], "Widgetを実装していればラップされずそのまま返る")
+}
+
+func TestPlaceable_非Widgetは描画専用として包む(t *testing.T) {
+	t.Parallel()
+	d := &recordDrawable{}
+	out := uicore.Placeable([]uicore.Drawable{d})
+
+	require.Len(t, out, 1)
+	w := out[0]
+	assert.Nil(t, w.Children(), "包んだ葉は子を持たない")
+
+	w.Layout(image.Rect(0, 0, 10, 10))
+	w.Draw(nil)
+	assert.Equal(t, 1, d.drawCount, "DrawはPlaceableで包んだ中身へ委譲される")
+}


### PR DESCRIPTION
## 概要

`internal/widgets/uicore` にテストを追加し、カバレッジを増強する。本体コードの変更はなし。

- カバレッジ: 40.3% → 61.9%

## 狙った振る舞い

- `FitWidth`: 中身が空のとき下限になる、最大値+extraがlowerを上回る/下回るケース
- `MeasureText`: フェイスがnilなら0を返す
- `LineHeight`: 実フェイスで`MeasureText("Ag", face)`と同じ高さを返す
- `Placeable`: Widget実装はそのまま通す、非WidgetはdrawOnlyで包んで子を持たずDrawだけ委譲する
- `Graphic`/`NineSlice`: 画像がnilなら何も描かない、あれば1回描く
- `Group`: 子を再配置せず渡した順にDrawする
- `Container.SetPadding`: paddingぶん内側から子が配置される
- `Container.SetBackgroundNineSlice`/`SetBottomLine`: 背景の9スライス・下端の区切り線がそれぞれ描かれる
- `Row`の0幅列: 余り幅を複数列で均等に吸収する
- `FlexColumn`: Growの行が余り高さを吸収し、後続行を下端へ押し付ける

## 検証

- `go test ./internal/widgets/uicore/...`: PASS、coverage 61.9%
- `make test`: 全パッケージPASS
- `make lint`: golangci-lint 0 issues、deadcode検出なし。`govulncheck`はサンドボックス環境のネットワークポリシーで`vuln.go.dev`への接続が拒否され未実行。テスト専用の差分のため依存脆弱性チェックへの影響はない

---
_Generated by [Claude Code](https://claude.ai/code/session_017C2v2J5Yu2L2TAT96xC2dJ)_