### PR TITLE
docs(design): OSS 調査 2026-09

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ $ make help
 | status | ドキュメント | 進捗 | tags |
 |---|---|---|---|
 | draft | [HPで気軽に戦い、部位の不調で緊張を足す: 怪我・病気・低体温ダメージと治療](docs/design/260830231055.md) | 0/12 | gamedesign, combat, ecs |
+| draft | [OSS 調査 2026-09](docs/design/260901001755.md) | 0/4 | ci, movement, combat, worldgen |
 
 
 ## Reference

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ $ make help
 | status | ドキュメント | 進捗 | tags |
 |---|---|---|---|
 | draft | [HPで気軽に戦い、部位の不調で緊張を足す: 怪我・病気・低体温ダメージと治療](docs/design/260830231055.md) | 0/12 | gamedesign, combat, ecs |
-| draft | [OSS 調査 2026-09](docs/design/260901001755.md) | 0/4 | ci, movement, combat, worldgen |
+| draft | [OSS 調査 2026-09](docs/design/260901001755.md) | 0/3 | ci, movement, combat, worldgen |
 
 
 ## Reference

--- a/docs/design/260901001755.md
+++ b/docs/design/260901001755.md
@@ -18,6 +18,7 @@ auto: needs-decision # mechanical=無人着手可 / needs-decision=人の判断�
 - ある程度のスターとメンテ実績があり、ライセンスが MIT/BSD/Apache 等の使えるものに限る。
 - `go.mod` の既存依存と重複しない。ebiten・ark・ark-serde・testify・urfave/cli・goldie・go-mutesting・BurntSushi/toml・pelletier/go-toml・yaml.v3・getkin/kin-openapi・oapi-codegen・furex とは別のもの。
 - 先月の調査候補、mlange-42/ark-tools・quasilyte/ebitengine-input・quasilyte/pathing・shawnridgeway/wfc・aquilax/go-perlin とは別のもの。
+- 過去の OSS 調査 doc だけでなく、コード品質ツールを扱った他の設計ドキュメントで既に検討済みの候補とも重複しないもの。
 - 既に自前実装がある領域は、単純な重複なら除外し、明確な優位性がある場合のみ注意書き付きで残す。
 
 ## 設計
@@ -37,32 +38,25 @@ auto: needs-decision # mechanical=無人着手可 / needs-decision=人の判断�
 
 ### 候補
 
-#### 1. mvdan/gofumpt
-
-- リポジトリ: https://github.com/mvdan/gofumpt
-- 概要: `gofmt` より厳格なフォーマッタ。`gofmt` が許す表記の一部だけを正とすることで、フォーマットの揺れをさらに減らす。後方互換があり `gofmt` の差し替えとして使える。
-- ruins での用途: `make lint` / `make check` のフォーマット工程に組み込み、`go fmt` より一段厳しい統一ルールを敷ける。同じ作者 mvdan の `mvdan.cc/sh`・`mvdan.cc/editorconfig` が既に間接依存に入っており、ツール群の親和性も高い。
-- 成熟度: 4,070 スター。2026-08-30 更新と直近も活発。Kubernetes 等の大規模プロジェクトでも採用実績がある定番ツール。
-- ライセンス: BSD-3-Clause
-
-#### 2. gotestyourself/gotestsum
+#### 1. gotestyourself/gotestsum
 
 - リポジトリ: https://github.com/gotestyourself/gotestsum
 - 概要: `go test -json` の出力を人が読みやすい形式に整形し、テスト結果のサマリを表示するテストランナー。JUnit XML 出力や `--rerun-fails` によるフレーキーテストの再実行にも対応する。
-- ruins での用途: `make test` の出力を見やすくし、CI での失敗テストの再実行や JUnit 形式でのレポートに使える。Kubernetes・Docker・etcd・Vault 等での採用実績がある。
-- 成熟度: 2,714 スター。2026-08-27 更新。
+- ruins での用途: `make test` は `xvfb-run` 上で `-v -cover -coverprofile -shuffle -timeout` 付きの `go test` を実行しており、出力を整形する余地がある。
+- 採用時の注意: `xvfb-run` との組み合わせで問題なく動くかの検証が要る。また、CI での JUnit XML 表示やフレーキーテストの再実行は既存の `make grill-branch`、`.github/workflows/check.yml` の `grill-branch` ジョブと役割が重なる可能性があり、GitHub Actions 上のテストサマリ表示を含めて既存の仕組みと比べたうえで導入価値を判断する必要がある。
+- 成熟度: 2,714 スター。2026-08-27 更新。Kubernetes・Docker・etcd・Vault 等での採用実績がある。
 - ライセンス: Apache-2.0
 
