### PR TITLE
test(menuframe): 画面ビルダーの構築を検証する

### DIFF
--- a/internal/widgets/menuframe/screens_test.go
+++ b/internal/widgets/menuframe/screens_test.go
@@ -33,7 +33,7 @@ func TestSplitScreen_タイトル説明ヒントと左右を含む(t *testing.T)
 	tree := SplitScreen(world, res, "タイトル", left, right, "説明", "ヒント")
 
 	labels := uicore.CollectLabels(tree)
-	assert.Subset(t, labels, []string{"タイトル", "説明", "ヒント", "左", "右"})
+	assertContainsAll(t, labels, []string{"タイトル", "説明", "ヒント", "左", "右"})
 }
 
 // TestFormScreen_タイトル本文ヒントを含む は、フォーム画面を組んだツリーに要素のラベルが
@@ -50,7 +50,7 @@ func TestFormScreen_タイトル本文ヒントを含む(t *testing.T) {
 		tree := FormScreen(world, res, "フォーム", body, "エラー", "ヒント")
 
 		labels := uicore.CollectLabels(tree)
-		assert.Subset(t, labels, []string{"フォーム", "本文", "エラー", "ヒント"})
+		assertContainsAll(t, labels, []string{"フォーム", "本文", "エラー", "ヒント"})
 	})
 
 	t.Run("エラー文なしはエラー行を含まない", func(t *testing.T) {
@@ -62,7 +62,16 @@ func TestFormScreen_タイトル本文ヒントを含む(t *testing.T) {
 		tree := FormScreen(world, res, "フォーム", body, "", "ヒント")
 
 		labels := uicore.CollectLabels(tree)
-		assert.Subset(t, labels, []string{"フォーム", "本文", "ヒント"})
+		assertContainsAll(t, labels, []string{"フォーム", "本文", "ヒント"})
 		assert.NotContains(t, labels, "エラー")
 	})
+}
+
+// assertContainsAll は list が want の各要素をすべて含むことを検証する。
+// testify の Subset は引数順を誤読されやすいため、意図が明確なこのヘルパーで包む。
+func assertContainsAll(t *testing.T, list, want []string) {
+	t.Helper()
+	for _, w := range want {
+		assert.Contains(t, list, w)
+	}
 }

--- a/internal/widgets/menuframe/screens_test.go
+++ b/internal/widgets/menuframe/screens_test.go
@@ -1,0 +1,68 @@
+package menuframe
+
+import (
+	"image"
+	"image/color"
+	"testing"
+
+	"github.com/kijimaD/ruins/internal/testutil"
+	"github.com/kijimaD/ruins/internal/widgets/theme"
+	"github.com/kijimaD/ruins/internal/widgets/uicore"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestPanelInner_内側の矩形を返す は、外枠の矩形からメニュー余白ぶん縮めた内側矩形を返す
+// 純関数を固定する。
+func TestPanelInner_内側の矩形を返す(t *testing.T) {
+	t.Parallel()
+
+	got := PanelInner(image.Rect(0, 0, 100, 100))
+	assert.Equal(t, image.Rect(theme.MenuPad, theme.MenuPad, 100-theme.MenuPad, 100-theme.MenuPad), got)
+}
+
+// TestSplitScreen_タイトル説明ヒントと左右を含む は、左右2枠の画面を組んだツリーに
+// タイトル・説明・ヒントと左右の中身のラベルが並ぶことを固定する。
+func TestSplitScreen_タイトル説明ヒントと左右を含む(t *testing.T) {
+	t.Parallel()
+
+	world := testutil.InitTestWorld(t, testutil.WithUI())
+	res := world.Resources.UIResources
+	left := uicore.NewText("左", res.Text.SmallFace, color.White)
+	right := uicore.NewText("右", res.Text.SmallFace, color.White)
+
+	tree := SplitScreen(world, res, "タイトル", left, right, "説明", "ヒント")
+
+	labels := uicore.CollectLabels(tree)
+	assert.Subset(t, labels, []string{"タイトル", "説明", "ヒント", "左", "右"})
+}
+
+// TestFormScreen_タイトル本文ヒントを含む は、フォーム画面を組んだツリーに要素のラベルが
+// 並ぶことを固定する。エラー文の有無で行が増減する分岐も検証する。
+func TestFormScreen_タイトル本文ヒントを含む(t *testing.T) {
+	t.Parallel()
+
+	t.Run("エラー文ありは全要素を含む", func(t *testing.T) {
+		t.Parallel()
+		world := testutil.InitTestWorld(t, testutil.WithUI())
+		res := world.Resources.UIResources
+		body := uicore.NewText("本文", res.Text.SmallFace, color.White)
+
+		tree := FormScreen(world, res, "フォーム", body, "エラー", "ヒント")
+
+		labels := uicore.CollectLabels(tree)
+		assert.Subset(t, labels, []string{"フォーム", "本文", "エラー", "ヒント"})
+	})
+
+	t.Run("エラー文なしはエラー行を含まない", func(t *testing.T) {
+		t.Parallel()
+		world := testutil.InitTestWorld(t, testutil.WithUI())
+		res := world.Resources.UIResources
+		body := uicore.NewText("本文", res.Text.SmallFace, color.White)
+
+		tree := FormScreen(world, res, "フォーム", body, "", "ヒント")
+
+		labels := uicore.CollectLabels(tree)
+		assert.Subset(t, labels, []string{"フォーム", "本文", "ヒント"})
+		assert.NotContains(t, labels, "エラー")
+	})
+}


### PR DESCRIPTION
## 概要

`internal/widgets/menuframe` の画面ビルダー（`SplitScreen`・`FormScreen`・`PanelInner`）が未検証だった。`testutil.WithUI` でツリーを組み、`uicore.CollectLabels` で要素の並びを固定する。window は要さない。本体コードの変更は無い。

## 追加したテスト

- `PanelInner`: 外枠から余白ぶん縮めた内側矩形を返す純関数
- `SplitScreen`: タイトル・説明・ヒント・左右の中身がツリーに並ぶ
- `FormScreen`: タイトル・本文・ヒントを含み、エラー文の有無で行が増減する

FormScreen 経由で InputBox の Children/Bounds も通る。いずれも `t.Parallel()` で走る。カバレッジ 50.9% → 82.1%。

## 検証

- `make check`: 緑（全テスト・lint 0 issues・脆弱性なし）

🤖 Generated with [Claude Code](https://claude.com/claude-code)