### PR TITLE
test(cmd): カバレッジ増強

### DIFF
--- a/internal/cmd/designdoc.go
+++ b/internal/cmd/designdoc.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os"
+	"io"
 	"slices"
 	"strings"
 	"text/tabwriter"
@@ -46,64 +46,87 @@ var CmdDesignDoc = &cli.Command{
 	},
 }
 
-func runDesignDocValidate(_ context.Context, _ *cli.Command) error {
-	docs, err := designdoc.LoadDir(designdoc.DefaultDir)
+// designDocFilter は list の絞り込み条件。空文字と false は無指定を表す。
+type designDocFilter struct {
+	status string
+	auto   string
+	tag    string
+	open   bool
+}
+
+func runDesignDocValidate(_ context.Context, cmd *cli.Command) error {
+	return designDocValidate(cmd.Writer, designdoc.DefaultDir)
+}
+
+// designDocValidate は dir 下の frontmatter を検証し、問題を out へ書く。問題があればエラーを返す。
+func designDocValidate(out io.Writer, dir string) error {
+	docs, err := designdoc.LoadDir(dir)
 	if err != nil {
 		return err
 	}
 
 	problems := designdoc.Validate(docs)
 	for _, p := range problems {
-		fmt.Printf("%s: %s\n", p.Path, p.Message)
+		_, _ = fmt.Fprintf(out, "%s: %s\n", p.Path, p.Message)
 	}
 
 	if len(problems) > 0 {
 		return errValidation
 	}
-	fmt.Printf("OK: validated %d documents\n", len(docs))
+	_, _ = fmt.Fprintf(out, "OK: validated %d documents\n", len(docs))
 
 	return nil
 }
 
-func runDesignDocGen(_ context.Context, _ *cli.Command) error {
-	changed, err := designdoc.BackfillDir(designdoc.DefaultDir)
+func runDesignDocGen(_ context.Context, cmd *cli.Command) error {
+	return designDocGen(cmd.Writer, designdoc.DefaultDir)
+}
+
+// designDocGen は dir 下の frontmatter を持たないドキュメントへ既定値を付与し、付与先を out へ書く。
+func designDocGen(out io.Writer, dir string) error {
+	changed, err := designdoc.BackfillDir(dir)
 	if err != nil {
 		return err
 	}
 
 	for _, path := range changed {
-		fmt.Printf("added: %s\n", path)
+		_, _ = fmt.Fprintf(out, "added: %s\n", path)
 	}
-	fmt.Printf("added frontmatter to %d documents\n", len(changed))
+	_, _ = fmt.Fprintf(out, "added frontmatter to %d documents\n", len(changed))
 
 	return nil
 }
 
 func runDesignDocList(_ context.Context, cmd *cli.Command) error {
-	docs, err := designdoc.LoadDir(designdoc.DefaultDir)
+	return designDocList(cmd.Writer, designdoc.DefaultDir, designDocFilter{
+		status: cmd.String("status"),
+		auto:   cmd.String("auto"),
+		tag:    cmd.String("tag"),
+		open:   cmd.Bool("open"),
+	})
+}
+
+// designDocList は dir 下のドキュメントを filter で絞り、表として out へ書く。
+func designDocList(out io.Writer, dir string, filter designDocFilter) error {
+	docs, err := designdoc.LoadDir(dir)
 	if err != nil {
 		return err
 	}
 
-	status := cmd.String("status")
-	auto := cmd.String("auto")
-	tag := cmd.String("tag")
-	openOnly := cmd.Bool("open")
-
-	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	w := tabwriter.NewWriter(out, 0, 0, 2, ' ', 0)
 	_, _ = fmt.Fprintln(w, "PATH\tSTATUS\tAUTO\tPROGRESS\tTAGS")
 	for _, doc := range docs {
 		f := doc.Front
-		if status != "" && string(f.Status) != status {
+		if filter.status != "" && string(f.Status) != filter.status {
 			continue
 		}
-		if auto != "" && string(f.Auto) != auto {
+		if filter.auto != "" && string(f.Auto) != filter.auto {
 			continue
 		}
-		if tag != "" && !slices.Contains(f.Tags, tag) {
+		if filter.tag != "" && !slices.Contains(f.Tags, filter.tag) {
 			continue
 		}
-		if openOnly && !f.Status.IsOpen() {
+		if filter.open && !f.Status.IsOpen() {
 			continue
 		}
 

--- a/internal/cmd/designdoc_test.go
+++ b/internal/cmd/designdoc_test.go
@@ -1,0 +1,194 @@
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/urfave/cli/v3"
+)
+
+// captureOutput はos.Stdoutの出力をキャプチャする
+func captureOutput(f func()) string {
+	old := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	f()
+
+	_ = w.Close()
+	os.Stdout = old
+
+	var buf bytes.Buffer
+	_, _ = io.Copy(&buf, r)
+	return buf.String()
+}
+
+// writeDesignDoc は tempDir/docs/design/name にドキュメントを書き込む
+func writeDesignDoc(t *testing.T, name, content string) {
+	t.Helper()
+	dir := filepath.Join("docs", "design")
+	require.NoError(t, os.MkdirAll(dir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, name), []byte(content), 0o644))
+}
+
+//nolint:paralleltest // t.Chdirとos.Stdoutのキャプチャがプロセス全体を変更するため並列化しない
+func TestRunDesignDocValidate_問題なしならnilを返す(t *testing.T) {
+	t.Chdir(t.TempDir())
+	writeDesignDoc(t, "ok.md", "---\nstatus: draft\ntags: []\nauto: needs-decision\n---\n\n# OK\n")
+
+	out := captureOutput(func() {
+		err := runDesignDocValidate(context.Background(), nil)
+		require.NoError(t, err)
+	})
+	assert.Equal(t, "OK: validated 1 documents\n", out)
+}
+
+//nolint:paralleltest // t.Chdirとos.Stdoutのキャプチャがプロセス全体を変更するため並列化しない
+func TestRunDesignDocValidate_問題があればエラーを返す(t *testing.T) {
+	t.Chdir(t.TempDir())
+	writeDesignDoc(t, "bad.md", "---\nstatus: bogus\ntags: []\nauto: needs-decision\n---\n\n# Bad\n")
+
+	var err error
+	out := captureOutput(func() {
+		err = runDesignDocValidate(context.Background(), nil)
+	})
+	require.ErrorIs(t, err, errValidation)
+	assert.Equal(t, "docs/design/bad.md: invalid status: \"bogus\"\n", out)
+}
+
+//nolint:paralleltest // t.Chdirとos.Stdoutのキャプチャがプロセス全体を変更するため並列化しない
+func TestRunDesignDocGen_frontmatterがないドキュメントに既定値を付与する(t *testing.T) {
+	t.Chdir(t.TempDir())
+	writeDesignDoc(t, "nofront.md", "# タイトル\n\n本文\n")
+
+	out := captureOutput(func() {
+		err := runDesignDocGen(context.Background(), nil)
+		require.NoError(t, err)
+	})
+	assert.Equal(t, "added: docs/design/nofront.md\nadded frontmatter to 1 documents\n", out)
+
+	got, err := os.ReadFile(filepath.Join("docs", "design", "nofront.md"))
+	require.NoError(t, err)
+	assert.Equal(t, "---\nstatus: draft\ntags: []\nauto: needs-decision\n---\n\n# タイトル\n\n本文\n", string(got))
+}
+
+//nolint:paralleltest // t.Chdirとos.Stdoutのキャプチャがプロセス全体を変更するため並列化しない
+func TestRunDesignDocGen_frontmatterがあるドキュメントは変更しない(t *testing.T) {
+	t.Chdir(t.TempDir())
+	content := "---\nstatus: draft\ntags: []\nauto: needs-decision\n---\n\n# 既にある\n"
+	writeDesignDoc(t, "hasfront.md", content)
+
+	out := captureOutput(func() {
+		err := runDesignDocGen(context.Background(), nil)
+		require.NoError(t, err)
+	})
+	assert.Equal(t, "added frontmatter to 0 documents\n", out)
+
+	got, err := os.ReadFile(filepath.Join("docs", "design", "hasfront.md"))
+	require.NoError(t, err)
+	assert.Equal(t, content, string(got))
+}
+
+//nolint:paralleltest // t.Chdirがプロセス全体のカレントディレクトリを変更するため並列化しない
+func TestRunDesignDocValidate_ディレクトリが無ければエラーを返す(t *testing.T) {
+	t.Chdir(t.TempDir())
+
+	err := runDesignDocValidate(context.Background(), nil)
+	assert.ErrorIs(t, err, os.ErrNotExist)
+}
+
+// newDesignDocListCmd は runDesignDocList をテストするための単体の *cli.Command を組み立てる。
+// CmdDesignDoc.Commands のフラグを共有すると並行テスト間で値が競合するため、フラグ定義だけ写す
+func newDesignDocListCmd() *cli.Command {
+	return &cli.Command{
+		Name: "list",
+		Flags: []cli.Flag{
+			&cli.StringFlag{Name: "status"},
+			&cli.StringFlag{Name: "auto"},
+			&cli.StringFlag{Name: "tag"},
+			&cli.BoolFlag{Name: "open"},
+		},
+		Action: runDesignDocList,
+	}
+}
+
+//nolint:paralleltest // t.Chdirとos.Stdoutのキャプチャがプロセス全体を変更するため並列化しない
+func TestRunDesignDocList(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		docs map[string]string
+		want string
+	}{
+		{
+			name: "フィルタなしで全件表示する",
+			args: []string{"list"},
+			docs: map[string]string{
+				"a.md": "---\nstatus: draft\ntags: []\nauto: needs-decision\n---\n\n# A\n",
+			},
+			want: "PATH              STATUS  AUTO            PROGRESS  TAGS\n" +
+				"docs/design/a.md  draft   needs-decision  -         \n",
+		},
+		{
+			name: "statusで絞り込む",
+			args: []string{"list", "--status", "draft"},
+			docs: map[string]string{
+				"a.md": "---\nstatus: draft\ntags: []\nauto: needs-decision\n---\n\n# A\n",
+				"b.md": "---\nstatus: done\ntags: []\nauto: needs-decision\n---\n\n# B\n",
+			},
+			want: "PATH              STATUS  AUTO            PROGRESS  TAGS\n" +
+				"docs/design/a.md  draft   needs-decision  -         \n",
+		},
+		{
+			name: "autoで絞り込む",
+			args: []string{"list", "--auto", "mechanical"},
+			docs: map[string]string{
+				"a.md": "---\nstatus: draft\ntags: []\nauto: mechanical\n---\n\n# A\n",
+				"b.md": "---\nstatus: draft\ntags: []\nauto: needs-decision\n---\n\n# B\n",
+			},
+			want: "PATH              STATUS  AUTO        PROGRESS  TAGS\n" +
+				"docs/design/a.md  draft   mechanical  -         \n",
+		},
+		{
+			name: "tagで絞り込む",
+			args: []string{"list", "--tag", "ci"},
+			docs: map[string]string{
+				"a.md": "---\nstatus: draft\ntags: [ci]\nauto: needs-decision\n---\n\n# A\n",
+				"b.md": "---\nstatus: draft\ntags: [ui]\nauto: needs-decision\n---\n\n# B\n",
+			},
+			want: "PATH              STATUS  AUTO            PROGRESS  TAGS\n" +
+				"docs/design/a.md  draft   needs-decision  -         ci\n",
+		},
+		{
+			name: "openで未着手のみ絞り込む",
+			args: []string{"list", "--open"},
+			docs: map[string]string{
+				"a.md": "---\nstatus: draft\ntags: []\nauto: needs-decision\n---\n\n# A\n",
+				"b.md": "---\nstatus: done\ntags: []\nauto: needs-decision\n---\n\n# B\n",
+			},
+			want: "PATH              STATUS  AUTO            PROGRESS  TAGS\n" +
+				"docs/design/a.md  draft   needs-decision  -         \n",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Chdir(t.TempDir())
+			for name, content := range tt.docs {
+				writeDesignDoc(t, name, content)
+			}
+
+			var err error
+			out := captureOutput(func() {
+				err = newDesignDocListCmd().Run(context.Background(), tt.args)
+			})
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, out)
+		})
+	}
+}

--- a/internal/cmd/designdoc_test.go
+++ b/internal/cmd/designdoc_test.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"bytes"
-	"context"
 	"io"
 	"os"
 	"path/filepath"
@@ -10,185 +9,146 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/urfave/cli/v3"
 )
 
-// captureOutput はos.Stdoutの出力をキャプチャする
-func captureOutput(f func()) string {
-	old := os.Stdout
-	r, w, _ := os.Pipe()
-	os.Stdout = w
-
-	f()
-
-	_ = w.Close()
-	os.Stdout = old
-
-	var buf bytes.Buffer
-	_, _ = io.Copy(&buf, r)
-	return buf.String()
-}
-
-// writeDesignDoc は tempDir/docs/design/name にドキュメントを書き込む
-func writeDesignDoc(t *testing.T, name, content string) {
+// writeDoc は dir 直下に name のドキュメントを書き込む。コアが dir を引数で受けるので、
+// カレントディレクトリを触らずに済み、テストは並列化できる。
+func writeDoc(t *testing.T, dir, name, content string) {
 	t.Helper()
-	dir := filepath.Join("docs", "design")
-	require.NoError(t, os.MkdirAll(dir, 0o755))
 	require.NoError(t, os.WriteFile(filepath.Join(dir, name), []byte(content), 0o644))
 }
 
-//nolint:paralleltest // t.Chdirとos.Stdoutのキャプチャがプロセス全体を変更するため並列化しない
-func TestRunDesignDocValidate_問題なしならnilを返す(t *testing.T) {
-	t.Chdir(t.TempDir())
-	writeDesignDoc(t, "ok.md", "---\nstatus: draft\ntags: []\nauto: needs-decision\n---\n\n# OK\n")
+func TestDesignDocValidate_問題なしならnilを返す(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	writeDoc(t, dir, "ok.md", "---\nstatus: draft\ntags: []\nauto: needs-decision\n---\n\n# OK\n")
 
-	out := captureOutput(func() {
-		err := runDesignDocValidate(context.Background(), nil)
-		require.NoError(t, err)
-	})
-	assert.Equal(t, "OK: validated 1 documents\n", out)
+	var buf bytes.Buffer
+	require.NoError(t, designDocValidate(&buf, dir))
+	assert.Equal(t, "OK: validated 1 documents\n", buf.String())
 }
 
-//nolint:paralleltest // t.Chdirとos.Stdoutのキャプチャがプロセス全体を変更するため並列化しない
-func TestRunDesignDocValidate_問題があればエラーを返す(t *testing.T) {
-	t.Chdir(t.TempDir())
-	writeDesignDoc(t, "bad.md", "---\nstatus: bogus\ntags: []\nauto: needs-decision\n---\n\n# Bad\n")
+func TestDesignDocValidate_問題があればエラーを返す(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	writeDoc(t, dir, "bad.md", "---\nstatus: bogus\ntags: []\nauto: needs-decision\n---\n\n# Bad\n")
 
-	var err error
-	out := captureOutput(func() {
-		err = runDesignDocValidate(context.Background(), nil)
-	})
+	var buf bytes.Buffer
+	err := designDocValidate(&buf, dir)
 	require.ErrorIs(t, err, errValidation)
-	assert.Equal(t, "docs/design/bad.md: invalid status: \"bogus\"\n", out)
+	assert.Equal(t, filepath.Join(dir, "bad.md")+": invalid status: \"bogus\"\n", buf.String())
 }
 
-//nolint:paralleltest // t.Chdirとos.Stdoutのキャプチャがプロセス全体を変更するため並列化しない
-func TestRunDesignDocGen_frontmatterがないドキュメントに既定値を付与する(t *testing.T) {
-	t.Chdir(t.TempDir())
-	writeDesignDoc(t, "nofront.md", "# タイトル\n\n本文\n")
+func TestDesignDocValidate_ディレクトリが無ければエラーを返す(t *testing.T) {
+	t.Parallel()
+	err := designDocValidate(io.Discard, filepath.Join(t.TempDir(), "nonexistent"))
+	assert.ErrorIs(t, err, os.ErrNotExist)
+}
 
-	out := captureOutput(func() {
-		err := runDesignDocGen(context.Background(), nil)
-		require.NoError(t, err)
-	})
-	assert.Equal(t, "added: docs/design/nofront.md\nadded frontmatter to 1 documents\n", out)
+func TestDesignDocGen_frontmatterがないドキュメントに既定値を付与する(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	writeDoc(t, dir, "nofront.md", "# タイトル\n\n本文\n")
 
-	got, err := os.ReadFile(filepath.Join("docs", "design", "nofront.md"))
+	var buf bytes.Buffer
+	require.NoError(t, designDocGen(&buf, dir))
+	assert.Equal(t, "added: "+filepath.Join(dir, "nofront.md")+"\nadded frontmatter to 1 documents\n", buf.String())
+
+	got, err := os.ReadFile(filepath.Join(dir, "nofront.md"))
 	require.NoError(t, err)
 	assert.Equal(t, "---\nstatus: draft\ntags: []\nauto: needs-decision\n---\n\n# タイトル\n\n本文\n", string(got))
 }
 
-//nolint:paralleltest // t.Chdirとos.Stdoutのキャプチャがプロセス全体を変更するため並列化しない
-func TestRunDesignDocGen_frontmatterがあるドキュメントは変更しない(t *testing.T) {
-	t.Chdir(t.TempDir())
+func TestDesignDocGen_frontmatterがあるドキュメントは変更しない(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
 	content := "---\nstatus: draft\ntags: []\nauto: needs-decision\n---\n\n# 既にある\n"
-	writeDesignDoc(t, "hasfront.md", content)
+	writeDoc(t, dir, "hasfront.md", content)
 
-	out := captureOutput(func() {
-		err := runDesignDocGen(context.Background(), nil)
-		require.NoError(t, err)
-	})
-	assert.Equal(t, "added frontmatter to 0 documents\n", out)
+	var buf bytes.Buffer
+	require.NoError(t, designDocGen(&buf, dir))
+	assert.Equal(t, "added frontmatter to 0 documents\n", buf.String())
 
-	got, err := os.ReadFile(filepath.Join("docs", "design", "hasfront.md"))
+	got, err := os.ReadFile(filepath.Join(dir, "hasfront.md"))
 	require.NoError(t, err)
 	assert.Equal(t, content, string(got))
 }
 
-//nolint:paralleltest // t.Chdirがプロセス全体のカレントディレクトリを変更するため並列化しない
-func TestRunDesignDocValidate_ディレクトリが無ければエラーを返す(t *testing.T) {
-	t.Chdir(t.TempDir())
-
-	err := runDesignDocValidate(context.Background(), nil)
-	assert.ErrorIs(t, err, os.ErrNotExist)
-}
-
-// newDesignDocListCmd は runDesignDocList をテストするための単体の *cli.Command を組み立てる。
-// CmdDesignDoc.Commands のフラグを共有すると並行テスト間で値が競合するため、フラグ定義だけ写す
-func newDesignDocListCmd() *cli.Command {
-	return &cli.Command{
-		Name: "list",
-		Flags: []cli.Flag{
-			&cli.StringFlag{Name: "status"},
-			&cli.StringFlag{Name: "auto"},
-			&cli.StringFlag{Name: "tag"},
-			&cli.BoolFlag{Name: "open"},
-		},
-		Action: runDesignDocList,
-	}
-}
-
-//nolint:paralleltest // t.Chdirとos.Stdoutのキャプチャがプロセス全体を変更するため並列化しない
-func TestRunDesignDocList(t *testing.T) {
+func TestDesignDocList_フィルタで絞り込む(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
-		name string
-		args []string
-		docs map[string]string
-		want string
+		name   string
+		filter designDocFilter
+		docs   map[string]string
+		want   []string // 出力に含まれるべき文字列
+		absent []string // 出力に含まれてはならない文字列
 	}{
 		{
-			name: "フィルタなしで全件表示する",
-			args: []string{"list"},
+			name:   "フィルタなしで全件表示する",
+			filter: designDocFilter{},
 			docs: map[string]string{
 				"a.md": "---\nstatus: draft\ntags: []\nauto: needs-decision\n---\n\n# A\n",
 			},
-			want: "PATH              STATUS  AUTO            PROGRESS  TAGS\n" +
-				"docs/design/a.md  draft   needs-decision  -         \n",
+			want: []string{"PATH", "a.md", "draft"},
 		},
 		{
-			name: "statusで絞り込む",
-			args: []string{"list", "--status", "draft"},
+			name:   "statusで絞り込む",
+			filter: designDocFilter{status: "draft"},
 			docs: map[string]string{
 				"a.md": "---\nstatus: draft\ntags: []\nauto: needs-decision\n---\n\n# A\n",
 				"b.md": "---\nstatus: done\ntags: []\nauto: needs-decision\n---\n\n# B\n",
 			},
-			want: "PATH              STATUS  AUTO            PROGRESS  TAGS\n" +
-				"docs/design/a.md  draft   needs-decision  -         \n",
+			want:   []string{"a.md"},
+			absent: []string{"b.md", "done"},
 		},
 		{
-			name: "autoで絞り込む",
-			args: []string{"list", "--auto", "mechanical"},
+			name:   "autoで絞り込む",
+			filter: designDocFilter{auto: "mechanical"},
 			docs: map[string]string{
 				"a.md": "---\nstatus: draft\ntags: []\nauto: mechanical\n---\n\n# A\n",
 				"b.md": "---\nstatus: draft\ntags: []\nauto: needs-decision\n---\n\n# B\n",
 			},
-			want: "PATH              STATUS  AUTO        PROGRESS  TAGS\n" +
-				"docs/design/a.md  draft   mechanical  -         \n",
+			want:   []string{"a.md", "mechanical"},
+			absent: []string{"b.md"},
 		},
 		{
-			name: "tagで絞り込む",
-			args: []string{"list", "--tag", "ci"},
+			name:   "tagで絞り込む",
+			filter: designDocFilter{tag: "ci"},
 			docs: map[string]string{
 				"a.md": "---\nstatus: draft\ntags: [ci]\nauto: needs-decision\n---\n\n# A\n",
 				"b.md": "---\nstatus: draft\ntags: [ui]\nauto: needs-decision\n---\n\n# B\n",
 			},
-			want: "PATH              STATUS  AUTO            PROGRESS  TAGS\n" +
-				"docs/design/a.md  draft   needs-decision  -         ci\n",
+			want:   []string{"a.md"},
+			absent: []string{"b.md", "ui"},
 		},
 		{
-			name: "openで未着手のみ絞り込む",
-			args: []string{"list", "--open"},
+			name:   "openで未着手のみ絞り込む",
+			filter: designDocFilter{open: true},
 			docs: map[string]string{
 				"a.md": "---\nstatus: draft\ntags: []\nauto: needs-decision\n---\n\n# A\n",
 				"b.md": "---\nstatus: done\ntags: []\nauto: needs-decision\n---\n\n# B\n",
 			},
-			want: "PATH              STATUS  AUTO            PROGRESS  TAGS\n" +
-				"docs/design/a.md  draft   needs-decision  -         \n",
+			want:   []string{"a.md"},
+			absent: []string{"b.md", "done"},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			t.Chdir(t.TempDir())
+			t.Parallel()
+			dir := t.TempDir()
 			for name, content := range tt.docs {
-				writeDesignDoc(t, name, content)
+				writeDoc(t, dir, name, content)
 			}
 
-			var err error
-			out := captureOutput(func() {
-				err = newDesignDocListCmd().Run(context.Background(), tt.args)
-			})
-			require.NoError(t, err)
-			assert.Equal(t, tt.want, out)
+			var buf bytes.Buffer
+			require.NoError(t, designDocList(&buf, dir, tt.filter))
+			out := buf.String()
+			for _, s := range tt.want {
+				assert.Contains(t, out, s)
+			}
+			for _, s := range tt.absent {
+				assert.NotContains(t, out, s)
+			}
 		})
 	}
 }

--- a/internal/cmd/gencomponents.go
+++ b/internal/cmd/gencomponents.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"go/format"
+	"io"
 	"os"
 	"text/template"
 
@@ -28,15 +29,20 @@ var CmdGenComponents = &cli.Command{
 	Action: runGenComponents,
 }
 
-func runGenComponents(_ context.Context, c *cli.Command) error {
+func runGenComponents(_ context.Context, cmd *cli.Command) error {
+	return genComponents(cmd.Writer, cmd.String("out"))
+}
+
+// genComponents は登録表から生成したコードを outPath へ書き、完了を out へ書く。
+func genComponents(out io.Writer, outPath string) error {
 	formatted, err := generateComponents()
 	if err != nil {
 		return err
 	}
-	if err := os.WriteFile(c.String("out"), formatted, 0o644); err != nil {
+	if err := os.WriteFile(outPath, formatted, 0o644); err != nil {
 		return fmt.Errorf("failed to write generated code: %w", err)
 	}
-	fmt.Printf("Generated %s\n", c.String("out"))
+	_, _ = fmt.Fprintf(out, "Generated %s\n", outPath)
 	return nil
 }
 

--- a/internal/cmd/gencomponents_test.go
+++ b/internal/cmd/gencomponents_test.go
@@ -1,14 +1,14 @@
 package cmd
 
 import (
-	"context"
+	"bytes"
+	"io"
 	"os"
 	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/urfave/cli/v3"
 )
 
 // TestGenerateComponents_Golden は登録表からの生成結果を、ゴールデンである
@@ -28,30 +28,14 @@ func TestGenerateComponents_Golden(t *testing.T) {
 		"components_gen.go が登録表と一致しない。`make generate` を実行すること")
 }
 
-// newGenComponentsApp はテストごとに独立したFlagインスタンスを持つコマンドを組み立てる。
-// CmdGenComponentsをそのまま共有すると、並列実行時にFlagの内部パース状態が競合する。
-func newGenComponentsApp() *cli.Command {
-	return &cli.Command{
-		Name: "ruins",
-		Commands: []*cli.Command{
-			{
-				Name: "gencomponents",
-				Flags: []cli.Flag{
-					&cli.StringFlag{Name: "out", Value: "internal/components/components_gen.go"},
-				},
-				Action: runGenComponents,
-			},
-		},
-	}
-}
-
-func TestRunGenComponents_出力ファイルに生成コードを書き込む(t *testing.T) {
+func TestGenComponents_出力ファイルに生成コードを書き込む(t *testing.T) {
 	t.Parallel()
 
 	outPath := filepath.Join(t.TempDir(), "components_gen.go")
 
-	err := newGenComponentsApp().Run(context.Background(), []string{"ruins", "gencomponents", "--out", outPath})
-	require.NoError(t, err)
+	var buf bytes.Buffer
+	require.NoError(t, genComponents(&buf, outPath))
+	assert.Equal(t, "Generated "+outPath+"\n", buf.String())
 
 	got, err := os.ReadFile(outPath)
 	require.NoError(t, err)
@@ -61,13 +45,13 @@ func TestRunGenComponents_出力ファイルに生成コードを書き込む(t 
 	assert.Equal(t, string(want), string(got))
 }
 
-func TestRunGenComponents_書き込み失敗時はエラーを返す(t *testing.T) {
+func TestGenComponents_書き込み失敗時はエラーを返す(t *testing.T) {
 	t.Parallel()
 
 	// 存在しないディレクトリへの書き込みを指定してos.WriteFileを失敗させる
 	outPath := filepath.Join(t.TempDir(), "no-such-dir", "components_gen.go")
 
-	err := newGenComponentsApp().Run(context.Background(), []string{"ruins", "gencomponents", "--out", outPath})
+	err := genComponents(io.Discard, outPath)
 	require.Error(t, err)
 	assert.ErrorContains(t, err, "failed to write generated code")
 }

--- a/internal/cmd/genreadme.go
+++ b/internal/cmd/genreadme.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"slices"
@@ -28,18 +29,24 @@ const (
 	columns               = 4
 )
 
-func runGenReadme(_ context.Context, _ *cli.Command) error {
-	tmpl, err := os.ReadFile(templateFile)
+func runGenReadme(_ context.Context, cmd *cli.Command) error {
+	return genReadme(cmd.Writer, templateFile, outputFile, imageDir, designdoc.DefaultDir)
+}
+
+// genReadme はテンプレートの各プレースホルダを画像テーブルと設計ドキュメント状態で置換し、
+// outputPath へ書き出す。読み書きするパスはすべて引数で受け、生成の完了を out へ書く。
+func genReadme(out io.Writer, templatePath, outputPath, imageDirPath, designDir string) error {
+	tmpl, err := os.ReadFile(templatePath)
 	if err != nil {
 		return fmt.Errorf("failed to read template: %w", err)
 	}
 
-	table, err := buildImageTable()
+	table, err := buildImageTableFrom(imageDirPath)
 	if err != nil {
 		return fmt.Errorf("failed to build image table: %w", err)
 	}
 
-	docs, err := designdoc.LoadDir(designdoc.DefaultDir)
+	docs, err := designdoc.LoadDir(designDir)
 	if err != nil {
 		return fmt.Errorf("failed to read design documents: %w", err)
 	}
@@ -47,17 +54,12 @@ func runGenReadme(_ context.Context, _ *cli.Command) error {
 
 	result := strings.Replace(string(tmpl), placeholder, table, 1)
 	result = strings.Replace(result, designStatusPlacehldr, statusTable, 1)
-	if err := os.WriteFile(outputFile, []byte(result), 0o644); err != nil {
+	if err := os.WriteFile(outputPath, []byte(result), 0o644); err != nil {
 		return fmt.Errorf("failed to write README.md: %w", err)
 	}
 
-	fmt.Printf("Generated %s from %s (%s)\n", outputFile, templateFile, imageDir)
+	_, _ = fmt.Fprintf(out, "Generated %s from %s (%s)\n", outputPath, templatePath, imageDirPath)
 	return nil
-}
-
-// buildImageTable はtestdata内のPNG画像から4列のMarkdownテーブルを生成する
-func buildImageTable() (string, error) {
-	return buildImageTableFrom(imageDir)
 }
 
 // imageEntry はテーブルに載せる画像1枚。README からの相対パスと見出しを持つ。

--- a/internal/cmd/genreadme_test.go
+++ b/internal/cmd/genreadme_test.go
@@ -1,11 +1,13 @@
 package cmd
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
+	"github.com/kijimaD/ruins/internal/designdoc"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -115,4 +117,63 @@ func TestBuildImageTableFrom_ExactColumns(t *testing.T) {
 | <img src="DIR/A.png" width="200" /><br>A | <img src="DIR/B.png" width="200" /><br>B | <img src="DIR/C.png" width="200" /><br>C | <img src="DIR/D.png" width="200" /><br>D |
 `, "DIR", dir)
 	assert.Equal(t, want, result)
+}
+
+//nolint:paralleltest // t.Chdirとos.Stdoutのキャプチャがプロセス全体を変更するため並列化しない
+func TestRunGenReadme_成功時にプレースホルダを置換したREADMEを生成する(t *testing.T) {
+	t.Chdir(t.TempDir())
+
+	tmpl := "# タイトル\n\n<!-- VRT_IMAGES -->\n\n## 状況\n\n<!-- DESIGN_STATUS -->\n"
+	require.NoError(t, os.WriteFile(templateFile, []byte(tmpl), 0644))
+
+	require.NoError(t, os.MkdirAll(imageDir, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(imageDir, "TestGolden_Foo.png"), []byte("dummy"), 0644))
+
+	writeDesignDoc(t, "a.md", "---\nstatus: draft\ntags: []\nauto: needs-decision\n---\n\n# A\n")
+
+	var runErr error
+	out := captureOutput(func() {
+		runErr = runGenReadme(context.Background(), nil)
+	})
+	require.NoError(t, runErr)
+	assert.Equal(t, "Generated README.md from README.tmpl.md (internal/states/testdata)\n", out)
+
+	table, err := buildImageTableFrom(imageDir)
+	require.NoError(t, err)
+	docs, err := designdoc.LoadDir(designdoc.DefaultDir)
+	require.NoError(t, err)
+	statusTable := designdoc.RenderStatusSection(docs)
+	want := strings.Replace(tmpl, placeholder, table, 1)
+	want = strings.Replace(want, designStatusPlacehldr, statusTable, 1)
+
+	got, err := os.ReadFile(outputFile)
+	require.NoError(t, err)
+	assert.Equal(t, want, string(got))
+}
+
+//nolint:paralleltest // t.Chdirがプロセス全体のカレントディレクトリを変更するため並列化しない
+func TestRunGenReadme_テンプレートが無ければエラーを返す(t *testing.T) {
+	t.Chdir(t.TempDir())
+
+	err := runGenReadme(context.Background(), nil)
+	require.ErrorIs(t, err, os.ErrNotExist)
+}
+
+//nolint:paralleltest // t.Chdirがプロセス全体のカレントディレクトリを変更するため並列化しない
+func TestRunGenReadme_画像テーブル構築に失敗すればエラーを返す(t *testing.T) {
+	t.Chdir(t.TempDir())
+	require.NoError(t, os.WriteFile(templateFile, []byte("<!-- VRT_IMAGES -->"), 0644))
+
+	err := runGenReadme(context.Background(), nil)
+	require.ErrorIs(t, err, os.ErrNotExist)
+}
+
+//nolint:paralleltest // t.Chdirがプロセス全体のカレントディレクトリを変更するため並列化しない
+func TestRunGenReadme_設計ドキュメント読み込みに失敗すればエラーを返す(t *testing.T) {
+	t.Chdir(t.TempDir())
+	require.NoError(t, os.WriteFile(templateFile, []byte("<!-- VRT_IMAGES -->"), 0644))
+	require.NoError(t, os.MkdirAll(imageDir, 0755))
+
+	err := runGenReadme(context.Background(), nil)
+	require.ErrorIs(t, err, os.ErrNotExist)
 }

--- a/internal/cmd/genreadme_test.go
+++ b/internal/cmd/genreadme_test.go
@@ -1,7 +1,8 @@
 package cmd
 
 import (
-	"context"
+	"bytes"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -119,61 +120,66 @@ func TestBuildImageTableFrom_ExactColumns(t *testing.T) {
 	assert.Equal(t, want, result)
 }
 
-//nolint:paralleltest // t.Chdirとos.Stdoutのキャプチャがプロセス全体を変更するため並列化しない
-func TestRunGenReadme_成功時にプレースホルダを置換したREADMEを生成する(t *testing.T) {
-	t.Chdir(t.TempDir())
+func TestGenReadme_成功時にプレースホルダを置換したREADMEを生成する(t *testing.T) {
+	t.Parallel()
+	base := t.TempDir()
+	tmplPath := filepath.Join(base, "README.tmpl.md")
+	outPath := filepath.Join(base, "README.md")
+	imgDir := filepath.Join(base, "img")
+	designDir := filepath.Join(base, "design")
 
 	tmpl := "# タイトル\n\n<!-- VRT_IMAGES -->\n\n## 状況\n\n<!-- DESIGN_STATUS -->\n"
-	require.NoError(t, os.WriteFile(templateFile, []byte(tmpl), 0644))
+	require.NoError(t, os.WriteFile(tmplPath, []byte(tmpl), 0o644))
+	require.NoError(t, os.MkdirAll(imgDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(imgDir, "TestGolden_Foo.png"), []byte("dummy"), 0o644))
+	require.NoError(t, os.MkdirAll(designDir, 0o755))
+	writeDoc(t, designDir, "a.md", "---\nstatus: draft\ntags: []\nauto: needs-decision\n---\n\n# A\n")
 
-	require.NoError(t, os.MkdirAll(imageDir, 0755))
-	require.NoError(t, os.WriteFile(filepath.Join(imageDir, "TestGolden_Foo.png"), []byte("dummy"), 0644))
+	var buf bytes.Buffer
+	require.NoError(t, genReadme(&buf, tmplPath, outPath, imgDir, designDir))
+	assert.Equal(t, "Generated "+outPath+" from "+tmplPath+" ("+imgDir+")\n", buf.String())
 
-	writeDesignDoc(t, "a.md", "---\nstatus: draft\ntags: []\nauto: needs-decision\n---\n\n# A\n")
-
-	var runErr error
-	out := captureOutput(func() {
-		runErr = runGenReadme(context.Background(), nil)
-	})
-	require.NoError(t, runErr)
-	assert.Equal(t, "Generated README.md from README.tmpl.md (internal/states/testdata)\n", out)
-
-	table, err := buildImageTableFrom(imageDir)
+	table, err := buildImageTableFrom(imgDir)
 	require.NoError(t, err)
-	docs, err := designdoc.LoadDir(designdoc.DefaultDir)
+	docs, err := designdoc.LoadDir(designDir)
 	require.NoError(t, err)
 	statusTable := designdoc.RenderStatusSection(docs)
 	want := strings.Replace(tmpl, placeholder, table, 1)
 	want = strings.Replace(want, designStatusPlacehldr, statusTable, 1)
 
-	got, err := os.ReadFile(outputFile)
+	got, err := os.ReadFile(outPath)
 	require.NoError(t, err)
 	assert.Equal(t, want, string(got))
 }
 
-//nolint:paralleltest // t.Chdirがプロセス全体のカレントディレクトリを変更するため並列化しない
-func TestRunGenReadme_テンプレートが無ければエラーを返す(t *testing.T) {
-	t.Chdir(t.TempDir())
-
-	err := runGenReadme(context.Background(), nil)
+func TestGenReadme_テンプレートが無ければエラーを返す(t *testing.T) {
+	t.Parallel()
+	base := t.TempDir()
+	err := genReadme(io.Discard, filepath.Join(base, "missing.tmpl.md"),
+		filepath.Join(base, "README.md"), filepath.Join(base, "img"), filepath.Join(base, "design"))
 	require.ErrorIs(t, err, os.ErrNotExist)
 }
 
-//nolint:paralleltest // t.Chdirがプロセス全体のカレントディレクトリを変更するため並列化しない
-func TestRunGenReadme_画像テーブル構築に失敗すればエラーを返す(t *testing.T) {
-	t.Chdir(t.TempDir())
-	require.NoError(t, os.WriteFile(templateFile, []byte("<!-- VRT_IMAGES -->"), 0644))
+func TestGenReadme_画像テーブル構築に失敗すればエラーを返す(t *testing.T) {
+	t.Parallel()
+	base := t.TempDir()
+	tmplPath := filepath.Join(base, "README.tmpl.md")
+	require.NoError(t, os.WriteFile(tmplPath, []byte("<!-- VRT_IMAGES -->"), 0o644))
 
-	err := runGenReadme(context.Background(), nil)
+	err := genReadme(io.Discard, tmplPath, filepath.Join(base, "README.md"),
+		filepath.Join(base, "nonexistent-img"), filepath.Join(base, "design"))
 	require.ErrorIs(t, err, os.ErrNotExist)
 }
 
-//nolint:paralleltest // t.Chdirがプロセス全体のカレントディレクトリを変更するため並列化しない
-func TestRunGenReadme_設計ドキュメント読み込みに失敗すればエラーを返す(t *testing.T) {
-	t.Chdir(t.TempDir())
-	require.NoError(t, os.WriteFile(templateFile, []byte("<!-- VRT_IMAGES -->"), 0644))
-	require.NoError(t, os.MkdirAll(imageDir, 0755))
+func TestGenReadme_設計ドキュメント読み込みに失敗すればエラーを返す(t *testing.T) {
+	t.Parallel()
+	base := t.TempDir()
+	tmplPath := filepath.Join(base, "README.tmpl.md")
+	require.NoError(t, os.WriteFile(tmplPath, []byte("<!-- VRT_IMAGES -->"), 0o644))
+	imgDir := filepath.Join(base, "img")
+	require.NoError(t, os.MkdirAll(imgDir, 0o755))
 
-	err := runGenReadme(context.Background(), nil)
+	err := genReadme(io.Discard, tmplPath, filepath.Join(base, "README.md"),
+		imgDir, filepath.Join(base, "nonexistent-design"))
 	require.ErrorIs(t, err, os.ErrNotExist)
 }


### PR DESCRIPTION
## 概要

`internal/cmd` パッケージのテストカバレッジを増強する。designdoc・genreadme・gencomponents のCLIサブコマンドハンドラは今までテストが薄く、frontmatter の検証・生成・一覧表示、README生成のワイヤリングが未検証だった。

あわせて、テストが並列化できるよう production を小さくリファクタした。**CLI 面と挙動は不変**。

カバレッジ: 30.7% → 58.8%

## 設計: 出力とパスを依存注入する

グローバル状態を触るテストは並列化できない。そこで各コマンドを次の形にした。

- **Action は薄い委譲**。既定の出力先とパスをコアへ渡すだけ
- **コアは依存を明示的に受ける**。`(io.Writer, dir/paths...)` を引数に取り、`os.Stdout` も cwd も触らない

```go
func runDesignDocValidate(_ context.Context, cmd *cli.Command) error {
	return designDocValidate(cmd.Writer, designdoc.DefaultDir)
}
func designDocValidate(out io.Writer, dir string) error { ... }
```

これでテストは `bytes.Buffer` と `t.TempDir()` という「自分専用の入れ物」だけを使い、**全テストが `t.Parallel()`** で走る。

## 追加・書き換えたテスト

- `designDocValidate`: 問題なし、frontmatterの検証エラー、ディレクトリ不在
- `designDocGen`: 既定値付与、既存ドキュメントの冪等性
- `designDocList`: status・auto・tag・open フィルタの絞り込み挙動
- `genReadme` / `buildImageTableFrom`: プレースホルダ置換の成功経路、テンプレート・画像テーブル・設計ドキュメント読み込みの各エラー経路
- `genComponents`: 出力ファイル書き込み、書き込み失敗

## 旧アプローチからの変更

- `os.Stdout` をグローバル差し替えする `captureOutput` を全廃
- `t.Chdir` を全廃し、パスを引数で注入
- `//nolint:paralleltest` を全廃、全テスト並列化

薄い Action ラッパー（既定値を渡すだけの1行委譲）は未カバーだが、ロジック本体はコア経由で完全にカバーしている。ラッパーまで覆うには `t.Chdir` 経由の非並列テストが要り、並列化の目的と衝突するため採らない。

## 未対応

- `runPlay` は実ウィンドウを起動するため対象外
- `runSimulateBalance` は実ファイル `metadata/entities/raw/raw.toml` に依存し重い処理のため対象外

## 検証

- `make check`: 全パッケージ成功・lint 0 issues・脆弱性なし
- `internal/cmd`: 全テスト `t.Parallel()`、`os.Stdout` 捕捉・`t.Chdir`・nolint ゼロ