### PR TITLE
test(widgets/styled): カバレッジ増強

### DIFF
--- a/internal/widgets/styled/col_test.go
+++ b/internal/widgets/styled/col_test.go
@@ -1,0 +1,66 @@
+package styled_test
+
+import (
+	"testing"
+
+	"github.com/kijimaD/ruins/internal/widgets/styled"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestName_伸びる左寄せ列を返す(t *testing.T) {
+	t.Parallel()
+	assert.Equal(t, styled.Col{Mode: styled.ColGrow, Align: styled.AlignLeft}, styled.Name())
+}
+
+func TestFit_実測幅の左寄せ列を返す(t *testing.T) {
+	t.Parallel()
+	assert.Equal(t, styled.Col{Mode: styled.ColFit, Align: styled.AlignLeft}, styled.Fit())
+}
+
+func TestNum_実測幅の右寄せ列を返す(t *testing.T) {
+	t.Parallel()
+	assert.Equal(t, styled.Col{Mode: styled.ColFit, Align: styled.AlignRight}, styled.Num())
+}
+
+func TestIcon_正方の左寄せ列を返す(t *testing.T) {
+	t.Parallel()
+	assert.Equal(t, styled.Col{Mode: styled.ColIcon, Align: styled.AlignLeft}, styled.Icon())
+}
+
+func TestDesc_伸びる右寄せ列を返す(t *testing.T) {
+	t.Parallel()
+	assert.Equal(t, styled.Col{Mode: styled.ColGrow, Align: styled.AlignRight}, styled.Desc())
+}
+
+func TestCols(t *testing.T) {
+	t.Parallel()
+
+	t.Run("受け取った列をそのまま並びとして返す", func(t *testing.T) {
+		t.Parallel()
+		got := styled.Cols(styled.Name(), styled.Num(), styled.Icon())
+		assert.Equal(t, []styled.Col{styled.Name(), styled.Num(), styled.Icon()}, got)
+	})
+
+	t.Run("空で呼ぶと空スライスを返す", func(t *testing.T) {
+		t.Parallel()
+		got := styled.Cols()
+		assert.Empty(t, got)
+	})
+}
+
+func TestAligns(t *testing.T) {
+	t.Parallel()
+
+	t.Run("各列の揃えだけを順に取り出す", func(t *testing.T) {
+		t.Parallel()
+		cols := []styled.Col{styled.Name(), styled.Num(), styled.Icon(), styled.Desc()}
+		got := styled.Aligns(cols)
+		assert.Equal(t, []styled.TextAlign{styled.AlignLeft, styled.AlignRight, styled.AlignLeft, styled.AlignRight}, got)
+	})
+
+	t.Run("空列なら空スライスを返す", func(t *testing.T) {
+		t.Parallel()
+		got := styled.Aligns(nil)
+		assert.Empty(t, got)
+	})
+}

--- a/internal/widgets/styled/table_test.go
+++ b/internal/widgets/styled/table_test.go
@@ -1,0 +1,52 @@
+package styled_test
+
+import (
+	"testing"
+
+	"github.com/hajimehoshi/ebiten/v2"
+	"github.com/kijimaD/ruins/internal/widgets/styled"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTextCell_文字列だけを持つセルを返す(t *testing.T) {
+	t.Parallel()
+	got := styled.TextCell("HP")
+	assert.Equal(t, styled.Cell{Text: "HP", Icon: nil}, got)
+}
+
+func TestIconCell(t *testing.T) {
+	t.Parallel()
+
+	t.Run("画像を持つセルを返す", func(t *testing.T) {
+		t.Parallel()
+		img := ebiten.NewImage(4, 4)
+		got := styled.IconCell(img)
+		assert.Equal(t, styled.Cell{Text: "", Icon: img}, got)
+	})
+
+	t.Run("nilを渡すと透明セルになり文字列は空のまま", func(t *testing.T) {
+		t.Parallel()
+		got := styled.IconCell(nil)
+		assert.Equal(t, styled.Cell{Text: "", Icon: nil}, got)
+	})
+}
+
+func TestTextCells(t *testing.T) {
+	t.Parallel()
+
+	t.Run("文字列を順にTextCellへ変換する", func(t *testing.T) {
+		t.Parallel()
+		got := styled.TextCells("剣", "12", "重い")
+		assert.Equal(t, []styled.Cell{
+			{Text: "剣"},
+			{Text: "12"},
+			{Text: "重い"},
+		}, got)
+	})
+
+	t.Run("空で呼ぶと空スライスを返す", func(t *testing.T) {
+		t.Parallel()
+		got := styled.TextCells()
+		assert.Empty(t, got)
+	})
+}


### PR DESCRIPTION
## 概要

`internal/widgets/styled` パッケージにテストを追加する。本体コードの変更はなし。

## カバレッジ

- 変更前: 0.0%
- 変更後: 100.0%

## 追加したテスト

- `col_test.go`: `Name`・`Fit`・`Num`・`Icon`・`Desc` が期待どおりの `Col` を返すこと、`Cols` が渡した列をそのまま並びとして返すこと、`Aligns` が各列から揃えだけを順に取り出すことを検証する。
- `table_test.go`: `TextCell`・`IconCell` が文字列とアイコンのどちらかだけを持つセルを組み立てること、`nil` 画像を渡した場合の挙動、`TextCells` が複数文字列を順に `Cell` へ変換することを検証する。

## 検証

- `make test` 通過
- `make lint` 通過
- `go build ./...` 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017mZ7e3T7YKyg7G26X1ZoqM

---
_Generated by [Claude Code](https://claude.ai/code/session_017mZ7e3T7YKyg7G26X1ZoqM)_