### PR TITLE
fix(vrt): 再生ハーネスの screen.Deallocate を外し atlas 競合を断つ

### DIFF
--- a/internal/vrt/replay/replay.go
+++ b/internal/vrt/replay/replay.go
@@ -25,8 +25,9 @@ import (
 //
 // フレーム数は len(actions)+1 になる。StateMachine は state が返した遷移を次フレーム冒頭で
 // 適用するので、最後の Action の Push/Pop を確定させる1フレームを足す。capture は各フレームの
-// 描画後に0起点のフレーム番号で呼ぶ。nil なら駆動のみで描画しない。screen は capture から
-// 戻ったところで解放するので、抱え込まずその場で読み切る。
+// 描画後に0起点のフレーム番号で呼ぶ。nil なら駆動のみで描画しない。screen はフレームごとに
+// 作るので、抱え込まずその場で読み切る。明示的な解放はしない。別 goroutine から ebiten 画像を
+// Deallocate すると、裏で回るレンダーループの atlas 処理と競合するため、解放は GC に委ねる。
 //
 // state 側に再生用の口は要らない。入力供給源は world が持ち、押し込んだ先の state にも同じ源が
 // 効く。world は自前の独立フェイスを持つので、駆動と描画はロック無しで並列に走れる。
@@ -61,7 +62,6 @@ func PlayScenario(
 		screen := ebiten.NewImage(consts.GameWidth, consts.GameHeight)
 		game.Draw(screen)
 		capture(frame, world, screen)
-		screen.Deallocate()
 	}
 	return game
 }


### PR DESCRIPTION
## 背景

main の race-check、`make test RACE=-race`、が間欠的に赤くなる。原因は VRT 再生ハーネスに内在する ebiten atlas の DATA RACE。

- 書き込み側: ebiten のレンダーループ goroutine。`vrt.RunTestMain` の `ebiten.RunGame` がホストの Draw が空でも毎フレーム `BeginFrame → flushDeferred → atlas allocate` を回し続ける
- 読み取り側: テスト goroutine。`internal/vrt/replay/replay.go` の `screen.Deallocate()`。遅延キューを通らずテスト goroutine 上で同期実行され、atlas backend を直接触る
- golden 再生テストは `t.Parallel` なので、あるテストの Deallocate と別テストの遅延描画フラッシュが、共有 backend ページで衝突する

`-shuffle=on` で実行順が毎回変わるため、低確率のシードでだけ発火するフレーク。特定機能の回帰ではない。

## 変更内容

`PlayScenario` から `screen.Deallocate()` を外す。ebiten 画像は GC 管理なので明示解放をやめても機能は変わらない。競合の読み取り側だった同期 Deallocate が消える。`NewImage` と `Draw` は遅延キュー経由でループがロック下に処理するため安全なまま残る。ロックは足さない。

doc コメントも実態に合わせ、なぜ明示解放しないかを定常状態として残す。

## 検証

- `make check` 緑
- CI 同条件の `make test RACE=-race` フルラン: EXIT=0 / DATA RACE 0件 / FAIL 0件

## 限界

この race は CI で約11回に1回の頻度。ローカルのフルラン1回の緑では確率的 race の完全消滅は証明できない。この修正の確度は「-race が名指ししたアクセスそのものを構造的に除去した」点に拠る。ループ対テストの atlas 共有自体は残るため別の race に化ける可能性はゼロではないが、最も危険だった同期解放は消えた。

🤖 Generated with [Claude Code](https://claude.com/claude-code)