### PR TITLE
test(hud): カバレッジ増強

### DIFF
--- a/internal/widgets/hud/canvas_fake_test.go
+++ b/internal/widgets/hud/canvas_fake_test.go
@@ -1,0 +1,50 @@
+package hud
+
+import (
+	"image"
+	"image/color"
+
+	"github.com/hajimehoshi/ebiten/v2"
+	text "github.com/hajimehoshi/ebiten/v2/text/v2"
+)
+
+// fakeCanvas は uicore.Canvas の記録用実装。ebiten の描画コンテキスト無しで
+// どの描画命令が何回・どの引数で呼ばれたかだけを検証する。
+type fakeCanvas struct {
+	texts       []textCall
+	fillRects   []image.Rectangle
+	strokeRects []image.Rectangle
+	nineSlices  int
+	tintedRects []image.Rectangle
+}
+
+// textCall は DrawText 呼び出し1回ぶんの記録
+type textCall struct {
+	pos   image.Point
+	str   string
+	color color.Color
+}
+
+func (c *fakeCanvas) FillRect(r image.Rectangle, _ color.Color) {
+	c.fillRects = append(c.fillRects, r)
+}
+
+func (c *fakeCanvas) StrokeRect(r image.Rectangle, _ int, _ color.Color) {
+	c.strokeRects = append(c.strokeRects, r)
+}
+
+func (c *fakeCanvas) DrawText(pos image.Point, s string, _ text.Face, col color.Color) {
+	c.texts = append(c.texts, textCall{pos: pos, str: s, color: col})
+}
+
+func (c *fakeCanvas) DrawImage(_ image.Point, _ *ebiten.Image) {}
+
+func (c *fakeCanvas) DrawImageRect(_ image.Rectangle, _ *ebiten.Image) {}
+
+func (c *fakeCanvas) DrawNineSlice(_ image.Rectangle, _ *ebiten.Image, _, _ [3]int) {
+	c.nineSlices++
+}
+
+func (c *fakeCanvas) DrawImageTintedRect(dst image.Rectangle, _ *ebiten.Image, _ color.Color) {
+	c.tintedRects = append(c.tintedRects, dst)
+}