-#### 3. kelindar/tile
+#### 2. kelindar/tile
 
 - リポジトリ: https://github.com/kelindar/tile
 - 概要: データ指向・キャッシュフレンドリーな2Dグリッドエンジン。3000×3000のグリッドを約64MBで保持できる省メモリ設計で、A* と幅優先探索によるパスファインディング、タイル更新をチャンネルで通知するオブザーバーパターンを備える。並行読み書きにも対応する。
 - ruins での用途: `internal/mapplanner` や `internal/overworld` が持つ自前のグリッド表現とは別に、タイル更新の購読通知という仕組みを持たない点が異なる。マップの一部だけが変わったときの再描画範囲の絞り込みや、シームレスワールドでのチャンク更新通知に使える可能性がある。
-- 採用時の注意: パスファインディングは既存の自前 BFS と重複するため、グリッド表現とオブザーバー機能だけを部分的に参考にするか、既存グリッドの置き換えとして採用するかは設計判断が要る。
+- 採用時の注意: パスファインディングは既存の自前 BFS と重複するため、グリッド表現とオブザーバー機能だけを部分的に参考にするか、既存グリッドの置き換えとして採用するかは設計判断が要る。225 スターと本ドキュメントの他候補より小規模で、直近コミットが機能追加かバグ修正かまでは未確認のため、採用前に変更履歴を確認したほうがよい。
 - 成熟度: 225 スター。2026-07-06 更新。
 - ライセンス: MIT
 
-#### 4. joeycumines/go-behaviortree
+#### 3. joeycumines/go-behaviortree
 
 - リポジトリ: https://github.com/joeycumines/go-behaviortree
 - 概要: 「fluff のないシンプルな」ビヘイビアツリー実装。Sequence・Selector の基本ノードに加え、状態を持つ処理向けの Memorize・Async・Sync といったリアクティブな拡張ノードを提供する。ツリー実行を管理する Manager・Ticker、デバッグ用の文字列整形も備える。
@@ -81,6 +75,7 @@ auto: needs-decision # mechanical=無人着手可 / needs-decision=人の判断�
 
 ## 採用しなかった方法
 
+- `mvdan/gofumpt`: `gofmt` より厳格なフォーマッタ。status が done の `docs/design/260718102336.md` の「Tier 3 — 状況次第」に「golangci-lint 経由で低コスト」として既に記載済みで、新規候補としての再提案は重複になるため今回の候補からは外した。採否は本ドキュメントではなく `260718102336.md` 側の判断に委ねる。
 - `quasilyte/ebitengine-resource`: Ebitengine 向けリソースマネージャ。ruins は既に `internal/resources` で ECS の World と密結合したリソース管理を持ち、単純な置き換えでは優位性がないため見送った。
 - `magicsea/behavior3go`: 300スターとより人気だが、Behavior3 という外部エディタ向けJSON形式への依存を前提にした設計で、ruins のようなコード内完結の小規模な行動計画には fluff が多い。`joeycumines/go-behaviortree` のほうがシンプルで導入コストが低いと判断した。
 - `RyanCarrier/dijkstra`・`fzipp/astar` 等の汎用パスファインディングライブラリ: グラフ表現からの構築が前提で、ruins のタイルグリッドにそのまま乗らず、自前 BFS を上回る明確な利点も確認できなかった。
@@ -91,11 +86,10 @@ auto: needs-decision # mechanical=無人着手可 / needs-decision=人の判断�
 
 ## コメント
 
-いずれも人が採否を判断する。候補1・2はCIワークフローへの追加で影響範囲が小さく、着手しやすい。候補3・4はゲームプレイに関わる既存アーキテクチャへの部分的な変更または将来の移行先候補であり、実際に採用するかは既存実装との比較検討が要る。
+いずれも人が採否を判断する。候補1はCIワークフローへの追加だが、既存の `make grill-branch` との役割分担を先に整理する必要がある。候補2・3はゲームプレイに関わる既存アーキテクチャへの部分的な変更または将来の移行先候補であり、実際に採用するかは既存実装との比較検討が要る。
 
 ## 進捗
 
