### PR TITLE
test(mapplanner): カバレッジ増強

### DIFF
--- a/internal/mapplanner/lib_test.go
+++ b/internal/mapplanner/lib_test.go
@@ -1,0 +1,101 @@
+package mapplanner
+
+import (
+	"math/rand/v2"
+	"testing"
+
+	gc "github.com/kijimaD/ruins/internal/components"
+	"github.com/kijimaD/ruins/internal/consts"
+	"github.com/kijimaD/ruins/internal/oapi"
+	w "github.com/kijimaD/ruins/internal/world"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPlannerTypeByName_通常プランナーを名前で引ける(t *testing.T) {
+	t.Parallel()
+
+	pt, ok := PlannerTypeByName("Small Room")
+	assert.True(t, ok)
+	assert.Equal(t, PlannerTypeSmallRoom.Name, pt.Name)
+}
+
+func TestPlannerTypeByName_デバッグ用プランナーも名前で引ける(t *testing.T) {
+	t.Parallel()
+
+	pt, ok := PlannerTypeByName("Debug Town")
+	assert.True(t, ok)
+	assert.Equal(t, PlannerTypeDebugTown.Name, pt.Name)
+}
+
+func TestPlannerTypeByName_存在しない名前はfalseを返す(t *testing.T) {
+	t.Parallel()
+
+	pt, ok := PlannerTypeByName("存在しないプランナー")
+	assert.False(t, ok)
+	assert.Equal(t, PlannerType{}, pt)
+}
+
+// newRandomPositionNearTestPlan は randomPositionNear 検証用の5x5全壁マップを作る。
+// 中心タイルだけを floor / wall で使い分けられるよう呼び出し側に委ねる
+func newRandomPositionNearTestPlan(centerFloor bool, centerX, centerY consts.Tile) *MetaPlan {
+	width, height := consts.Tile(5), consts.Tile(5)
+	tiles := make([]oapi.Tile, int(width)*int(height))
+	plan := &MetaPlan{
+		Level: gc.Level{
+			TileWidth:  width,
+			TileHeight: height,
+		},
+		Tiles:     tiles,
+		RawMaster: CreateTestRawMaster(),
+		RNG:       rand.New(rand.NewPCG(1, 2)),
+	}
+	for i := range tiles {
+		tiles[i] = plan.GetTile("wall")
+	}
+	if centerFloor {
+		idx := plan.Level.CoordToIndex(consts.Coord[consts.Tile]{X: centerX, Y: centerY})
+		tiles[idx] = plan.GetTile("floor")
+	}
+	return plan
+}
+
+func TestMetaPlan_randomPositionNear_中心が部屋内かつスポーン可能なら座標を返す(t *testing.T) {
+	t.Parallel()
+
+	centerX, centerY := consts.Tile(2), consts.Tile(2)
+	plan := newRandomPositionNearTestPlan(true, centerX, centerY)
+	room := gc.Rect{Min: consts.Coord[consts.Tile]{X: 1, Y: 1}, Max: consts.Coord[consts.Tile]{X: 3, Y: 3}}
+
+	// radius=0 なので候補座標は常に中心そのものになり、乱数に依存せず決定的に検証できる
+	tx, ty, ok := plan.randomPositionNear(centerX, centerY, 0, room, w.World{}, 1)
+	assert.True(t, ok)
+	assert.Equal(t, centerX, tx)
+	assert.Equal(t, centerY, ty)
+}
+
+func TestMetaPlan_randomPositionNear_スポーン不可なタイルなら試行回数内で失敗する(t *testing.T) {
+	t.Parallel()
+
+	centerX, centerY := consts.Tile(2), consts.Tile(2)
+	plan := newRandomPositionNearTestPlan(false, centerX, centerY) // 中心を壁のままにする
+	room := gc.Rect{Min: consts.Coord[consts.Tile]{X: 1, Y: 1}, Max: consts.Coord[consts.Tile]{X: 3, Y: 3}}
+
+	tx, ty, ok := plan.randomPositionNear(centerX, centerY, 0, room, w.World{}, 3)
+	assert.False(t, ok)
+	assert.Equal(t, consts.Tile(0), tx)
+	assert.Equal(t, consts.Tile(0), ty)
+}
+
+func TestMetaPlan_randomPositionNear_部屋の範囲外の座標は候補から除外する(t *testing.T) {
+	t.Parallel()
+
+	// 中心(0,0)は床にしてスポーン可能にするが、部屋の範囲外なので選ばれてはいけない
+	centerX, centerY := consts.Tile(0), consts.Tile(0)
+	plan := newRandomPositionNearTestPlan(true, centerX, centerY)
+	room := gc.Rect{Min: consts.Coord[consts.Tile]{X: 1, Y: 1}, Max: consts.Coord[consts.Tile]{X: 3, Y: 3}}
+
+	tx, ty, ok := plan.randomPositionNear(centerX, centerY, 0, room, w.World{}, 3)
+	assert.False(t, ok)
+	assert.Equal(t, consts.Tile(0), tx)
+	assert.Equal(t, consts.Tile(0), ty)
+}

--- a/internal/mapplanner/position_selector_test.go
+++ b/internal/mapplanner/position_selector_test.go
@@ -1,0 +1,98 @@
+package mapplanner
+
+import (
+	"math/rand/v2"
+	"testing"
+
+	gc "github.com/kijimaD/ruins/internal/components"
+	"github.com/kijimaD/ruins/internal/consts"
+	"github.com/kijimaD/ruins/internal/oapi"
+	w "github.com/kijimaD/ruins/internal/world"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newSelectorTestPlan は position_selector 検証用のマップを作る。allFloor が true なら全面床、
+// false なら全面壁にする
+func newSelectorTestPlan(allFloor bool) *MetaPlan {
+	width, height := consts.Tile(5), consts.Tile(5)
+	tiles := make([]oapi.Tile, int(width)*int(height))
+	plan := &MetaPlan{
+		Level: gc.Level{
+			TileWidth:  width,
+			TileHeight: height,
+		},
+		Tiles:     tiles,
+		RawMaster: CreateTestRawMaster(),
+		RNG:       rand.New(rand.NewPCG(1, 2)),
+	}
+	tileName := "wall"
+	if allFloor {
+		tileName = "floor"
+	}
+	for i := range tiles {
+		tiles[i] = plan.GetTile(tileName)
+	}
+	return plan
+}
+
+func TestOnMapSelector_スポーン可能なタイルがあれば座標を返す(t *testing.T) {
+	t.Parallel()
+
+	plan := newSelectorTestPlan(true)
+	sel := onMapSelector(5)
+
+	tx, ty, ok := sel(plan, w.World{})
+	assert.True(t, ok)
+	assert.True(t, tx >= 0 && tx < plan.Level.TileWidth)
+	assert.True(t, ty >= 0 && ty < plan.Level.TileHeight)
+}
+
+func TestOnMapSelector_スポーン可能なタイルが無ければ試行回数内で失敗する(t *testing.T) {
+	t.Parallel()
+
+	plan := newSelectorTestPlan(false)
+	sel := onMapSelector(3)
+
+	tx, ty, ok := sel(plan, w.World{})
+	assert.False(t, ok)
+	assert.Equal(t, consts.Tile(0), tx)
+	assert.Equal(t, consts.Tile(0), ty)
+}
+
+func TestNearSelector_中心座標がスポーン可能なら中心を返す(t *testing.T) {
+	t.Parallel()
+
+	plan := newSelectorTestPlan(true)
+	room := gc.Rect{Min: consts.Coord[consts.Tile]{X: 1, Y: 1}, Max: consts.Coord[consts.Tile]{X: 3, Y: 3}}
+	// radius=0 なので候補座標は常に中心そのものになる
+	sel := nearSelector(2, 2, 0, room, 1)
+
+	tx, ty, ok := sel(plan, w.World{})
+	assert.True(t, ok)
+	assert.Equal(t, consts.Tile(2), tx)
+	assert.Equal(t, consts.Tile(2), ty)
+}
+
+func TestFindPosition_最初に成功したセレクタの座標を返す(t *testing.T) {
+	t.Parallel()
+
+	plan := newSelectorTestPlan(true)
+	alwaysFail := func(_ *MetaPlan, _ w.World) (consts.Tile, consts.Tile, bool) { return 0, 0, false }
+	alwaysSucceed := func(_ *MetaPlan, _ w.World) (consts.Tile, consts.Tile, bool) { return 4, 3, true }
+
+	tx, ty, err := findPosition(plan, w.World{}, alwaysFail, alwaysSucceed)
+	require.NoError(t, err)
+	assert.Equal(t, consts.Tile(4), tx)
+	assert.Equal(t, consts.Tile(3), ty)
+}
+
+func TestFindPosition_全セレクタが失敗するとエラーを返す(t *testing.T) {
+	t.Parallel()
+
+	plan := newSelectorTestPlan(true)
+	alwaysFail := func(_ *MetaPlan, _ w.World) (consts.Tile, consts.Tile, bool) { return 0, 0, false }
+
+	_, _, err := findPosition(plan, w.World{}, alwaysFail, alwaysFail)
+	assert.ErrorContains(t, err, "all 2 selectors failed")
+}

--- a/internal/mapplanner/snapshot_test.go
+++ b/internal/mapplanner/snapshot_test.go
@@ -1,0 +1,72 @@
+package mapplanner
+
+import (
+	"testing"
+
+	gc "github.com/kijimaD/ruins/internal/components"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPlannerChain_takeSnapshot_Recordingが無効なら記録しない(t *testing.T) {
+	t.Parallel()
+
+	chain := &PlannerChain{Recording: false}
+	chain.takeSnapshot("Initial")
+
+	assert.Empty(t, chain.Snapshots)
+}
+
+func TestPlannerChain_takeSnapshot_Recordingが有効ならラベル付きで記録する(t *testing.T) {
+	t.Parallel()
+
+	chain := &PlannerChain{
+		Recording: true,
+		PlanData: MetaPlan{
+			Corridors: [][]gc.TileIdx{{1, 2, 3}},
+		},
+	}
+	chain.takeSnapshot("Initial")
+
+	require.Len(t, chain.Snapshots, 1)
+	assert.Equal(t, "Initial", chain.Snapshots[0].Label)
+	assert.Equal(t, [][]gc.TileIdx{{1, 2, 3}}, chain.Snapshots[0].Corridors)
+}
+
+func TestPlannerChain_takeSnapshot_記録後のPlanData変更はスナップショットに影響しない(t *testing.T) {
+	t.Parallel()
+
+	chain := &PlannerChain{
+		Recording: true,
+		PlanData: MetaPlan{
+			Corridors: [][]gc.TileIdx{{1, 2, 3}},
+		},
+	}
+	chain.takeSnapshot("Initial")
+
+	// スナップショット取得後にPlanDataの内側スライスを書き換える
+	chain.PlanData.Corridors[0][0] = 99
+
+	require.Len(t, chain.Snapshots, 1)
+	assert.Equal(t, [][]gc.TileIdx{{1, 2, 3}}, chain.Snapshots[0].Corridors,
+		"深くコピーされていれば元データの変更はスナップショットに反映されないはず")
+}
+
+func TestDeepCloneCorridors_内側スライスも独立してコピーする(t *testing.T) {
+	t.Parallel()
+
+	src := [][]gc.TileIdx{{1, 2}, {3, 4, 5}}
+	dst := deepCloneCorridors(src)
+
+	assert.Equal(t, src, dst)
+
+	dst[0][0] = 999
+	assert.Equal(t, gc.TileIdx(1), src[0][0], "コピー先の変更が元のスライスに波及してはならない")
+}
+
+func TestDeepCloneCorridors_空スライスはそのまま空を返す(t *testing.T) {
+	t.Parallel()
+
+	dst := deepCloneCorridors([][]gc.TileIdx{})
+	assert.Empty(t, dst)
+}

--- a/internal/mapplanner/wall_type_test.go
+++ b/internal/mapplanner/wall_type_test.go
@@ -115,3 +115,32 @@ func TestPlanData_GetWallType_WithWarpTiles(t *testing.T) {
 	wallType := planData.GetWallType(wallIdx)
 	assert.Equal(t, WallTypeTop, wallType, "床タイルに対するWallTypeTopの判定が間違っています")
 }
+
+func TestWallType_String_全種別を文字列に変換する(t *testing.T) {
+	t.Parallel()
+
+	tests := map[WallType]string{
+		WallTypeTop:         "Top",
+		WallTypeBottom:      "Bottom",
+		WallTypeLeft:        "Left",
+		WallTypeRight:       "Right",
+		WallTypeTopLeft:     "TopLeft",
+		WallTypeTopRight:    "TopRight",
+		WallTypeBottomLeft:  "BottomLeft",
+		WallTypeBottomRight: "BottomRight",
+		WallTypeGeneric:     "Generic",
+	}
+
+	for wt, want := range tests {
+		assert.Equal(t, want, wt.String())
+	}
+}
+
+func TestWallType_String_未定義の値はパニックする(t *testing.T) {
+	t.Parallel()
+
+	invalid := WallType(999)
+	assert.PanicsWithValue(t, "invalid WallType value: 999", func() {
+		_ = invalid.String()
+	})
+}

--- a/internal/mapplanner/wall_type_test.go
+++ b/internal/mapplanner/wall_type_test.go
@@ -116,23 +116,29 @@ func TestPlanData_GetWallType_WithWarpTiles(t *testing.T) {
 	assert.Equal(t, WallTypeTop, wallType, "床タイルに対するWallTypeTopの判定が間違っています")
 }
 
-func TestWallType_String_全種別を文字列に変換する(t *testing.T) {
+func TestWallType_String(t *testing.T) {
 	t.Parallel()
 
-	tests := map[WallType]string{
-		WallTypeTop:         "Top",
-		WallTypeBottom:      "Bottom",
-		WallTypeLeft:        "Left",
-		WallTypeRight:       "Right",
-		WallTypeTopLeft:     "TopLeft",
-		WallTypeTopRight:    "TopRight",
-		WallTypeBottomLeft:  "BottomLeft",
-		WallTypeBottomRight: "BottomRight",
-		WallTypeGeneric:     "Generic",
+	tests := []struct {
+		wt   WallType
+		want string
+	}{
+		{WallTypeTop, "Top"},
+		{WallTypeBottom, "Bottom"},
+		{WallTypeLeft, "Left"},
+		{WallTypeRight, "Right"},
+		{WallTypeTopLeft, "TopLeft"},
+		{WallTypeTopRight, "TopRight"},
+		{WallTypeBottomLeft, "BottomLeft"},
+		{WallTypeBottomRight, "BottomRight"},
+		{WallTypeGeneric, "Generic"},
 	}
 
-	for wt, want := range tests {
-		assert.Equal(t, want, wt.String())
+	for _, tt := range tests {
+		t.Run(tt.want+"に変換される", func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, tt.wt.String())
+		})
 	}
 }
 


### PR DESCRIPTION
## 概要

`internal/mapplanner` のうち、未テストだった純粋ロジック関数にテストを追加した。本体コードの変更はなく `*_test.go` のみの差分。

## カバレッジ

- `internal/mapplanner`: 88.7% → 91.2%

## 追加したテストの狙い

- `WallType.String`: 全種別の文字列表現と、未定義値を渡したときにパニックすることを検証する
- `PlannerTypeByName`: `AllPlannerTypes` の通常プランナー、`debugPlannerTypes` のデバッグ用プランナー、存在しない名前でのフォールバックの3経路を検証する
- `MetaPlan.randomPositionNear`: 中心座標がスポーン可能なときの成功、スポーン不可なときの試行回数内での失敗、部屋の範囲外に出た座標が候補から除外されることを検証する
- `position_selector.go` の `onMapSelector`・`nearSelector`・`findPosition`: スポーン可能/不可によるセレクタの成功・失敗、複数セレクタのうち最初に成功したものの結果採用、全滅時のエラー内容を検証する
- `PlannerChain.takeSnapshot` と `deepCloneCorridors`: `Recording` フラグ有無での記録可否、スナップショット取得後に元データを書き換えても記録済みスナップショットが影響を受けない深いコピーの独立性を検証する

## 検証

- `go build ./...`
- `go test ./internal/mapplanner/...`
- `golangci-lint run ./internal/mapplanner/...`
- `make test`
- `make lint`（Goのlintは0 issues。govulncheckのみサンドボックスのネットワーク制限で脆弱性DB取得が403になり失敗するが、本差分とは無関係）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C7BxTbBqJ8MN7BUKW4o3MF

---
_Generated by [Claude Code](https://claude.ai/code/session_01C7BxTbBqJ8MN7BUKW4o3MF)_