### PR TITLE
test(lifecycle): カバレッジ増強

### DIFF
--- a/internal/world/lifecycle/disassembly_test.go
+++ b/internal/world/lifecycle/disassembly_test.go
@@ -4,8 +4,12 @@ import (
 	"math/rand/v2"
 	"testing"
 
+	gc "github.com/kijimaD/ruins/internal/components"
+	"github.com/kijimaD/ruins/internal/consts"
 	"github.com/kijimaD/ruins/internal/oapi"
+	"github.com/kijimaD/ruins/internal/testutil"
 	"github.com/kijimaD/ruins/internal/world/lifecycle"
+	"github.com/mlange-42/ark/ecs"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -199,5 +203,59 @@ func TestRollDisassemblyYields(t *testing.T) {
 			}
 		}
 		assert.InDelta(t, 600, hit, 150, "確定枠はDestroySalvageChance前後で当選するべき")
+	})
+
+	t.Run("個数表記が不正だとエラーを返す", func(t *testing.T) {
+		t.Parallel()
+		rng := rand.New(rand.NewPCG(10, 0))
+		def := &oapi.Disassembly{
+			ToolCategory: oapi.Prying,
+			BaseAP:       100,
+			Yields:       []oapi.DisassemblyYield{{Id: "鉄くず", Count: "invalid"}},
+		}
+
+		_, err := lifecycle.RollDisassemblyYields(rng, def, 0, 1, true)
+
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "invalid disassembly yield count notation")
+	})
+}
+
+// TestSpawnDisassemblyYields は分解産出の一覧を指定タイルへフィールドアイテムとして
+// 生成することと、アイテム生成に失敗した場合にエラーが伝播することを検証する。
+func TestSpawnDisassemblyYields(t *testing.T) {
+	t.Parallel()
+
+	t.Run("指定タイルへ産出をフィールドアイテムとして生成する", func(t *testing.T) {
+		t.Parallel()
+		world := testutil.InitTestWorld(t)
+		stacks := []lifecycle.YieldStack{
+			{Name: "scrap_iron", Count: 2},
+			{Name: "healing_potion", Count: 1},
+		}
+
+		err := lifecycle.SpawnDisassemblyYields(world, stacks, consts.Tile(3), consts.Tile(4))
+		require.NoError(t, err)
+
+		counts := map[string]int{}
+		q := ecs.NewFilter2[gc.LocationOnField, gc.GridElement](world.ECS).Query()
+		for q.Next() {
+			entity := q.Entity()
+			grid := world.Components.GridElement.Get(entity)
+			assert.Equal(t, consts.Tile(3), grid.X)
+			assert.Equal(t, consts.Tile(4), grid.Y)
+			counts[world.Components.RawID.Get(entity).ID]++
+		}
+		assert.Equal(t, map[string]int{"scrap_iron": 2, "healing_potion": 1}, counts, "定義した個数どおりにフィールドへ生成される")
+	})
+
+	t.Run("存在しないアイテム名はエラーを返す", func(t *testing.T) {
+		t.Parallel()
+		world := testutil.InitTestWorld(t)
+		stacks := []lifecycle.YieldStack{{Name: "存在しないアイテム", Count: 1}}
+
+		err := lifecycle.SpawnDisassemblyYields(world, stacks, consts.Tile(0), consts.Tile(0))
+
+		require.ErrorIs(t, err, lifecycle.ErrItemGeneration)
 	})
 }

--- a/internal/world/lifecycle/disassembly_test.go
+++ b/internal/world/lifecycle/disassembly_test.go
@@ -221,8 +221,6 @@ func TestRollDisassemblyYields(t *testing.T) {
 	})
 }
 
