### PR TITLE
test(config): カバレッジ増強

### DIFF
--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -45,6 +45,26 @@ func TestApplyProfileDefaults_UnknownProfile(t *testing.T) {
 	assert.False(t, cfg.SkipOpening)
 }
 
+// make test は RUINS_LOG_LEVEL=ignore を設定して実行するため、未設定時のデフォルト分岐は
+// 明示的に空へ上書きしないと踏めない。t.Setenv を使うため t.Parallel は呼ばない。
+func TestApplyProfileDefaults_LogLevel未設定なら本番はinfoになる(t *testing.T) {
+	t.Setenv("RUINS_LOG_LEVEL", "")
+
+	cfg := &Config{Profile: ProfileProduction}
+	cfg.ApplyProfileDefaults()
+
+	assert.Equal(t, "info", cfg.LogLevel)
+}
+
+func TestApplyProfileDefaults_LogLevel未設定なら開発もinfoになる(t *testing.T) {
+	t.Setenv("RUINS_LOG_LEVEL", "")
+
+	cfg := &Config{Profile: ProfileDevelopment}
+	cfg.ApplyProfileDefaults()
+
+	assert.Equal(t, "info", cfg.LogLevel)
+}
+
 func TestConfig_StringGolden(t *testing.T) {
 	t.Parallel()
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -94,6 +94,7 @@ func TestLoad(t *testing.T) {
 	assert.Positive(t, cfg.User.WindowHeight)
 	assert.Positive(t, cfg.TargetFPS)
 }
+
 func TestValidate(t *testing.T) {
 	t.Parallel()
 

--- a/internal/config/manager_test.go
+++ b/internal/config/manager_test.go
@@ -1,0 +1,45 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// 以下は t.Setenv でプロセス環境変数を書き換えて Load の分岐を検証するため、
+// t.Setenv の制約上 t.Parallel は呼ばない。
+
+func TestLoad_RUINS_PROFILEを指定するとプロファイルへ反映される(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", dir)
+	t.Setenv("RUINS_PROFILE", "development")
+
+	cfg, err := Load()
+	require.NoError(t, err)
+
+	assert.Equal(t, ProfileDevelopment, cfg.Profile)
+	assert.True(t, cfg.SkipOpening) // 開発プロファイル固有のデフォルト値
+}
+
+func TestLoad_環境変数の型が不正だとエラーを返す(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", dir)
+	t.Setenv("RUINS_PPROF_PORT", "not-a-number")
+
+	_, err := Load()
+
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "failed to load config")
+}
+
+func TestLoad_Validateに失敗するとエラーを返す(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", dir)
+	t.Setenv("RUINS_WINDOW_WIDTH", "100") // Validate の最小値320を下回る
+
+	_, err := Load()
+
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "failed to validate config")
+}

--- a/internal/config/store_desktop_test.go
+++ b/internal/config/store_desktop_test.go
@@ -3,6 +3,7 @@
 package config
 
 import (
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -158,6 +159,108 @@ func TestLoadUserConfig_保存済み設定を読み込んで上書きする(t *t
 	require.NoError(t, err)
 	assert.Equal(t, 1280, c.User.WindowWidth)
 	assert.Equal(t, 720, c.User.WindowHeight) // 保存に無いフィールドはデフォルトが残る
+}
+
+func TestUserConfigPath_HOMEもXDG_CONFIG_HOMEも無ければエラーになる(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", "")
+	t.Setenv("HOME", "")
+
+	_, err := userConfigPath()
+
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "failed to get config directory")
+}
+
+func TestReadSettings_userConfigPathの解決に失敗するとエラーを返す(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", "")
+	t.Setenv("HOME", "")
+
+	_, _, err := readSettings()
+
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "failed to get config directory")
+}
+
+func TestWriteSettings_userConfigPathの解決に失敗するとエラーを返す(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", "")
+	t.Setenv("HOME", "")
+
+	err := writeSettings([]byte("x"))
+
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "failed to get config directory")
+}
+
+func TestReadSettingsFrom_ファイル以外が原因の読み込み失敗はエラーを返す(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	// パスをファイルではなくディレクトリにして、ENOENT以外の理由で読み込みを失敗させる
+	adir := filepath.Join(dir, "adir")
+	require.NoError(t, os.Mkdir(adir, 0o755))
+
+	_, _, err := readSettingsFrom(adir)
+
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "failed to read config file")
+}
+
+func TestSettingsExistAt_ファイル以外が原因の確認失敗はエラーを返す(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	// パス途中の要素をディレクトリではなくファイルにして、ENOENT以外の理由で確認を失敗させる
+	notADir := filepath.Join(dir, "notadir")
+	require.NoError(t, os.WriteFile(notADir, []byte("x"), 0o644))
+	path := filepath.Join(notADir, "settings.toml")
+
+	_, err := settingsExistAt(path)
+
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "failed to check config file existence")
+}
+
+func TestWriteSettingsTo_ディレクトリ作成に失敗するとエラーを返す(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	// パス途中の要素をディレクトリではなくファイルにして、MkdirAllを失敗させる
+	notADir := filepath.Join(dir, "notadir")
+	require.NoError(t, os.WriteFile(notADir, []byte("x"), 0o644))
+	path := filepath.Join(notADir, "sub", "settings.toml")
+
+	err := writeSettingsTo(path, []byte("x"))
+
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "failed to create config directory")
+}
+
+func TestWriteSettingsTo_一時ファイルの書き込みに失敗するとエラーを返す(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "settings.toml")
+	// 一時ファイルのパスを先にディレクトリとして作っておき、WriteFileを失敗させる
+	require.NoError(t, os.Mkdir(path+".tmp", 0o755))
+
+	err := writeSettingsTo(path, []byte("x"))
+
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "failed to write config file")
+}
+
+func TestWriteSettingsTo_リネームに失敗するとエラーを返す(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "settings.toml")
+	// 置き換え先を既存のディレクトリにして、Renameを失敗させる
+	require.NoError(t, os.Mkdir(path, 0o755))
+
+	err := writeSettingsTo(path, []byte("x"))
+
+	require.ErrorContains(t, err, "failed to replace config file")
+	assert.NoFileExists(t, path+".tmp") // 失敗時は一時ファイルを削除する
 }
 
 func TestLoadUserConfig_不正なTOMLはエラーを返す(t *testing.T) {

--- a/internal/config/store_desktop_test.go
+++ b/internal/config/store_desktop_test.go
@@ -259,7 +259,8 @@ func TestWriteSettingsTo_リネームに失敗するとエラーを返す(t *tes
 
 	err := writeSettingsTo(path, []byte("x"))
 
-	require.ErrorContains(t, err, "failed to replace config file")
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "failed to replace config file")
 	assert.NoFileExists(t, path+".tmp") // 失敗時は一時ファイルを削除する
 }
 

