### PR TITLE
test(hud): カバレッジ増強

### DIFF
--- a/internal/widgets/hud/currency_test.go
+++ b/internal/widgets/hud/currency_test.go
@@ -1,0 +1,44 @@
+package hud
+
+import (
+	"testing"
+
+	"github.com/kijimaD/ruins/internal/consts"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCurrencyDisplay_Draw_無効なら何も描かない(t *testing.T) {
+	t.Parallel()
+	display := NewCurrencyDisplay(nil)
+	display.SetEnabled(false)
+	cv := &fakeCanvas{}
+
+	display.Draw(cv, CurrencyData{
+		Currency:         consts.Currency(100),
+		ScreenDimensions: ScreenDimensions{Width: 1024, Height: 768},
+		Config:           DefaultMessageAreaConfig,
+	})
+
+	assert.Empty(t, cv.texts)
+}
+
+func TestCurrencyDisplay_Draw_有効なら通貨をログ領域の上に描く(t *testing.T) {
+	t.Parallel()
+	display := NewCurrencyDisplay(nil)
+	cv := &fakeCanvas{}
+
+	data := CurrencyData{
+		Currency:         consts.Currency(1234),
+		ScreenDimensions: ScreenDimensions{Width: 1024, Height: 768},
+		Config:           DefaultMessageAreaConfig,
+	}
+	display.Draw(cv, data)
+
+	require.NotEmpty(t, cv.texts)
+	last := cv.texts[len(cv.texts)-1]
+	assert.Equal(t, data.Currency.String(), last.str)
+
+	logAreaY := data.ScreenDimensions.Height - data.Config.Height()
+	assert.Less(t, last.pos.Y, logAreaY, "ログ領域より上に描く")
+}

--- a/internal/widgets/hud/minimap_test.go
+++ b/internal/widgets/hud/minimap_test.go
@@ -1,0 +1,93 @@
+package hud
+
+import (
+	"testing"
+
+	gc "github.com/kijimaD/ruins/internal/components"
+	"github.com/kijimaD/ruins/internal/consts"
+	"github.com/kijimaD/ruins/internal/loader"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newTestMinimap(t *testing.T) *Minimap {
+	t.Helper()
+	res, err := loader.LoadUIResources()
+	require.NoError(t, err)
+	return NewMinimap(nil, NewChrome(res))
+}
+
+func TestMinimap_Draw_無効なら何も描かない(t *testing.T) {
+	t.Parallel()
+	minimap := newTestMinimap(t)
+	minimap.enabled = false
+	cv := &fakeCanvas{}
+
+	minimap.Draw(cv, MinimapData{
+		MinimapConfig:    MinimapConfig{Width: 150, Height: 150, Scale: 3},
+		ScreenDimensions: ScreenDimensions{Width: 1024, Height: 768},
+	})
+
+	assert.Equal(t, 0, cv.nineSlices)
+	assert.Empty(t, cv.texts)
+	assert.Empty(t, cv.fillRects)
+}
+
+func TestMinimap_Draw_探索済みタイルがなければNoDataを表示する(t *testing.T) {
+	t.Parallel()
+	minimap := newTestMinimap(t)
+	cv := &fakeCanvas{}
+
+	minimap.Draw(cv, MinimapData{
+		MinimapConfig:    MinimapConfig{Width: 150, Height: 150, Scale: 3},
+		ScreenDimensions: ScreenDimensions{Width: 1024, Height: 768},
+	})
+
+	assert.Equal(t, 1, cv.nineSlices, "背景パネルを1回描く")
+	require.NotEmpty(t, cv.texts)
+	assert.Equal(t, "No Data", cv.texts[len(cv.texts)-1].str)
+	assert.Empty(t, cv.fillRects, "タイルが無いので塗りつぶしは無い")
+}
+
+func TestMinimap_Draw_サイズ0なら探索済みタイルがあっても背景パネルを描かない(t *testing.T) {
+	t.Parallel()
+	minimap := newTestMinimap(t)
+	cv := &fakeCanvas{}
+
+	tile := gc.GridElement{Coord: consts.Coord[consts.Tile]{X: 5, Y: 5}}
+	minimap.Draw(cv, MinimapData{
+		ExploredTiles:    map[gc.GridElement]bool{tile: true},
+		MinimapConfig:    MinimapConfig{Width: 0, Height: 0, Scale: 3},
+		ScreenDimensions: ScreenDimensions{Width: 1024, Height: 768},
+	})
+
+	assert.Equal(t, 0, cv.nineSlices, "サイズ0のときは背景を敷かない")
+}
+
+func TestMinimap_Draw_探索済みタイルをプレイヤー位置基準で描く(t *testing.T) {
+	t.Parallel()
+	minimap := newTestMinimap(t)
+	cv := &fakeCanvas{}
+
+	playerTile := consts.Coord[consts.Tile]{X: 10, Y: 10}
+	inRange := gc.GridElement{Coord: consts.Coord[consts.Tile]{X: 11, Y: 10}}
+	outOfRange := gc.GridElement{Coord: consts.Coord[consts.Tile]{X: 1000, Y: 1000}}
+
+	data := MinimapData{
+		PlayerTile: playerTile,
+		ExploredTiles: map[gc.GridElement]bool{
+			inRange:    true,
+			outOfRange: true,
+		},
+		TileColors: map[gc.GridElement]TileColorInfo{
+			inRange:    {R: 10, G: 20, B: 30, A: 255},
+			outOfRange: {R: 1, G: 2, B: 3, A: 255},
+		},
+		MinimapConfig:    MinimapConfig{Width: 150, Height: 150, Scale: 3},
+		ScreenDimensions: ScreenDimensions{Width: 1024, Height: 768},
+	}
+	minimap.Draw(cv, data)
+
+	assert.Equal(t, 1, cv.nineSlices, "背景パネルを描く")
+	assert.Len(t, cv.fillRects, 2, "範囲内のタイル1つとプレイヤーの印だけ描く。範囲外のタイルは除外する")
+}

--- a/internal/widgets/hud/status_badges_test.go
+++ b/internal/widgets/hud/status_badges_test.go
@@ -1,0 +1,95 @@
+package hud
+
+import (
+	"image"
+	"image/color"
+	"testing"
+
+	theme "github.com/kijimaD/ruins/internal/widgets/theme"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestStatusBadges_Draw_無効または空なら何も描かない(t *testing.T) {
+	t.Parallel()
+
+	t.Run("無効なら描かない", func(t *testing.T) {
+		t.Parallel()
+		badges := NewStatusBadges(nil)
+		badges.enabled = false
+		cv := &fakeCanvas{}
+		badges.Draw(cv, StatusBadgesData{Badges: []StatusBadge{{Text: "毒"}}})
+		assert.Empty(t, cv.texts)
+	})
+
+	t.Run("バッジが空なら描かない", func(t *testing.T) {
+		t.Parallel()
+		badges := NewStatusBadges(nil)
+		cv := &fakeCanvas{}
+		badges.Draw(cv, StatusBadgesData{Badges: nil})
+		assert.Empty(t, cv.texts)
+	})
+}
+
+func TestStatusBadges_Draw_バッジを下から積み上げて描く(t *testing.T) {
+	t.Parallel()
+	badges := NewStatusBadges(nil)
+	cv := &fakeCanvas{}
+
+	data := StatusBadgesData{
+		Badges: []StatusBadge{
+			{Text: "毒", Color: color.RGBA{R: 1, G: 0, B: 0, A: 255}},
+			{Text: "麻痺", Color: color.RGBA{R: 0, G: 1, B: 0, A: 255}},
+		},
+		MessageAreaHeight: 40,
+		ScreenDimensions:  ScreenDimensions{Width: 1024, Height: 768},
+	}
+	badges.Draw(cv, data)
+
+	// 後ろのバッジから下から積み上げるので、後ろの「麻痺」がベースラインに近い下側に、
+	// 先頭の「毒」がその上に来る
+	poison := findText(t, cv.texts, "毒")
+	paralysis := findText(t, cv.texts, "麻痺")
+	assert.Greater(t, paralysis.pos.Y, poison.pos.Y, "後ろのバッジほど下に来る")
+}
+
+func TestStatusBadges_Draw_5個を超えると残数を表示する(t *testing.T) {
+	t.Parallel()
+	badges := NewStatusBadges(nil)
+	cv := &fakeCanvas{}
+
+	data := StatusBadgesData{
+		Badges: []StatusBadge{
+			{Text: "1"}, {Text: "2"}, {Text: "3"}, {Text: "4"}, {Text: "5"}, {Text: "6"}, {Text: "7"},
+		},
+		MessageAreaHeight: 40,
+		ScreenDimensions:  ScreenDimensions{Width: 1024, Height: 768},
+	}
+	badges.Draw(cv, data)
+
+	more := findText(t, cv.texts, "+2")
+	assert.Equal(t, "+2", more.str, "上限を超えたぶんは+N表示になる")
+	assert.False(t, hasText(cv.texts, "6"), "上限を超えたバッジ自体は描かない")
+	assert.False(t, hasText(cv.texts, "7"), "上限を超えたバッジ自体は描かない")
+}
+
+// hasText は指定した文字列を描いたかどうかを返す
+func hasText(texts []textCall, s string) bool {
+	for _, tc := range texts {
+		if tc.str == s {
+			return true
+		}
+	}
+	return false
+}
+
+func TestBadgeChrome_枠と塗りと上下のラインを描く(t *testing.T) {
+	t.Parallel()
+	cv := &fakeCanvas{}
+	r := image.Rect(0, 0, 40, 20)
+
+	badgeChrome(cv, r, theme.HUDBadgeBg)
+
+	assert.Len(t, cv.strokeRects, 1, "外枠を描く")
+	assert.Equal(t, r, cv.strokeRects[0])
+	assert.Len(t, cv.fillRects, 3, "背景と上辺ハイライト・下辺シャドウの3つを塗る")
+}

--- a/internal/widgets/hud/status_badges_test.go
+++ b/internal/widgets/hud/status_badges_test.go
@@ -66,8 +66,7 @@ func TestStatusBadges_Draw_5個を超えると残数を表示する(t *testing.T
 	}
 	badges.Draw(cv, data)
 
-	more := findText(t, cv.texts, "+2")
-	assert.Equal(t, "+2", more.str, "上限を超えたぶんは+N表示になる")
+	findText(t, cv.texts, "+2") // 上限を超えたぶんは+N表示になる。見つからなければ内部でFailする
 	assert.False(t, hasText(cv.texts, "6"), "上限を超えたバッジ自体は描かない")
 	assert.False(t, hasText(cv.texts, "7"), "上限を超えたバッジ自体は描かない")
 }


### PR DESCRIPTION
## 概要

`internal/widgets/hud` パッケージのテストカバレッジを増強する。本体コードの変更はなく、`*_test.go` の追加のみ。

カバレッジ: 49.0% → 65.4%

## 追加したテスト

- `minimap_test.go`: `Minimap.Draw` / `drawEmpty`
  - 無効時は何も描かない
  - 探索済みタイルが無ければ「No Data」を表示する
  - ミニマップサイズが0なら探索済みタイルがあっても背景パネルを描かない
  - 探索済みタイルをプレイヤー位置基準の相対座標へ変換し、ミニマップ範囲外のタイルは除外して描く
- `currency_test.go`: `CurrencyDisplay.Draw`
  - 無効時は何も描かない
  - 有効時は通貨表示をログ領域の上に描く
- `status_badges_test.go`: `StatusBadges.Draw` / `badgeChrome`
  - 無効時・バッジが空のときは何も描かない
  - バッジを下から積み上げて描く順序
  - 表示上限の5個を超えると残りバッジは描かず「+N」で残数を表示する
  - `badgeChrome` が枠・塗り・上下のハイライト/シャドウ線を描く

いずれも既存の `fakeCanvas`・`loader.LoadUIResources()` によるテストパターンに沿っている。無効化フラグの分岐、境界値（範囲内外・上限超過）、描画順序など振る舞いに直結する分岐を狙った。

## 検証

- `make test`: 全パッケージパス
- `golangci-lint run ./...`: 0 issues
- `go tool deadcode -test`: 到達不能関数の検出なし
- `go build ./...`: 成功
- `go tool govulncheck ./...`: 実行環境のネットワークポリシーにより `vuln.go.dev` への到達が拒否され未実行。本変更はテストファイルの追加のみで依存関係の変更は無い

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BFrcSqjEY1p8XdSKeyaDqD

---
_Generated by [Claude Code](https://claude.ai/code/session_01BFrcSqjEY1p8XdSKeyaDqD)_