-// TestSpawnDisassemblyYields は分解産出の一覧を指定タイルへフィールドアイテムとして
-// 生成することと、アイテム生成に失敗した場合にエラーが伝播することを検証する。
 func TestSpawnDisassemblyYields(t *testing.T) {
 	t.Parallel()
 

--- a/internal/world/lifecycle/inventory_test.go
+++ b/internal/world/lifecycle/inventory_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/kijimaD/ruins/internal/consts"
 	"github.com/kijimaD/ruins/internal/testutil"
 	w "github.com/kijimaD/ruins/internal/world"
+	"github.com/kijimaD/ruins/internal/world/query"
 	"github.com/mlange-42/ark/ecs"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -154,5 +155,31 @@ func TestChangeItemCount(t *testing.T) {
 
 		// WeightDirtyフラグが立っていることを確認
 		assert.True(t, world.Components.WeightDirty.Has(player), "WeightDirtyフラグが立つべき")
+	})
+
+	t.Run("収納アイテムを増やすと収納へ同種を生成する", func(t *testing.T) {
+		t.Parallel()
+		world := testutil.InitTestWorld(t)
+
+		storage := world.ECS.NewEntity()
+		item, err := SpawnStorageItem(world, "healing_potion", 2, storage)
+		require.NoError(t, err)
+
+		err = ChangeItemCount(world, item, 3)
+		require.NoError(t, err)
+
+		assert.Len(t, query.GetStorageItems(world, storage), 5, "収納の在庫が5個になる")
+	})
+
+	t.Run("バックパックにも収納にもないアイテムを増やそうとするとエラー", func(t *testing.T) {
+		t.Parallel()
+		world := testutil.InitTestWorld(t)
+
+		// フィールド上のアイテムはバックパックにも収納にも属さない
+		item, err := SpawnFieldItem(world, "healing_potion", consts.Tile(1), consts.Tile(1), 1)
+		require.NoError(t, err)
+
+		err = ChangeItemCount(world, item, 1)
+		require.EqualError(t, err, "cannot add to stack: entity has no backpack or storage location")
 	})
 }

--- a/internal/world/lifecycle/location_test.go
+++ b/internal/world/lifecycle/location_test.go
@@ -274,3 +274,50 @@ func TestUnequipAll(t *testing.T) {
 		assert.True(t, world.Components.LocationEquipped.Has(item))
 	})
 }
+
+func TestRemoveOwnedStorage(t *testing.T) {
+	t.Parallel()
+
+	t.Run("owner指定なしでは何も削除しない", func(t *testing.T) {
+		t.Parallel()
+		world := testutil.InitTestWorld(t)
+
+		storage := world.ECS.NewEntity()
+		item, err := SpawnStorageItem(world, "wooden_sword", 1, storage)
+		require.NoError(t, err)
+
+		RemoveOwnedStorage(world, nil)
+
+		assert.True(t, world.ECS.Alive(item), "owner未指定では在庫は残る")
+	})
+
+	t.Run("指定した所有者の収納在庫を削除する", func(t *testing.T) {
+		t.Parallel()
+		world := testutil.InitTestWorld(t)
+
+		storage := world.ECS.NewEntity()
+		item, err := SpawnStorageItem(world, "wooden_sword", 1, storage)
+		require.NoError(t, err)
+
+		RemoveOwnedStorage(world, []ecs.Entity{storage})
+
+		assert.False(t, world.ECS.Alive(item), "指定した所有者の在庫は削除される")
+	})
+
+	t.Run("指定していない所有者の収納在庫は残る", func(t *testing.T) {
+		t.Parallel()
+		world := testutil.InitTestWorld(t)
+
+		storageA := world.ECS.NewEntity()
+		storageB := world.ECS.NewEntity()
+		itemA, err := SpawnStorageItem(world, "wooden_sword", 1, storageA)
+		require.NoError(t, err)
+		itemB, err := SpawnStorageItem(world, "wooden_sword", 1, storageB)
+		require.NoError(t, err)
+
+		RemoveOwnedStorage(world, []ecs.Entity{storageA})
+
+		assert.False(t, world.ECS.Alive(itemA), "指定した所有者Aの在庫は削除される")
+		assert.True(t, world.ECS.Alive(itemB), "指定していない所有者Bの在庫は残る")
+	})
+}