-- [ ] mvdan/gofumpt の採用を検討する
 - [ ] gotestyourself/gotestsum の採用を検討する
 - [ ] kelindar/tile の採用を検討する
 - [ ] joeycumines/go-behaviortree の採用を検討する

--- a/docs/design/260901001755.md
+++ b/docs/design/260901001755.md
@@ -61,7 +61,7 @@ auto: needs-decision # mechanical=無人着手可 / needs-decision=人の判断�
 - リポジトリ: https://github.com/joeycumines/go-behaviortree
 - 概要: 「fluff のないシンプルな」ビヘイビアツリー実装。Sequence・Selector の基本ノードに加え、状態を持つ処理向けの Memorize・Async・Sync といったリアクティブな拡張ノードを提供する。ツリー実行を管理する Manager・Ticker、デバッグ用の文字列整形も備える。
 - ruins での用途: `internal/aiinput/planner.go` は `Planner` インターフェースと `runAPLoop` によるシンプルな行動計画で、ビヘイビアツリーではない。隊員数や敵AIの行動パターンが複雑化した場合、Sequence/Selector による宣言的な行動記述への移行先候補になる。
-- 採用時の注意: 既存の `Planner` インターフェースとAPループの設計を置き換える規模の変更になるため、現状のAI行動が実際に複雑化してから検討するのが妥当。ライブラリ自体は小規模で依存も薄い。
+- 採用時の注意: 既存の `Planner` インターフェースとAPループの設計を置き換える規模の変更になるため、現状のAI行動が実際に複雑化してから検討するのが妥当。ライブラリ自体は小規模で依存も薄いが、79 スターと `kelindar/tile` よりさらに小規模で、メンテ継続性は同様に不確か。将来の移行先候補として保留し、実際に採用を検討する段階で変更履歴を再確認する。
 - 成熟度: 79 スター。2026-07-27 更新。
 - ライセンス: Apache-2.0
 