--- a/internal/config/store_desktop_test.go
+++ b/internal/config/store_desktop_test.go
@@ -260,7 +260,7 @@ func TestWriteSettingsTo_リネームに失敗するとエラーを返す(t *tes
 	err := writeSettingsTo(path, []byte("x"))
 
 	require.Error(t, err)
-	assert.ErrorContains(t, err, "failed to replace config file")
+	require.ErrorContains(t, err, "failed to replace config file")
 	assert.NoFileExists(t, path+".tmp") // 失敗時は一時ファイルを削除する
 }
 

--- a/internal/config/store_desktop_test.go
+++ b/internal/config/store_desktop_test.go
@@ -259,7 +259,7 @@ func TestWriteSettingsTo_リネームに失敗するとエラーを返す(t *tes
 
 	err := writeSettingsTo(path, []byte("x"))
 
-	require.Error(t, err)
+	// 想定どおりのエラーでなければ後続のファイル検査に意味がないので require で止める
 	require.ErrorContains(t, err, "failed to replace config file")
 	assert.NoFileExists(t, path+".tmp") // 失敗時は一時ファイルを削除する
 }

--- a/internal/config/store_test.go
+++ b/internal/config/store_test.go
@@ -1,6 +1,8 @@
 package config
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/BurntSushi/toml"
@@ -30,4 +32,29 @@ func TestUserConfig_保存に無いフィールドはデフォルトが残る(t 
 	assert.Equal(t, 1024, dst.User.WindowWidth) // 保存値で上書き
 	assert.Equal(t, 720, dst.User.WindowHeight) // デフォルトが残る
 	assert.Equal(t, "en", dst.User.Language)    // デフォルトが残る
+}
+
+// t.Setenv で XDG_CONFIG_HOME を書き換えるため t.Parallel は呼ばない。
+func TestLoadUserConfig_読み込みエラーをそのまま返す(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", dir)
+	// 設定ファイルの位置をディレクトリにして、ENOENT以外の理由で読み込みを失敗させる
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "ruins", "settings.toml"), 0o755))
+
+	c := &Config{User: DefaultUserConfig()}
+	err := c.loadUserConfig()
+
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "failed to read config file")
+}
+
+// t.Setenv で HOME/XDG_CONFIG_HOME を書き換えるため t.Parallel は呼ばない。
+func TestEnsureUserConfigFile_存在確認に失敗するとエラーを返す(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", "")
+	t.Setenv("HOME", "")
+
+	err := EnsureUserConfigFile()
+
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "failed to get config directory")
 }


### PR DESCRIPTION
## 概要

`internal/config` パッケージにテストを追加し、統計カバレッジを 88.6% から 98.3% へ引き上げた。本体コードの変更はなく、`*_test.go` のみを追加している。

## 対象にした振る舞い

- `Load`: `RUINS_PROFILE` を指定したときにプロファイルが反映されること、環境変数の型が不正なとき `env.Parse` のエラーを返すこと、`Validate` に失敗したときエラーを返すこと
- `loadUserConfig` / `EnsureUserConfigFile`: 設定ファイルの読み込み・存在確認が ENOENT 以外の理由で失敗したときに、エラーをそのまま返すこと
- `readSettingsFrom` / `settingsExistAt` / `writeSettingsTo` / `readSettings` / `writeSettings` / `userConfigPath`: ファイルの代わりにディレクトリが置かれている、パス途中の要素がファイルになっている、置き換え先が既存ディレクトリである、`HOME`・`XDG_CONFIG_HOME` が両方未設定である、といった ENOENT 以外の失敗経路
- `writeSettingsTo` の Rename 失敗時に一時ファイルを削除すること
- `ApplyProfileDefaults`: `RUINS_LOG_LEVEL` が未設定のとき、本番・開発の両プロファイルでログレベルが `info` になること。`make test` は `RUINS_LOG_LEVEL=ignore` を設定して実行するため、この分岐は明示的に空へ上書きしないと踏めなかった

`SaveUserConfig` の `encodeUserConfig` 失敗経路と `EnsureUserConfigFile` の Steam 言語取得成功経路は、本体コードを変更せずに再現する手段がなく対象外にした。

## カバレッジ

`internal/config`: 88.6% → 98.3%

## 検証

- `make test`
- `golangci-lint run ./...` は 0 issues。`make lint` の `govulncheck` はサンドボックスの egress ポリシーで `vuln.go.dev` への通信がブロックされ検証できなかったが、コードに起因する失敗ではない

---
_Generated by [Claude Code](https://claude.ai/code/session_011YXWgpSRFPW49f6jZCaGHj)_