### PR TITLE
feat: 日付の変わり目にN日目をスプラッシュ表示する

### DIFF
--- a/internal/components/game_time.go
+++ b/internal/components/game_time.go
@@ -139,6 +139,17 @@ func (gt *GameTime) SeasonJustChanged() bool {
 	return gt.GetSeason() != prev.GetSeason()
 }
 
+// DayJustChanged は現在の日数と、直前のターンから日付が変わったかを返す。Advance の直後に呼ぶ想定。
+// 呼び出し側が変わった先の日数をそのまま通知に使えるよう日数も返す。
+func (gt *GameTime) DayJustChanged() (int, bool) {
+	cur := gt.GetDayNumber()
+	if gt.TotalTurns == 0 {
+		return cur, false
+	}
+	prev := GameTime{TotalTurns: gt.TotalTurns - 1}
+	return cur, prev.GetDayNumber() != cur
+}
+
 // TimeOfDayJustChanged は現在の時間帯と、直前のターンから変わったかを返す。
 // 呼び出し側が入った先で日の出入りを見分けられるよう時間帯も返す。
 func (gt *GameTime) TimeOfDayJustChanged() (TimeOfDay, bool) {

--- a/internal/components/game_time_test.go
+++ b/internal/components/game_time_test.go
@@ -295,6 +295,33 @@ func TestGameTime_SeasonJustChanged(t *testing.T) {
 	}
 }
 