--- a/docs/design/260901001755.md
+++ b/docs/design/260901001755.md
@@ -1,0 +1,101 @@
+---
+status: draft # draft|accepted|in-progress|done|superseded|dropped
+tags: [ci, movement, combat, worldgen]
+auto: needs-decision # mechanical=無人着手可 / needs-decision=人の判断必須
+---
+
+# OSS 調査 2026-09
+
+## 背景
+
+月次の OSS 調査ルーチンによる自動調査。GitHub の検索とトレンドから ruins に役立ちそうな OSS を探し、採否の判断材料として残す。コードの変更や依存追加は行わない。判断と実装は人が行う。
+
+先月の調査 `docs/design/260801002222.md` は候補5件を挙げたが `dropped` として採否判断は見送られた。同じ候補を重複提案しないよう、今回は別領域を中心に探した。
+
+## 要件
+
+- ruins に実際に役立つか。Ebiten・ECS・ゲーム・ローグライク、または Go の開発・テスト・CI・シリアライズ・生成に関わるものに絞る。
+- ある程度のスターとメンテ実績があり、ライセンスが MIT/BSD/Apache 等の使えるものに限る。
+- `go.mod` の既存依存と重複しない。ebiten・ark・ark-serde・testify・urfave/cli・goldie・go-mutesting・BurntSushi/toml・pelletier/go-toml・yaml.v3・getkin/kin-openapi・oapi-codegen・furex とは別のもの。
+- 先月の調査候補、mlange-42/ark-tools・quasilyte/ebitengine-input・quasilyte/pathing・shawnridgeway/wfc・aquilax/go-perlin とは別のもの。
+- 既に自前実装がある領域は、単純な重複なら除外し、明確な優位性がある場合のみ注意書き付きで残す。
+
+## 設計
+
+### 調査方法
+
+1. `gh search repos` 相当の検索を `language:go` で複数ドメインに対して実行した。対象語: `ebiten` / `entity component system` / `roguelike` / `procedural generation` / `game engine` / `pathfinding` / `behavior tree` / `dungeon generation` / `voronoi` / `fuzz testing framework` / `golangci-lint custom linter` / `dice roller rpg` / `gofumpt` / `gotestsum` / `live reload air` / `ebitengine particle`。
+2. GitHub Trends の Go 月間トレンドを取得した。AI エージェント・CLI ツール・インフラ系が中心で、ruins に関係する候補は無かった。先月と同じ傾向。
+3. 候補ごとに README とライセンスを確認し、`go.mod` および `internal/` の既存実装と重複しないか照合した。
+
+### 既存実装との重複チェック
+
+調査の過程で、以下がすでに ruins に自前実装されていることを確認し、候補から除外した。
+
+- アセット管理: `internal/resources/resources.go` がスプライトシート・UI リソース・i18n・設定・シングルトンエンティティを束ねる `Resources` 構造体を持つ。`quasilyte/ebitengine-resource` は Ebitengine 向けリソースマネージャだが、ruins は ECS の World と密結合した自前の管理を既に持ち、単純な置き換えでは優位性がないため除外した。
+- パスファインディング: `internal/mapplanner/pathfinder.go` と `internal/aiinput/planner_squad.go` に自前 BFS がある。先月 `quasilyte/pathing` を注意書き付きで挙げたため今回は重複を避けて別候補にした。
+
+### 候補
+
+#### 1. mvdan/gofumpt
+
+- リポジトリ: https://github.com/mvdan/gofumpt
+- 概要: `gofmt` より厳格なフォーマッタ。`gofmt` が許す表記の一部だけを正とすることで、フォーマットの揺れをさらに減らす。後方互換があり `gofmt` の差し替えとして使える。
+- ruins での用途: `make lint` / `make check` のフォーマット工程に組み込み、`go fmt` より一段厳しい統一ルールを敷ける。同じ作者 mvdan の `mvdan.cc/sh`・`mvdan.cc/editorconfig` が既に間接依存に入っており、ツール群の親和性も高い。
+- 成熟度: 4,070 スター。2026-08-30 更新と直近も活発。Kubernetes 等の大規模プロジェクトでも採用実績がある定番ツール。
+- ライセンス: BSD-3-Clause
+
+#### 2. gotestyourself/gotestsum
+
+- リポジトリ: https://github.com/gotestyourself/gotestsum
+- 概要: `go test -json` の出力を人が読みやすい形式に整形し、テスト結果のサマリを表示するテストランナー。JUnit XML 出力や `--rerun-fails` によるフレーキーテストの再実行にも対応する。
+- ruins での用途: `make test` の出力を見やすくし、CI での失敗テストの再実行や JUnit 形式でのレポートに使える。Kubernetes・Docker・etcd・Vault 等での採用実績がある。
+- 成熟度: 2,714 スター。2026-08-27 更新。
+- ライセンス: Apache-2.0
+
+#### 3. kelindar/tile
+
+- リポジトリ: https://github.com/kelindar/tile
+- 概要: データ指向・キャッシュフレンドリーな2Dグリッドエンジン。3000×3000のグリッドを約64MBで保持できる省メモリ設計で、A* と幅優先探索によるパスファインディング、タイル更新をチャンネルで通知するオブザーバーパターンを備える。並行読み書きにも対応する。
+- ruins での用途: `internal/mapplanner` や `internal/overworld` が持つ自前のグリッド表現とは別に、タイル更新の購読通知という仕組みを持たない点が異なる。マップの一部だけが変わったときの再描画範囲の絞り込みや、シームレスワールドでのチャンク更新通知に使える可能性がある。
+- 採用時の注意: パスファインディングは既存の自前 BFS と重複するため、グリッド表現とオブザーバー機能だけを部分的に参考にするか、既存グリッドの置き換えとして採用するかは設計判断が要る。
+- 成熟度: 225 スター。2026-07-06 更新。
+- ライセンス: MIT
+
+#### 4. joeycumines/go-behaviortree
+
+- リポジトリ: https://github.com/joeycumines/go-behaviortree
+- 概要: 「fluff のないシンプルな」ビヘイビアツリー実装。Sequence・Selector の基本ノードに加え、状態を持つ処理向けの Memorize・Async・Sync といったリアクティブな拡張ノードを提供する。ツリー実行を管理する Manager・Ticker、デバッグ用の文字列整形も備える。
+- ruins での用途: `internal/aiinput/planner.go` は `Planner` インターフェースと `runAPLoop` によるシンプルな行動計画で、ビヘイビアツリーではない。隊員数や敵AIの行動パターンが複雑化した場合、Sequence/Selector による宣言的な行動記述への移行先候補になる。
+- 採用時の注意: 既存の `Planner` インターフェースとAPループの設計を置き換える規模の変更になるため、現状のAI行動が実際に複雑化してから検討するのが妥当。ライブラリ自体は小規模で依存も薄い。
+- 成熟度: 79 スター。2026-07-27 更新。
+- ライセンス: Apache-2.0
+
+## 変更箇所
+
+本ドキュメントの新規作成のみ。コードおよび依存関係の変更はない。
+
+| ファイル | 変更内容 |
+| --- | --- |
+| `docs/design/260901001755.md` | 新規作成 |
+
+## 採用しなかった方法
+
+- `quasilyte/ebitengine-resource`: Ebitengine 向けリソースマネージャ。ruins は既に `internal/resources` で ECS の World と密結合したリソース管理を持ち、単純な置き換えでは優位性がないため見送った。
+- `magicsea/behavior3go`: 300スターとより人気だが、Behavior3 という外部エディタ向けJSON形式への依存を前提にした設計で、ruins のようなコード内完結の小規模な行動計画には fluff が多い。`joeycumines/go-behaviortree` のほうがシンプルで導入コストが低いと判断した。
+- `RyanCarrier/dijkstra`・`fzipp/astar` 等の汎用パスファインディングライブラリ: グラフ表現からの構築が前提で、ruins のタイルグリッドにそのまま乗らず、自前 BFS を上回る明確な利点も確認できなかった。
+- ビヘイビアツリー全般の他候補、`askft/go-behave`・`shionryuu/gobevtree` 等: スター数・更新頻度が低く、`joeycumines/go-behaviortree` を上回る理由がなかった。
+- Voronoi 図生成ライブラリ群、`pzsz/voronoi`・`peterhellberg/karta` 等: `internal/overworld` の集落・ランドマーク配置は `Placement` 構造体によるグリッド+ソルトのハッシュ配置で、Voronoi 分割を要する具体的な用途が今のところ無い。
+- ダイスローラー・fuzz テストフレームワーク・golangci-lint 用カスタムリンタの検索: 該当領域はヒットしたリポジトリのスター数が極めて少なく、ruins の `math/rand/v2` 直接利用や既存の `testify`・`go-mutesting` を上回る候補が無かった。
+- GitHub Trends（Go 月間）: DeepSeek関連のAIコーディングエージェント・App Store Connect CLI・Kubernetes関連ツール・Traefik・Caddy 等が中心で、ruins に関連する候補は無かった。
+
+## コメント
+
+いずれも人が採否を判断する。候補1・2はCIワークフローへの追加で影響範囲が小さく、着手しやすい。候補3・4はゲームプレイに関わる既存アーキテクチャへの部分的な変更または将来の移行先候補であり、実際に採用するかは既存実装との比較検討が要る。
+
+## 進捗
+
+- [ ] mvdan/gofumpt の採用を検討する
+- [ ] gotestyourself/gotestsum の採用を検討する
+- [ ] kelindar/tile の採用を検討する
+- [ ] joeycumines/go-behaviortree の採用を検討する


