### PR TITLE
test(systems): InitializeSystems の全システム登録を検証する

### DIFF
--- a/internal/systems/helper_test.go
+++ b/internal/systems/helper_test.go
@@ -1,0 +1,36 @@
+package systems
+
+import (
+	"testing"
+
+	"github.com/kijimaD/ruins/internal/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestInitializeSystems は全システムの登録を固定する。各システムを String() のキーで
+// updaters/renderers へ登録するので、代表的なシステムの存在と、キーが String() と一致する
+// 不変条件を検証する。
+func TestInitializeSystems(t *testing.T) {
+	t.Parallel()
+
+	world := testutil.InitTestWorld(t, testutil.WithUI())
+
+	updaters, renderers := InitializeSystems(world)
+
+	require.NotEmpty(t, updaters, "Updater が登録される")
+	require.NotEmpty(t, renderers, "Renderer が登録される")
+
+	// 代表的な Updater が登録されている
+	for _, name := range []string{"CameraSystem", "AnimationSystem", "TurnSystem", "TemperatureSystem", "VisionSystem", "AuctionSystem"} {
+		assert.Contains(t, updaters, name, "%s が登録される", name)
+	}
+
+	// マップのキーは対応するシステムの String() と一致する
+	for name, u := range updaters {
+		assert.Equal(t, name, u.String(), "Updater のキーは String() と一致する")
+	}
+	for name, r := range renderers {
+		assert.Equal(t, name, r.String(), "Renderer のキーは String() と一致する")
+	}
+}

--- a/internal/systems/helper_test.go
+++ b/internal/systems/helper_test.go
@@ -10,27 +10,43 @@ import (
 
 // TestInitializeSystems は全システムの登録を固定する。各システムを String() のキーで
 // updaters/renderers へ登録するので、代表的なシステムの存在と、キーが String() と一致する
-// 不変条件を検証する。
+// 不変条件、Updater と Renderer 両方へ登録される特殊システムを検証する。
+// WithUI は HUDRenderingSystem など UI リソースを要するシステムの初期化のため。
 func TestInitializeSystems(t *testing.T) {
 	t.Parallel()
 
 	world := testutil.InitTestWorld(t, testutil.WithUI())
-
 	updaters, renderers := InitializeSystems(world)
 
-	require.NotEmpty(t, updaters, "Updater が登録される")
-	require.NotEmpty(t, renderers, "Renderer が登録される")
+	t.Run("代表的なUpdaterが登録される", func(t *testing.T) {
+		t.Parallel()
+		require.NotEmpty(t, updaters)
+		for _, name := range []string{"CameraSystem", "AnimationSystem", "TurnSystem", "TemperatureSystem", "VisionSystem", "AuctionSystem"} {
+			assert.Contains(t, updaters, name, "%s が登録される", name)
+		}
+	})
 
-	// 代表的な Updater が登録されている
-	for _, name := range []string{"CameraSystem", "AnimationSystem", "TurnSystem", "TemperatureSystem", "VisionSystem", "AuctionSystem"} {
-		assert.Contains(t, updaters, name, "%s が登録される", name)
-	}
+	t.Run("代表的なRendererが登録される", func(t *testing.T) {
+		t.Parallel()
+		require.NotEmpty(t, renderers)
+		assert.Contains(t, renderers, "RenderSpriteSystem", "スプライト描画が登録される")
+	})
 
-	// マップのキーは対応するシステムの String() と一致する
-	for name, u := range updaters {
-		assert.Equal(t, name, u.String(), "Updater のキーは String() と一致する")
-	}
-	for name, r := range renderers {
-		assert.Equal(t, name, r.String(), "Renderer のキーは String() と一致する")
-	}
+	t.Run("HUDとVisualEffectはUpdaterとRendererの両方へ登録される", func(t *testing.T) {
+		t.Parallel()
+		for _, name := range []string{"HUDRenderingSystem", "VisualEffectSystem"} {
+			assert.Contains(t, updaters, name, "%s は Updater にも登録される", name)
+			assert.Contains(t, renderers, name, "%s は Renderer にも登録される", name)
+		}
+	})
+
+	t.Run("マップのキーは対応するStringと一致する", func(t *testing.T) {
+		t.Parallel()
+		for name, u := range updaters {
+			assert.Equal(t, name, u.String(), "Updater のキーは String() と一致する")
+		}
+		for name, r := range renderers {
+			assert.Equal(t, name, r.String(), "Renderer のキーは String() と一致する")
+		}
+	})
 }


### PR DESCRIPTION
## 概要

`internal/systems` は最も低カバレッジのパッケージで、`InitializeSystems` と多くの `String()` が 0% だった。`InitializeSystems` は各 System の `String()` をキーに `updaters`/`renderers` マップへ登録するため、1テストで登録処理と各 `String()` を同時に固定できる高レバレッジな対象。

## 変更

- `internal/systems/helper_test.go` を追加
  - `InitializeSystems(world)` を呼び、代表 Updater の登録有無を検証
  - マップのキーが対応 System の `String()` と一致する不変条件を検証
  - `testutil.InitTestWorld(t, testutil.WithUI())` を使い window 非依存。`t.Parallel()`

## カバレッジ

0% → 100% になった関数:
- `helper.go InitializeSystems`
- `animation_system.go / auction.go / stats_changed.go / turn_system.go / vision.go / weight_dirty.go` の各 `String()`

`make check` 緑。

🤖 Generated with [Claude Code](https://claude.com/claude-code)