--- a/internal/widgets/hud/chrome_test.go
+++ b/internal/widgets/hud/chrome_test.go
@@ -1,0 +1,35 @@
+package hud
+
+import (
+	"image"
+	"testing"
+
+	"github.com/kijimaD/ruins/internal/loader"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestChrome_Panel(t *testing.T) {
+	t.Parallel()
+
+	t.Run("テクスチャがあれば9スライスで矩形へ敷く", func(t *testing.T) {
+		t.Parallel()
+		res, err := loader.LoadUIResources()
+		require.NoError(t, err)
+
+		chrome := NewChrome(res)
+		cv := &fakeCanvas{}
+		chrome.Panel(cv, image.Rect(0, 0, 100, 50))
+
+		assert.Equal(t, 1, cv.nineSlices)
+	})
+
+	t.Run("テクスチャが無ければ何も描かない", func(t *testing.T) {
+		t.Parallel()
+		chrome := Chrome{}
+		cv := &fakeCanvas{}
+		chrome.Panel(cv, image.Rect(0, 0, 10, 10))
+
+		assert.Equal(t, 0, cv.nineSlices)
+	})
+}

--- a/internal/widgets/hud/game_info_draw_test.go
+++ b/internal/widgets/hud/game_info_draw_test.go
@@ -1,0 +1,93 @@
+package hud
+
+import (
+	"image/color"
+	"testing"
+
+	"github.com/kijimaD/ruins/internal/consts"
+	"github.com/kijimaD/ruins/internal/loader"
+	"github.com/kijimaD/ruins/internal/widgets/theme"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newTestGameInfo(t *testing.T) *GameInfo {
+	t.Helper()
+	res, err := loader.LoadUIResources()
+	require.NoError(t, err)
+	return NewGameInfo(res.Text.BodyFace, res.Text.TitleFontFace, nil)
+}
+
+func TestGameInfo_drawTemperatureArrow(t *testing.T) {
+	t.Parallel()
+	info := newTestGameInfo(t)
+
+	t.Run("非表示なら何も描かない", func(t *testing.T) {
+		t.Parallel()
+		cv := &fakeCanvas{}
+		info.drawTemperatureArrow(cv, TemperatureArrow{Visible: false, Direction: TempDirectionUp})
+		assert.Empty(t, cv.texts)
+	})
+
+	tests := []struct {
+		name      string
+		dir       TempDirection
+		wantGlyph string
+	}{
+		{"上向きは上矢印グリフを使う", TempDirectionUp, consts.IconArrowUp},
+		{"下向きは下矢印グリフを使う", TempDirectionDown, consts.IconArrowDown},
+		{"一定は右矢印グリフを使う", TempDirectionSteady, consts.IconArrowRight},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			cv := &fakeCanvas{}
+			arrowColor := color.RGBA{R: 1, G: 2, B: 3, A: 4}
+			info.drawTemperatureArrow(cv, TemperatureArrow{Visible: true, Direction: tt.dir, Color: arrowColor})
+
+			require.NotEmpty(t, cv.texts)
+			last := cv.texts[len(cv.texts)-1]
+			assert.Equal(t, tt.wantGlyph, last.str, "本体の文字は方向ごとのグリフになる")
+			assert.Equal(t, arrowColor, last.color, "本体の色は矢印の色をそのまま使う")
+		})
+	}
+}
+
+func TestGameInfo_drawAmbientTemperature(t *testing.T) {
+	t.Parallel()
+	info := newTestGameInfo(t)
+
+	t.Run("非表示なら何も描かない", func(t *testing.T) {
+		t.Parallel()
+		cv := &fakeCanvas{}
+		info.drawAmbientTemperature(cv, GameInfoData{AmbientTempVisible: false})
+		assert.Empty(t, cv.texts)
+	})
+
+	t.Run("表示するとラベルと気温を右寄せで描く", func(t *testing.T) {
+		t.Parallel()
+		cv := &fakeCanvas{}
+		tempColor := color.RGBA{R: 10, G: 20, B: 30, A: 255}
+		data := GameInfoData{
+			AmbientTempVisible:  true,
+			AmbientTemp:         25,
+			AmbientTempColor:    tempColor,
+			AmbientShelterLabel: "屋内",
+			MessageAreaHeight:   40,
+			ScreenDimensions:    ScreenDimensions{Width: 1024, Height: 768},
+		}
+		info.drawAmbientTemperature(cv, data)
+
+		// OutlinedText は縁取り8回+本体1回の9回描く。ラベルと気温で2回呼ぶので18回になる
+		require.Len(t, cv.texts, 18)
+		label := cv.texts[8]
+		temp := cv.texts[17]
+
+		assert.Equal(t, "屋内 ", label.str)
+		assert.Equal(t, theme.TextPrimary, label.color)
+		assert.Equal(t, "25℃", temp.str)
+		assert.Equal(t, tempColor, temp.color)
+		assert.Equal(t, label.pos.Y, temp.pos.Y, "ラベルと気温は同じ高さに揃える")
+		assert.Greater(t, temp.pos.X, label.pos.X, "気温はラベルの右に置く")
+	})
+}

--- a/internal/widgets/hud/game_info_draw_test.go
+++ b/internal/widgets/hud/game_info_draw_test.go
@@ -18,6 +18,19 @@ func newTestGameInfo(t *testing.T) *GameInfo {
 	return NewGameInfo(res.Text.BodyFace, res.Text.TitleFontFace, nil)
 }
 