+func TestGameTime_DayJustChanged(t *testing.T) {
+	t.Parallel()
+
+	// 日付が切り替わるのは turnsPerDay=1500 の倍数。turn 0 は1日目の開始だが前ターンが無く変化なしとする
+	tests := []struct {
+		name    string
+		turns   consts.Turn
+		day     int
+		changed bool
+	}{
+		{"開始ターンは1日目で変化なし", 0, 1, false},
+		{"1日目の最後のターンは変化なし", 1499, 1, false},
+		{"日付が切り替わるターンは2日目", 1500, 2, true},
+		{"切り替わりの次は変化なし", 1501, 2, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			gt := &GameTime{TotalTurns: tt.turns}
+			day, changed := gt.DayJustChanged()
+			assert.Equal(t, tt.day, day)
+			assert.Equal(t, tt.changed, changed)
+		})
+	}
+}
+
 func TestGameTime_TimeOfDayJustChanged(t *testing.T) {
 	t.Parallel()
 

--- a/internal/i18n/locale/ja.po
+++ b/internal/i18n/locale/ja.po
@@ -5907,6 +5907,9 @@ msgstr "熱量"
 msgid "Turns left"
 msgstr "残りターン"
 
+msgid "Day %d"
+msgstr "%d日目"
+
 msgid "The season changed to %s."
 msgstr "季節が%sになった。"
 

--- a/internal/states/dungeon.go
+++ b/internal/states/dungeon.go
@@ -106,7 +106,13 @@ func (st *DungeonState) OnStart(world w.World) error {
 	// overworld.Driver に閉じ込め、DungeonState はここで開始を委譲するだけにする
 	if st.isSeamless() {
 		st.driver = overworld.NewDriver(st.planner, st.overworldDefinition, st.newGame)
-		return st.driver.Start(world)
+		if err := st.driver.Start(world); err != nil {
+			return err
+		}
+		// オーバーワールドの開始はダンジョン名でなく経過日数を大書きする。
+		// 生き延びた日数がこのゲームの目的であることを、新規開始とロード復帰の節目で示す
+		lifecycle.SpawnSplashText(world, query.T(world, "Day %d", query.GetGameTime(world).GetDayNumber()))
+		return nil
 	}
 
 	// 進入先の遺跡定義名を決める。State に明示指定があればそれを使い、無ければ現ステージ、
@@ -145,18 +151,12 @@ func (st *DungeonState) OnStart(world w.World) error {
 	// 発生するため、古いデータが残り移動不能になることがある
 	query.InvalidateSpatialIndex(world)
 
-	// ダンジョンタイトルエフェクト用エンティティを作成する
-	screenW, screenH := world.Resources.GetScreenDimensions()
+	// ダンジョン名のタイトルをスプラッシュ表示する
 	titleText := query.T(world, def.Name())
 	if st.Depth > 0 {
 		titleText = fmt.Sprintf("%s %dF", query.T(world, def.Name()), st.Depth)
 	}
-	splashFace := world.Resources.UIResources.Text.SplashFontFace
-	titleEffect := gc.NewSplashTextEffect(titleText, splashFace, screenW, screenH)
-	titleEntity := world.ECS.NewEntity()
-	world.Components.VisualEffects.Add(titleEntity, &gc.VisualEffects{
-		Effects: []gc.VisualEffect{titleEffect},
-	})
+	lifecycle.SpawnSplashText(world, titleText)
 
 	return nil
 }

--- a/internal/states/dungeon.go
+++ b/internal/states/dungeon.go
@@ -109,8 +109,7 @@ func (st *DungeonState) OnStart(world w.World) error {
 		if err := st.driver.Start(world); err != nil {
 			return err
 		}
-		// オーバーワールドの開始はダンジョン名でなく経過日数を大書きする。
-		// 生き延びた日数がこのゲームの目的であることを、新規開始とロード復帰の節目で示す
+		// 生き延びた日数がこのゲームの目的であることを、新規開始とロード復帰の節目で大書きして示す
 		lifecycle.SpawnSplashText(world, query.T(world, "Day %d", query.GetGameTime(world).GetDayNumber()))
 		return nil
 	}
@@ -151,7 +150,6 @@ func (st *DungeonState) OnStart(world w.World) error {
 	// 発生するため、古いデータが残り移動不能になることがある
 	query.InvalidateSpatialIndex(world)
 
-	// ダンジョン名のタイトルをスプラッシュ表示する
 	titleText := query.T(world, def.Name())
 	if st.Depth > 0 {
 		titleText = fmt.Sprintf("%s %dF", query.T(world, def.Name()), st.Depth)

--- a/internal/states/overworld_test.go
+++ b/internal/states/overworld_test.go
@@ -102,6 +102,32 @@ func TestOverworldState_OnStart_初期帯とプレイヤー中央(t *testing.T) 
 	assert.GreaterOrEqual(t, entranceCount, 1, "遺跡入口が少なくとも1つ置かれる")
 }
 
+// TestOverworldState_OnStart_経過日数のスプラッシュを出す は、オーバーワールド開始の節目に
+// 経過日数がスプラッシュ表示されることを固定する。生き延びた日数がこのゲームの目的である
+// ことを開始時に示す配線を守る。
+func TestOverworldState_OnStart_経過日数のスプラッシュを出す(t *testing.T) {
+	t.Parallel()
+
+	world := testutil.InitTestWorld(t)
+	factory := NewOverworldState(mapplanner.PlannerTypeSmallRoom, dungeon.NewOverworldDefinition("オーバーワールド", 0, 30, 20, 3, 1), &overworld.NewGameParams{RunSeed: 777})
+	state, err := factory()
+	require.NoError(t, err)
+	st, ok := state.(*DungeonState)
+	require.True(t, ok)
+	require.NoError(t, st.OnStart(world))
+
+	var texts []string
+	q := ecs.NewFilter1[gc.VisualEffects](world.ECS).Query()
+	for q.Next() {
+		for _, effect := range world.Components.VisualEffects.Get(q.Entity()).Effects {
+			if splash, isSplash := effect.(*gc.SplashTextEffect); isSplash {
+				texts = append(texts, splash.Text)
+			}
+		}
+	}
+	assert.Equal(t, []string{"Day 1"}, texts, "新規開始は1日目のスプラッシュが湧く")
+}
+
 // TestOverworldState_オーバーレイ進入で帯タイルを消さない は、射撃/観察等のオーバーレイ
 // （TransPush → OnPause）に入ったときに帯タイルが消えない（黒画面にならない）ことを固定する。
 func TestOverworldState_オーバーレイ進入で帯タイルを消さない(t *testing.T) {

--- a/internal/systems/turn_system.go
+++ b/internal/systems/turn_system.go
@@ -9,6 +9,7 @@ import (
 	"github.com/kijimaD/ruins/internal/logger"
 	w "github.com/kijimaD/ruins/internal/world"
 
+	"github.com/kijimaD/ruins/internal/world/lifecycle"
 	"github.com/kijimaD/ruins/internal/world/query"
 )
 
@@ -116,15 +117,21 @@ func runEndPhase(world w.World, turnState *gc.TurnState) error {
 	// ゲーム内時間を1ターン進める。昼夜・気温の時間修正がこれに依存する。
 	// GameTime は Dungeon 内で永続なのでセーブ/ロードでも一貫する
 	query.GetGameTime(world).Advance()
-	// 季節や日の出入りが変わったらログへ出す
-	logEnvironmentChange(world)
+	// 季節や日付、日の出入りが変わったらプレイヤーへ知らせる
+	notifyEnvironmentChange(world)
 	return nil
 }
 
-// logEnvironmentChange は季節や日の出入りが変わったらゲームログへ出す。
+// notifyEnvironmentChange は季節や日の出入りが変わったらゲームログへ出し、日付が変わったら
+// 画面中央にスプラッシュで大書きする。生き延びた日数はこのゲームの目的の実感そのものなので、
+// ログに流さず節目として目立たせる。
 // 変化は現在ターンと直前ターンの導出値の差で判定するので、GameTime.Advance の直後に呼ぶ。
-func logEnvironmentChange(world w.World) {
+func notifyEnvironmentChange(world w.World) {
 	gt := query.GetGameTime(world)
+
+	if day, changed := gt.DayJustChanged(); changed {
+		lifecycle.SpawnSplashText(world, query.T(world, "Day %d", day))
+	}
 
 	if gt.SeasonJustChanged() {
 		name := query.T(world, gt.GetSeason().String())

--- a/internal/systems/turn_system.go
+++ b/internal/systems/turn_system.go
@@ -117,7 +117,6 @@ func runEndPhase(world w.World, turnState *gc.TurnState) error {
 	// ゲーム内時間を1ターン進める。昼夜・気温の時間修正がこれに依存する。
 	// GameTime は Dungeon 内で永続なのでセーブ/ロードでも一貫する
 	query.GetGameTime(world).Advance()
-	// 季節や日付、日の出入りが変わったらプレイヤーへ知らせる
 	notifyEnvironmentChange(world)
 	return nil
 }

--- a/internal/systems/turn_system_test.go
+++ b/internal/systems/turn_system_test.go
@@ -964,7 +964,7 @@ func TestNotifyEnvironmentChange(t *testing.T) {
 		assert.Contains(t, hist[0], "The sun rises.")
 	})
 
-	t.Run("季節の変わるターンは季節と日の出の両方を出す", func(t *testing.T) {
+	t.Run("季節の変わるターンは季節と日の出のログと日数スプラッシュを出す", func(t *testing.T) {
 		t.Parallel()
 		world := testutil.InitTestWorld(t)
 		// 春から夏へ切り替わる経過ターン。日の始まりは夜明けなので日の出とも重なる
@@ -977,6 +977,8 @@ func TestNotifyEnvironmentChange(t *testing.T) {
 		assert.Contains(t, hist[0], "The season changed to")
 		assert.Contains(t, hist[0], "Summer")
 		assert.Contains(t, hist[1], "The sun rises.")
+		// 季節の切り替わりは日付の繰り上がりと同時に起きるので、日数スプラッシュも同じターンに湧く
+		assert.Equal(t, []string{"Day 9"}, splashTexts(world))
 	})
 
 	t.Run("時間帯も季節も変わらないターンはログを出さない", func(t *testing.T) {

--- a/internal/systems/turn_system_test.go
+++ b/internal/systems/turn_system_test.go
@@ -925,7 +925,7 @@ func TestTerritorialMovement(t *testing.T) {
 	}
 }
 
-func TestLogEnvironmentChange(t *testing.T) {
+func TestNotifyEnvironmentChange(t *testing.T) {
 	t.Parallel()
 
 	t.Run("夜へ入るターンは日が沈んだログを出す", func(t *testing.T) {
@@ -934,7 +934,7 @@ func TestLogEnvironmentChange(t *testing.T) {
 		// 夜の開始ターン。夕は薄暮で太陽がまだ空にあり、沈み切って夜になった瞬間が日の入り
 		query.GetGameTime(world).TotalTurns = 1000
 
-		logEnvironmentChange(world)
+		notifyEnvironmentChange(world)
 
 		hist := query.GetGameLog(world).GetHistory()
 		require.Len(t, hist, 1)
@@ -946,7 +946,7 @@ func TestLogEnvironmentChange(t *testing.T) {
 		world := testutil.InitTestWorld(t)
 		query.GetGameTime(world).TotalTurns = 750 // 夕の開始
 
-		logEnvironmentChange(world)
+		notifyEnvironmentChange(world)
 
 		assert.Equal(t, 0, query.GetGameLog(world).Count())
 	})
@@ -957,7 +957,7 @@ func TestLogEnvironmentChange(t *testing.T) {
 		// 2日目の夜明けの開始ターン。turn 0 は前ターンが無く変化判定が立たないため翌日で確かめる
 		query.GetGameTime(world).TotalTurns = 1500
 
-		logEnvironmentChange(world)
+		notifyEnvironmentChange(world)
 
 		hist := query.GetGameLog(world).GetHistory()
 		require.Len(t, hist, 1)
@@ -970,7 +970,7 @@ func TestLogEnvironmentChange(t *testing.T) {
 		// 春から夏へ切り替わる経過ターン。日の始まりは夜明けなので日の出とも重なる
 		query.GetGameTime(world).TotalTurns = 12000
 
-		logEnvironmentChange(world)
+		notifyEnvironmentChange(world)
 
 		hist := query.GetGameLog(world).GetHistory()
 		require.Len(t, hist, 2)
@@ -984,8 +984,43 @@ func TestLogEnvironmentChange(t *testing.T) {
 		world := testutil.InitTestWorld(t)
 		query.GetGameTime(world).TotalTurns = 1001
 
-		logEnvironmentChange(world)
+		notifyEnvironmentChange(world)
 
 		assert.Equal(t, 0, query.GetGameLog(world).Count())
 	})
+
+	t.Run("日付の変わるターンはN日目のスプラッシュを出す", func(t *testing.T) {
+		t.Parallel()
+		world := testutil.InitTestWorld(t)
+		// 2日目の開始ターン。日付の繰り上がりは夜明け入りと同時に起きる
+		query.GetGameTime(world).TotalTurns = 1500
+
+		notifyEnvironmentChange(world)
+
+		assert.Equal(t, []string{"Day 2"}, splashTexts(world))
+	})
+
+	t.Run("日付の変わらないターンはスプラッシュを出さない", func(t *testing.T) {
+		t.Parallel()
+		world := testutil.InitTestWorld(t)
+		query.GetGameTime(world).TotalTurns = 1501
+
+		notifyEnvironmentChange(world)
+
+		assert.Empty(t, splashTexts(world))
+	})
+}
+
+// splashTexts はワールドに湧いているスプラッシュ表示エフェクトのテキストを列挙する。
+func splashTexts(world w.World) []string {
+	var texts []string
+	q := ecs.NewFilter1[gc.VisualEffects](world.ECS).Query()
+	for q.Next() {
+		for _, effect := range world.Components.VisualEffects.Get(q.Entity()).Effects {
+			if splash, ok := effect.(*gc.SplashTextEffect); ok {
+				texts = append(texts, splash.Text)
+			}
+		}
+	}
+	return texts
 }

--- a/internal/world/lifecycle/spawn.go
+++ b/internal/world/lifecycle/spawn.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"math/rand/v2"
 
+	"github.com/hajimehoshi/ebiten/v2/text/v2"
 	gc "github.com/kijimaD/ruins/internal/components"
 	"github.com/kijimaD/ruins/internal/consts"
 	"github.com/kijimaD/ruins/internal/formula"
@@ -340,6 +341,23 @@ func SpawnVisualEffect(target ecs.Entity, effect gc.VisualEffect, world w.World)
 
 	effectEntity := world.ECS.NewEntity()
 	world.Components.GridElement.Add(effectEntity, &gc.GridElement{Coord: gridElement.Coord})
+	world.Components.VisualEffects.Add(effectEntity, &gc.VisualEffects{
+		Effects: []gc.VisualEffect{effect},
+	})
+}
+
+// SpawnSplashText は画面中央にテキストをスプラッシュ表示するエフェクト専用エンティティを生成する。
+// ダンジョン進入のタイトルや日付の切り替わりなど、場面の節目を大書きで知らせる演出に使う。
+// フォント未ロードの環境では face を nil のまま作る。描画は起きないので害がなく、
+// 生成の事実はテストから観測できる
+func SpawnSplashText(world w.World, textStr string) {
+	screenW, screenH := world.Resources.GetScreenDimensions()
+	var face text.Face
+	if tr := world.Resources.UIResources.Text; tr != nil {
+		face = tr.SplashFontFace
+	}
+	effect := gc.NewSplashTextEffect(textStr, face, screenW, screenH)
+	effectEntity := world.ECS.NewEntity()
 	world.Components.VisualEffects.Add(effectEntity, &gc.VisualEffects{
 		Effects: []gc.VisualEffect{effect},
 	})

--- a/internal/world/lifecycle/spawn.go
+++ b/internal/world/lifecycle/spawn.go
@@ -347,9 +347,8 @@ func SpawnVisualEffect(target ecs.Entity, effect gc.VisualEffect, world w.World)
 }
 
 // SpawnSplashText は画面中央にテキストをスプラッシュ表示するエフェクト専用エンティティを生成する。
-// ダンジョン進入のタイトルや日付の切り替わりなど、場面の節目を大書きで知らせる演出に使う。
-// フォント未ロードの環境では face を nil のまま作る。描画は起きないので害がなく、
-// 生成の事実はテストから観測できる
+// 場面の節目を大書きで知らせる演出に使う。face はフォント未ロードの環境では nil のまま作り、
+// 描画しない環境でも生成できるようにする
 func SpawnSplashText(world w.World, textStr string) {
 	screenW, screenH := world.Resources.GetScreenDimensions()
 	var face text.Face


### PR DESCRIPTION
## 概要

生き延びた日数がこのゲームの目的であることを見せるため、日付が変わったターンに「N日目」を画面中央へスプラッシュ表示する。ダンジョン進入時にタイトルを出していた既存の SplashTextEffect 演出を流用した。

## 変更内容

- `GameTime.DayJustChanged()` を追加。SeasonJustChanged と同じく1ターン前との導出値比較で判定し、状態を保存しない
- スプラッシュ生成を `lifecycle.SpawnSplashText(world, text)` へ共有ヘルパー化。ダンジョン進入タイトルもこれを通すよう置換
- ターン終了処理の `logEnvironmentChange` を `notifyEnvironmentChange` へ改名し、日付変化で「Day N」をスプラッシュ表示
- オーバーワールド開始時にも現在日数をスプラッシュ表示。新規開始とロード復帰の節目で生存日数を示す。従来ここは isSeamless の早期委譲でタイトル演出に到達せず何も出ていなかった
- i18n: msgid `"Day %d"` と ja 訳 `"%d日目"` を追加

## テスト

- `TestGameTime_DayJustChanged`: 日付境界 1499/1500/1501 の判定
- `TestNotifyEnvironmentChange`: 日付が変わるターンにスプラッシュが湧き、変わらないターンは湧かない
- `TestOverworldState_OnStart_経過日数のスプラッシュを出す`: 新規開始で「Day 1」が湧く
- VRT golden への影響なし。DisableAnimation 時は VisualEffectSystem がエフェクトを即削除するため
- `make check` exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NrH4X8pB7BsgL7cMstFtqQ