### PR TITLE
test(messagewindow): 選択肢メッセージの入力処理を検証する

### DIFF
--- a/internal/widgets/messagewindow/choice_input_test.go
+++ b/internal/widgets/messagewindow/choice_input_test.go
@@ -1,0 +1,73 @@
+package messagewindow
+
+import (
+	"testing"
+
+	"github.com/kijimaD/ruins/internal/inputmapper"
+	"github.com/kijimaD/ruins/internal/messagedata"
+	"github.com/kijimaD/ruins/internal/testutil"
+	w "github.com/kijimaD/ruins/internal/world"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newChoiceWindow は選択肢2つを持つメッセージウィンドウと、入力を差し替える供給源、
+// 選ばれた選択肢のテキストを記録するポインタを返す。
+func newChoiceWindow(t *testing.T) (*Window, *inputmapper.ActionID, *string) {
+	t.Helper()
+
+	world := testutil.InitTestWorld(t, testutil.WithUI())
+	var action inputmapper.ActionID
+	world.Resources.InputSource = func() (inputmapper.ActionID, bool) { return action, true }
+
+	selected := ""
+	msg := messagedata.NewSystemMessage("質問").
+		WithChoice("はい", func(_ w.World) error { selected = "はい"; return nil }).
+		WithChoice("いいえ", func(_ w.World) error { selected = "いいえ"; return nil })
+
+	return NewWindow(world, msg), &action, &selected
+}
+
+// TestWindowUpdate_選択肢キャンセルで閉じる は、選択肢表示中のキャンセル入力で
+// ウィンドウが閉じることを固定する。
+func TestWindowUpdate_選択肢キャンセルで閉じる(t *testing.T) {
+	t.Parallel()
+
+	win, action, _ := newChoiceWindow(t)
+	require.True(t, win.isOpen)
+
+	*action = inputmapper.ActionMenuCancel
+	require.NoError(t, win.Update())
+
+	assert.False(t, win.isOpen, "キャンセルで閉じる")
+}
+
+// TestWindowUpdate_選択肢決定でActionが走る は、先頭の選択肢を決定するとその Action が
+// 呼ばれることを固定する。
+func TestWindowUpdate_選択肢決定でActionが走る(t *testing.T) {
+	t.Parallel()
+
+	win, action, selected := newChoiceWindow(t)
+
+	*action = inputmapper.ActionMenuSelect
+	require.NoError(t, win.Update())
+
+	assert.Equal(t, "はい", *selected, "先頭の選択肢のActionが走る")
+}
+
+// TestWindowUpdate_下移動してから決定で次の選択肢を選ぶ は、下入力で選択が動き、
+// その後の決定で2つ目の選択肢が選ばれることを固定する。
+func TestWindowUpdate_下移動してから決定で次の選択肢を選ぶ(t *testing.T) {
+	t.Parallel()
+
+	win, action, selected := newChoiceWindow(t)
+
+	*action = inputmapper.ActionMenuDown
+	require.NoError(t, win.Update())
+	assert.True(t, win.isOpen, "移動では閉じない")
+
+	*action = inputmapper.ActionMenuSelect
+	require.NoError(t, win.Update())
+
+	assert.Equal(t, "いいえ", *selected, "下移動後の決定で2つ目を選ぶ")
+}


### PR DESCRIPTION
## 概要

`internal/widgets/messagewindow` の `Update` の選択肢入力フロー（`initChoiceMenu`・`handleChoiceInput`・`selectChoice`・`buildTree`）が未検証だった。`world.Resources.InputSource` に供給源を注入して入力を駆動し、window を要さずに固定する。本体コードの変更は無い。

## 追加したテスト

- キャンセルで選択肢ウィンドウが閉じる
- 決定で先頭の選択肢の Action が走る
- 下移動してから決定で2つ目の選択肢を選ぶ

いずれも `t.Parallel()` で走る。カバレッジ 57.9% → 89.2%。

## 検証

- `make check`: 緑（全テスト・lint 0 issues・脆弱性なし）

🤖 Generated with [Claude Code](https://claude.com/claude-code)