+// findText は文字列が一致する最後の描画呼び出しを返す。OutlinedText は縁取りと本体をまとめて描くため、
+// 本体だけを探すには末尾から一致するものを拾う
+func findText(t *testing.T, texts []textCall, s string) textCall {
+	t.Helper()
+	for i := len(texts) - 1; i >= 0; i-- {
+		if texts[i].str == s {
+			return texts[i]
+		}
+	}
+	t.Fatalf("text %q not found in %v", s, texts)
+	return textCall{}
+}
+
 func TestGameInfo_drawTemperatureArrow(t *testing.T) {
 	t.Parallel()
 	info := newTestGameInfo(t)
@@ -78,10 +91,8 @@ func TestGameInfo_drawAmbientTemperature(t *testing.T) {
 		}
 		info.drawAmbientTemperature(cv, data)
 
-		// OutlinedText は縁取り8回+本体1回の9回描く。ラベルと気温で2回呼ぶので18回になる
-		require.Len(t, cv.texts, 18)
-		label := cv.texts[8]
-		temp := cv.texts[17]
+		label := findText(t, cv.texts, "屋内 ")
+		temp := findText(t, cv.texts, "25℃")
 
 		assert.Equal(t, "屋内 ", label.str)
 		assert.Equal(t, theme.TextPrimary, label.color)

--- a/internal/widgets/hud/game_info_draw_test.go
+++ b/internal/widgets/hud/game_info_draw_test.go
@@ -2,6 +2,7 @@ package hud
 
 import (
 	"image/color"
+	"slices"
 	"testing"
 
 	"github.com/kijimaD/ruins/internal/consts"
@@ -22,12 +23,12 @@ func newTestGameInfo(t *testing.T) *GameInfo {
 // 本体だけを探すには末尾から一致するものを拾う
 func findText(t *testing.T, texts []textCall, s string) textCall {
 	t.Helper()
-	for i := len(texts) - 1; i >= 0; i-- {
-		if texts[i].str == s {
-			return texts[i]
+	for _, text := range slices.Backward(texts) {
+		if text.str == s {
+			return text
 		}
 	}
-	t.Fatalf("text %q not found in %v", s, texts)
+	require.Failf(t, "対象テキストが見つからない", "text %q not found in %v", s, texts)
 	return textCall{}
 }
 

--- a/internal/widgets/hud/infopanel_test.go
+++ b/internal/widgets/hud/infopanel_test.go
@@ -1,0 +1,45 @@
+package hud
+
+import (
+	"image"
+	"testing"
+
+	"github.com/kijimaD/ruins/internal/loader"
+	"github.com/kijimaD/ruins/internal/widgets/theme"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestInfoPanel(t *testing.T) {
+	t.Parallel()
+
+	res, err := loader.LoadUIResources()
+	require.NoError(t, err)
+	chrome := NewChrome(res)
+
+	cv := &fakeCanvas{}
+	const screenWidth = 800
+	const height = 200
+	panel := NewInfoPanel(cv, chrome, res.Text.BodyFace, screenWidth, height)
+
+	assert.Equal(t, 1, cv.nineSlices, "生成時にパネルの意匠を1回敷く")
+
+	panel.Line("1行目")
+	panel.Line("2行目")
+	require.Len(t, cv.texts, 2)
+	assert.Equal(t, "1行目", cv.texts[0].str)
+	assert.Equal(t, theme.TextPrimary, cv.texts[0].color)
+	assert.Equal(t, LineH, cv.texts[1].pos.Y-cv.texts[0].pos.Y, "Lineは呼ぶたびに1行ぶん書き込み位置を下げる")
+
+	panel.Gap(30)
+	panel.Line("3行目")
+	require.Len(t, cv.texts, 3)
+	assert.Equal(t, cv.texts[1].pos.Y+30+LineH, cv.texts[2].pos.Y, "Gapは指定pxだけ書き込み位置を送る")
+
+	wantRect := image.Rect(screenWidth-infoPanelWidth-infoPanelMargin, infoPanelMargin, screenWidth-infoPanelMargin, infoPanelMargin+height)
+	panel.SeekBottom(15)
+	panel.Line("末尾行")
+	require.Len(t, cv.texts, 4)
+	assert.Equal(t, wantRect.Max.Y-15, cv.texts[3].pos.Y, "SeekBottomはパネル下端からfromBottomだけ上へ書き込み位置を移す")
+	assert.Equal(t, wantRect.Min.X+infoPanelPad, cv.texts[3].pos.X)
+}


### PR DESCRIPTION
## 概要

`internal/widgets/hud` のカバレッジを 38.3% から 49.0% へ増強する。テストのみの追加で、本体コードは変更しない。

`uicore.Canvas` は描画命令を記録するだけのフェイクを差し替えられる設計になっている。これを用意し、次の未テストだった描画分岐を検証する。

- `GameInfo.drawTemperatureArrow`: 20.0% → 100%。非表示・上向き・下向き・一定の4分岐を、グリフと色の記録から検証する
- `GameInfo.drawAmbientTemperature`: 6.2% → 大幅改善。非表示・表示時のラベルと気温の描画位置・色を検証する
- `Chrome.Panel`: 0% → 100%。テクスチャあり・なしの2分岐を検証する
- `InfoPanel` の `NewInfoPanel`/`Line`/`Gap`/`SeekBottom`: 0% → 100%。書き込み位置の計算を検証する

## 検証

- `go test ./internal/widgets/hud/...`: PASS
- `make test`: PASS
- `golangci-lint run ./internal/widgets/hud/...`: 0 issues
- `go build ./...`: OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MMFninFuoottJBc3NhKzhe


---
_Generated by [Claude Code](https://claude.ai/code/session_01MMFninFuoottJBc3NhKzhe)_