### PR TITLE
fix(temperature): 敵が環境温度で凍死し一斉全滅するのを直す

### DIFF
--- a/internal/systems/temperature.go
+++ b/internal/systems/temperature.go
@@ -43,9 +43,7 @@ func (sys *TemperatureSystem) Update(world w.World) error {
 		return errors.New("dungeon resource is not set")
 	}
 
-	// 体温の生存機構はプレイヤーと味方だけに適用する。空腹・疲労と同じく敵には効かせない。
-	// FactionAlly を要求することで、HealthStatus を持つ敵が環境で冷えて凍死するのを防ぐ。
-	// 敵の位置に関係なく全員が同じターンに凍死する回帰を、対象を味方へ絞って断つ
+	// 体温の生存機構はプレイヤーと味方だけに適用する。空腹・疲労と同じく敵には効かせない
 	var toMark []ecs.Entity
 	healthQuery := query.ActiveFilter3[gc.HealthStatus, gc.GridElement, gc.FactionAlly](world).Query()
 	for healthQuery.Next() {

--- a/internal/systems/temperature.go
+++ b/internal/systems/temperature.go
@@ -43,9 +43,11 @@ func (sys *TemperatureSystem) Update(world w.World) error {
 		return errors.New("dungeon resource is not set")
 	}
 
-	// HealthStatusとGridElementを持つエンティティを処理。
+	// 体温の生存機構はプレイヤーと味方だけに適用する。空腹・疲労と同じく敵には効かせない。
+	// FactionAlly を要求することで、HealthStatus を持つ敵が環境で冷えて凍死するのを防ぐ。
+	// 敵の位置に関係なく全員が同じターンに凍死する回帰を、対象を味方へ絞って断つ
 	var toMark []ecs.Entity
-	healthQuery := query.ActiveFilter2[gc.HealthStatus, gc.GridElement](world).Query()
+	healthQuery := query.ActiveFilter3[gc.HealthStatus, gc.GridElement, gc.FactionAlly](world).Query()
 	for healthQuery.Next() {
 		entity := healthQuery.Entity()
 		hs := world.Components.HealthStatus.Get(entity)

--- a/internal/systems/temperature_test.go
+++ b/internal/systems/temperature_test.go
@@ -169,6 +169,26 @@ func TestTemperatureSystem_Update(t *testing.T) {
 		assert.Greater(t, cond.Timer, 0.0)
 	})
 
+	t.Run("敵は環境温度で冷えず凍死しない", func(t *testing.T) {
+		t.Parallel()
+		world := testutil.InitTestWorld(t)
+		setStage(world, gc.NewDungeonStage(coldDungeonName, 1)) // 基本気温0度
+
+		// FactionAlly を持たない敵。HealthStatus と GridElement は持つが体温の生存機構の対象外
+		enemy := world.ECS.NewEntity()
+		world.Components.HealthStatus.Add(enemy, &gc.HealthStatus{})
+		world.Components.GridElement.Add(enemy, &gc.GridElement{Coord: consts.Coord[consts.Tile]{X: 0, Y: 0}})
+
+		sys := &TemperatureSystem{}
+		for range 30 {
+			require.NoError(t, sys.Update(world))
+		}
+
+		hs := world.Components.HealthStatus.Get(enemy)
+		assert.Zero(t, hs.BodyTempOffset, "敵は環境で冷えず体温オフセットが動かない")
+		assert.Nil(t, hs.Parts[gc.BodyPartWholeBody].GetCondition(gc.ConditionHypothermia), "敵は低体温にならない")
+	})
+
 	t.Run("存在しないダンジョン名の場合はエラーなし", func(t *testing.T) {
 		t.Parallel()
 		world := testutil.InitTestWorld(t)


### PR DESCRIPTION
## 症状

一定ターン経過で、離れた場所・別チャンク・画面外の敵まで含めて全ての敵が一斉に全滅する。

## 原因

敵も `NewMemberSpec` 経由で `HealthStatus` を持つため、`TemperatureSystem.Update`（`internal/systems/temperature.go`）が全 HealthStatus エンティティの体温を毎ターン下げ、**距離に関係なく**低体温を進める。低体温 Severe → 血液量ドロップ → `ConditionSystem` の失血HPドレイン → 凍死、という連鎖で敵が死ぬ。

- AI 処理には `cullDistantSolo`（距離カリング）があるのに、健康系（体温・不調）には無い。この非対称で画面外の敵まで等しく冷える
- 全敵が平熱0・防寒0で盤面の気温がほぼ一様なので、同じレートで冷え、同じターンに致死域へ達して一斉に凍死する
- 空腹・疲労は味方だけが持つ（`NewPlayerSpec` のみ付与）のに、体温だけが敵に漏れていた

## 修正

空腹・疲労と同じく、環境からの受動的な体温低下を **FactionAlly 限定**にする。

- `TemperatureSystem` の対象クエリを `ActiveFilter2[HealthStatus, GridElement]` → `ActiveFilter3[..., FactionAlly]` へ
- 敵は HealthStatus を持つが環境では冷えず凍死しない
- 戦闘由来の不調（出血など）は `ConditionSystem` で敵にも効かせたまま残す。状態異常の対称性は維持
- 回帰テスト追加: 敵（FactionAlly なし）が寒い環境30ターンで体温オフセット0のまま、低体温にならない

## 検証

`make check` 緑。既存の体温テストは `SpawnPlayer`（FactionAlly 付与）を使うので不変で通過。

🤖 Generated with [Claude Code](https://claude.com/claude-code)