### PR DESCRIPTION
## 概要

月次の OSS 調査ルーチンによる自動調査です。GitHub 検索と GitHub Trends から ruins に役立ちそうな OSS を探し、`docs/design/260901001755.md` に調査結果をまとめました。

これは提案であり、採否は人がレビューで判断します。コードの変更や依存の追加は行っていません。

## 候補

- [mvdan/gofumpt](https://github.com/mvdan/gofumpt) — `gofmt` より厳格なフォーマッタ。CI/lint 工程向け
- [gotestyourself/gotestsum](https://github.com/gotestyourself/gotestsum) — 出力を整形するテストランナー。CI 向け
- [kelindar/tile](https://github.com/kelindar/tile) — キャッシュフレンドリーな2Dグリッドエンジン。パスファインディング・オブザーバーパターン
- [joeycumines/go-behaviortree](https://github.com/joeycumines/go-behaviortree) — シンプルなビヘイビアツリー実装。AI行動計画の将来的な移行先候補

先月の調査、`docs/design/260801002222.md` は `dropped` として見送られたため、今回は別領域を中心に探しました。詳細な評価理由と、採用しなかった候補についてはドキュメント本文を参照してください。

## 検証

- [x] `go run . designdoc validate` が通ることを確認
- [x] `make generate` で README を再生成

---
_Generated by [Claude Code](https://claude.ai/code/session_01FfaVFV7LGjCVnBcXdGTqAT)_