--- a/internal/world/lifecycle/spawn_test.go
+++ b/internal/world/lifecycle/spawn_test.go
@@ -5,6 +5,7 @@ import (
 
 	gc "github.com/kijimaD/ruins/internal/components"
 	"github.com/kijimaD/ruins/internal/consts"
+	"github.com/kijimaD/ruins/internal/raw"
 	"github.com/kijimaD/ruins/internal/testutil"
 	"github.com/kijimaD/ruins/internal/world/query"
 	"github.com/mlange-42/ark/ecs"
@@ -520,4 +521,47 @@ func TestMoveToBackpack_1個1エンティティなので合流しない(t *testi
 	assert.True(t, world.ECS.Alive(b1), "b1 は残る")
 	assert.True(t, world.ECS.Alive(b2), "b2 も残る。合流で消えない")
 	assert.Equal(t, 2, query.GetEntityCount(world, b1), "同一スタックとして個数2に数えられる")
+}
+
+func TestSpawnTile(t *testing.T) {
+	t.Parallel()
+
+	t.Run("通行不可タイルはBlockPassを持つ", func(t *testing.T) {
+		t.Parallel()
+		world := testutil.InitTestWorld(t)
+
+		entity, err := SpawnTile(world, consts.TileNameWall, consts.Tile(3), consts.Tile(4), nil)
+		require.NoError(t, err)
+
+		require.True(t, world.Components.GridElement.Has(entity))
+		grid := world.Components.GridElement.Get(entity)
+		assert.Equal(t, consts.Tile(3), grid.X)
+		assert.Equal(t, consts.Tile(4), grid.Y)
+		assert.True(t, world.Components.BlockPass.Has(entity), "壁は通行不可")
+	})
+
+	t.Run("autoTileIndex指定でスプライトキーにインデックスが付く", func(t *testing.T) {
+		t.Parallel()
+		world := testutil.InitTestWorld(t)
+
+		entity, err := SpawnTile(world, consts.TileNameDirt, consts.Tile(0), consts.Tile(0), new(2))
+		require.NoError(t, err)
+
+		require.True(t, world.Components.SpriteRender.Has(entity))
+		sprite := world.Components.SpriteRender.Get(entity)
+		assert.Equal(t, "dirt_2", sprite.SpriteKey, "オートタイルインデックスがスプライトキーに付与される")
+	})
+
+	t.Run("存在しないタイル名はKeyNotFoundErrorになる", func(t *testing.T) {
+		t.Parallel()
+		world := testutil.InitTestWorld(t)
+
+		_, err := SpawnTile(world, "存在しないタイル", consts.Tile(0), consts.Tile(0), nil)
+		require.Error(t, err)
+
+		var keyErr raw.KeyNotFoundError
+		require.ErrorAs(t, err, &keyErr)
+		assert.Equal(t, "存在しないタイル", keyErr.Key)
+		assert.Equal(t, "Tiles", keyErr.Collection)
+	})
 }


### PR DESCRIPTION
## 概要

`internal/world/lifecycle` のテストカバレッジを 86.5% → 93.6% に増強する。テストのみの追加で、本体コードは変更していない。

## 追加したテスト

- `inventory_test.go`: `ChangeItemCount` に収納アイテムを増やす経路と、バックパックにも収納にも属さないアイテムを増やそうとしてエラーになる経路を追加
- `location_test.go`: 未検証だった `RemoveOwnedStorage` に、owner 未指定時の無処理・指定した所有者の収納在庫の削除・指定していない所有者の在庫は残ることを検証
- `disassembly_test.go`: `RollDisassemblyYields` にダイス表記が不正な場合のエラー経路を追加。未検証だった `SpawnDisassemblyYields` に、指定タイルへの産出生成と、アイテム生成失敗時のエラー伝播を検証
- `spawn_test.go`: 未検証だった `SpawnTile` に、通行不可タイルの `BlockPass` 付与・オートタイル添字によるスプライトキー生成・存在しないタイル名での `KeyNotFoundError` を検証

## 検証

- `go build ./...`
- `make test`
- `make lint`

すべて成功を確認した。

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DC4KbjKWCxAo1RE1ibCPGv

---
_Generated by [Claude Code](https://claude.ai/code/session_01DC4KbjKWCxAo1RE1ibCPGv)_