### PR TITLE
ci(bench): bench-compareのコメントをdetailsで畳む

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -160,9 +160,9 @@ jobs:
           # benchstat -format csv の geomean 行は次の形:
           #   ,sec/op,CI,sec/op,CI,vs base,P        ← metric ヘッダ行（$1="" $2=metric）
           #   geomean,<base値>,,<pr値>,,+200.00%,    ← $1=geomean $2=base $4=pr
+          # コメントは常に details で畳む。退化を検出したときだけ open で開き見逃さない。
+          # summary 内で状態が読めるよう、見出しと退化有無を1行に出す
           if grep -q '^Benchmark' base.txt 2>/dev/null; then
-            # base vs PR を並べて表示
-            { echo '### ベンチ比較 (base vs PR)'; echo "$SHA_LINE"; echo '```'; go tool benchstat base.txt pr.txt; echo '```'; } > cmp.md
             # sec/op の geomean が2倍以上悪化したパッケージを検出する。
             # 個別ベンチはサンプル数1だとノイズで簡単に2倍になり誤発火するため、
             # 集約値の geomean で判定する。 geomean が2倍動くには大半のベンチが劣化する必要がある。
@@ -170,12 +170,24 @@ jobs:
               $1=="" && $2!="" { metric=$2; next }
               $1=="geomean" && metric=="sec/op" && ($2+0==$2) && ($4+0==$4) && $2>0 && $4/$2>=2 {
                 printf "- geomean: x%.2f\n", $4/$2 }')
+            if [ -n "$bad" ]; then
+              open=' open'; summary='⚠️ ベンチ比較 (base vs PR) — 2倍以上の悪化を検出'
+            else
+              open=''; summary='📊 ベンチ比較 (base vs PR)'
+            fi
+            # summary 直後と閉じタグ前の空行は details 内の Markdown を描画させるため必須
+            { echo "<details${open}><summary>${summary}</summary>";
+              echo "";
+              echo "$SHA_LINE"; echo '```'; go tool benchstat base.txt pr.txt; echo '```';
+              echo ""; echo '</details>'; } > cmp.md
           else
             # base 側にベンチが無い（初回PR・リネーム・base ビルド失敗等）場合、 PR のみ表示し比較不可を明示する
-            { echo '### ベンチ (PR のみ・base と比較不可)';
+            { echo '<details><summary>📊 ベンチ (PR のみ・base と比較不可)</summary>';
+              echo "";
               echo "$SHA_LINE";
               echo '> base 側に比較対象のベンチが取得できなかったため、今回は PR の数値のみ表示します。';
-              echo '```'; go tool benchstat pr.txt; echo '```'; } > cmp.md
+              echo '```'; go tool benchstat pr.txt; echo '```';
+              echo ""; echo '</details>'; } > cmp.md
           fi
           cat cmp.md
           { echo "bad<<EOF"; echo "$bad"; echo "EOF"; } >> "$GITHUB_OUTPUT"

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -171,12 +171,12 @@ jobs:
               $1=="geomean" && metric=="sec/op" && ($2+0==$2) && ($4+0==$4) && $2>0 && $4/$2>=2 {
                 printf "- geomean: x%.2f\n", $4/$2 }')
             if [ -n "$bad" ]; then
-              open=' open'; summary='⚠️ ベンチ比較 (base vs PR) — 2倍以上の悪化を検出'
+              open_attr=' open'; summary='⚠️ ベンチ比較 (base vs PR) — 2倍以上の悪化を検出'
             else
-              open=''; summary='📊 ベンチ比較 (base vs PR)'
+              open_attr=''; summary='📊 ベンチ比較 (base vs PR)'
             fi
             # summary 直後と閉じタグ前の空行は details 内の Markdown を描画させるため必須
-            { echo "<details${open}><summary>${summary}</summary>";
+            { echo "<details${open_attr}><summary>${summary}</summary>";
               echo "";
               echo "$SHA_LINE"; echo '```'; go tool benchstat base.txt pr.txt; echo '```';
               echo ""; echo '</details>'; } > cmp.md
@@ -189,6 +189,7 @@ jobs:
               echo '```'; go tool benchstat pr.txt; echo '```';
               echo ""; echo '</details>'; } > cmp.md
           fi
+          # CI ログで生成した Markdown を確認する
           cat cmp.md
           { echo "bad<<EOF"; echo "$bad"; echo "EOF"; } >> "$GITHUB_OUTPUT"
       - name: sticky comment


### PR DESCRIPTION
## 概要

PR ごとに投稿される bench-compare の sticky コメントが常時展開でノイズになるため、`<details>` で折りたたむ。ただし単純に畳むと本物の退化が隠れて通知の意味が薄れるので、**2倍以上の悪化を検出したときだけ自動展開**する。

## 変更内容

`compare` ステップの cmp.md 組み立てを `<details>` で包む。`bad`（catastrophic 判定）の計算を cmp.md 生成より前へ移し、その有無で表示を出し分ける。

| 状態 | 表示 | summary |
|---|---|---|
| 退化なし | 折りたたみ | `📊 ベンチ比較 (base vs PR)` |
| 退化あり | `<details open>` で展開 | `⚠️ ベンチ比較 (base vs PR) — 2倍以上の悪化を検出` |
| base 比較不可 | 折りたたみ | `📊 ベンチ (PR のみ・base と比較不可)` |

summary は常に見えるので、開かなくてもコメントの種別と退化の有無が一目で分かる。

## 検証

- 両分岐をローカルでドライランし、`<details>` の開閉・summary・空行が正しい Markdown を吐くことを確認
- summary 直後と閉じタグ前の空行は details 内のコードブロック描画に必須で、両方に配置済み
- `bad` は従来どおり `$GITHUB_OUTPUT` へ出力し、gate ステップの発火条件は不変
- CI 専用の変更で Go への影響なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019vvke2hSd5G5WfPy25uSwC