### PR TITLE
test(systems): 温度メッセージの純関数を検証する

### DIFF
--- a/internal/systems/temperature_message_test.go
+++ b/internal/systems/temperature_message_test.go
@@ -1,0 +1,58 @@
+package systems
+
+import (
+	"testing"
+
+	gc "github.com/kijimaD/ruins/internal/components"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestGetWorseningMessage は低体温の悪化メッセージを重症度ごとに固定する。
+// 低体温以外や重症度なしは空文字になる分岐も検証する。
+func TestGetWorseningMessage(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		condType gc.ConditionType
+		severity gc.Severity
+		want     string
+	}{
+		{"低体温なしは空", gc.ConditionHypothermia, gc.SeverityNone, ""},
+		{"低体温軽", gc.ConditionHypothermia, gc.SeverityMinor, "The cold is setting in"},
+		{"低体温中", gc.ConditionHypothermia, gc.SeverityMedium, "You are quite cold"},
+		{"低体温重", gc.ConditionHypothermia, gc.SeveritySevere, "The cold is dangerous"},
+		{"低体温以外は空", gc.ConditionFracture, gc.SeveritySevere, ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, getWorseningMessage(tt.condType, tt.severity))
+		})
+	}
+}
+
+// TestGetRecoveryMessage は低体温の回復メッセージを重症度ごとに固定する。
+// 重症のまま回復した場合や低体温以外は空文字になる分岐も検証する。
+func TestGetRecoveryMessage(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		condType gc.ConditionType
+		severity gc.Severity
+		want     string
+	}{
+		{"低体温なしまで回復", gc.ConditionHypothermia, gc.SeverityNone, "You have warmed up"},
+		{"低体温軽", gc.ConditionHypothermia, gc.SeverityMinor, "You are warming up a little"},
+		{"低体温中", gc.ConditionHypothermia, gc.SeverityMedium, "Still cold, but a little better"},
+		{"低体温重は空", gc.ConditionHypothermia, gc.SeveritySevere, ""},
+		{"低体温以外は空", gc.ConditionFracture, gc.SeverityMinor, ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, getRecoveryMessage(tt.condType, tt.severity))
+		})
+	}
+}

--- a/internal/systems/temperature_message_test.go
+++ b/internal/systems/temperature_message_test.go
@@ -7,8 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-// TestGetWorseningMessage は低体温の悪化メッセージを重症度ごとに固定する。
-// 低体温以外や重症度なしは空文字になる分岐も検証する。
+// TestGetWorseningMessage は getWorseningMessage の全分岐を固定する。
 func TestGetWorseningMessage(t *testing.T) {
 	t.Parallel()
 
@@ -32,8 +31,7 @@ func TestGetWorseningMessage(t *testing.T) {
 	}
 }
 
-// TestGetRecoveryMessage は低体温の回復メッセージを重症度ごとに固定する。
-// 重症のまま回復した場合や低体温以外は空文字になる分岐も検証する。
+// TestGetRecoveryMessage は getRecoveryMessage の全分岐を固定する。
 func TestGetRecoveryMessage(t *testing.T) {
 	t.Parallel()
 
@@ -43,7 +41,7 @@ func TestGetRecoveryMessage(t *testing.T) {
 		severity gc.Severity
 		want     string
 	}{
-		{"低体温なしまで回復", gc.ConditionHypothermia, gc.SeverityNone, "You have warmed up"},
+		{"重症度なしは完全回復メッセージ", gc.ConditionHypothermia, gc.SeverityNone, "You have warmed up"},
 		{"低体温軽", gc.ConditionHypothermia, gc.SeverityMinor, "You are warming up a little"},
 		{"低体温中", gc.ConditionHypothermia, gc.SeverityMedium, "Still cold, but a little better"},
 		{"低体温重は空", gc.ConditionHypothermia, gc.SeveritySevere, ""},


### PR DESCRIPTION
## 概要

`internal/systems/temperature.go` の低体温メッセージを組む純関数 `getWorseningMessage` / `getRecoveryMessage` に、一部の重症度分岐しかテストが無かった。全分岐を固定する。本体コードの変更は無い。

## 追加したテスト

- `getWorseningMessage`: 低体温の重症度なし/軽/中/重、および非低体温
- `getRecoveryMessage`: 低体温の重症度なし/軽/中/重、および非低体温

いずれも world を要さない純関数で `t.Parallel()` で走る。

## 検証

- `make check`: 緑（全テスト・lint 0 issues・脆弱性なし）

🤖 Generated with [Claude Code](https://claude.com/claude-code)