### PR TITLE
test(systems): VisionSystem の基本と描画情報の番兵を検証する

### DIFF
--- a/internal/systems/vision_pure_test.go
+++ b/internal/systems/vision_pure_test.go
@@ -10,8 +10,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestVisionSystem_NewAndString はコンストラクタと名前を検証する。
-func TestVisionSystem_NewAndString(t *testing.T) {
+// TestNewVisionSystem_初期化してStringを返す はコンストラクタと名前を検証する。
+func TestNewVisionSystem_初期化してStringを返す(t *testing.T) {
 	t.Parallel()
 
 	sys := NewVisionSystem()
@@ -19,9 +19,9 @@ func TestVisionSystem_NewAndString(t *testing.T) {
 	assert.Equal(t, "VisionSystem", sys.String())
 }
 
-// TestVisionSystem_Update_NoPlayer はプレイヤー不在時に何もせず nil を返すことを検証する。
+// TestVisionSystem_Update_プレイヤー不在なら早期returnしnilを返す を検証する。
 // InitTestWorld はプレイヤーもダンジョンも持たないため、Update は最初の早期 return を通る。
-func TestVisionSystem_Update_NoPlayer(t *testing.T) {
+func TestVisionSystem_Update_プレイヤー不在なら早期returnしnilを返す(t *testing.T) {
 	t.Parallel()
 
 	world := testutil.InitTestWorld(t)
@@ -30,9 +30,8 @@ func TestVisionSystem_Update_NoPlayer(t *testing.T) {
 	require.NoError(t, sys.Update(world))
 }
 
-// TestTileRenderAt は描画情報の取得を検証する。
-// map にあればその状態を返し、無ければ未探索の番兵 TileRenderUnexplored を返す。
-func TestTileRenderAt(t *testing.T) {
+// TestTileRenderAt_格納済みは同じ状態を返し不在は未探索番兵を返す を検証する。
+func TestTileRenderAt_格納済みは同じ状態を返し不在は未探索番兵を返す(t *testing.T) {
 	t.Parallel()
 
 	present := gc.GridElement{Coord: consts.Coord[consts.Tile]{X: 1, Y: 2}}
@@ -40,12 +39,12 @@ func TestTileRenderAt(t *testing.T) {
 		present: TileRenderVisible{Darkness: 0.2},
 	}
 
-	// 在れば格納された状態を返す
-	_, ok := tileRenderAt(m, present).(TileRenderVisible)
-	assert.True(t, ok, "格納済みタイルは TileRenderVisible")
+	// 在れば格納された状態を、同じ値のまま返す
+	v, ok := tileRenderAt(m, present).(TileRenderVisible)
+	require.True(t, ok, "格納済みタイルは TileRenderVisible")
+	assert.Equal(t, VisibleDarkness(0.2), v.Darkness, "格納した値がそのまま返る")
 
 	// 不在は未探索の番兵
-	absent := gc.GridElement{Coord: consts.Coord[consts.Tile]{X: 9, Y: 9}}
-	_, ok = tileRenderAt(m, absent).(TileRenderUnexplored)
+	_, ok = tileRenderAt(m, gc.GridElement{Coord: consts.Coord[consts.Tile]{X: 9, Y: 9}}).(TileRenderUnexplored)
 	assert.True(t, ok, "未格納タイルは TileRenderUnexplored")
 }

--- a/internal/systems/vision_pure_test.go
+++ b/internal/systems/vision_pure_test.go
@@ -1,0 +1,51 @@
+package systems
+
+import (
+	"testing"
+
+	gc "github.com/kijimaD/ruins/internal/components"
+	"github.com/kijimaD/ruins/internal/consts"
+	"github.com/kijimaD/ruins/internal/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestVisionSystem_NewAndString はコンストラクタと名前を検証する。
+func TestVisionSystem_NewAndString(t *testing.T) {
+	t.Parallel()
+
+	sys := NewVisionSystem()
+	require.NotNil(t, sys)
+	assert.Equal(t, "VisionSystem", sys.String())
+}
+
+// TestVisionSystem_Update_NoPlayer はプレイヤー不在時に何もせず nil を返すことを検証する。
+// InitTestWorld はプレイヤーもダンジョンも持たないため、Update は最初の早期 return を通る。
+func TestVisionSystem_Update_NoPlayer(t *testing.T) {
+	t.Parallel()
+
+	world := testutil.InitTestWorld(t)
+	sys := NewVisionSystem()
+
+	require.NoError(t, sys.Update(world))
+}
+
+// TestTileRenderAt は描画情報の取得を検証する。
+// map にあればその状態を返し、無ければ未探索の番兵 TileRenderUnexplored を返す。
+func TestTileRenderAt(t *testing.T) {
+	t.Parallel()
+
+	present := gc.GridElement{Coord: consts.Coord[consts.Tile]{X: 1, Y: 2}}
+	m := map[gc.GridElement]TileRenderInfo{
+		present: TileRenderVisible{Darkness: 0.2},
+	}
+
+	// 在れば格納された状態を返す
+	_, ok := tileRenderAt(m, present).(TileRenderVisible)
+	assert.True(t, ok, "格納済みタイルは TileRenderVisible")
+
+	// 不在は未探索の番兵
+	absent := gc.GridElement{Coord: consts.Coord[consts.Tile]{X: 9, Y: 9}}
+	_, ok = tileRenderAt(m, absent).(TileRenderUnexplored)
+	assert.True(t, ok, "未格納タイルは TileRenderUnexplored")
+}


### PR DESCRIPTION
## 概要

`internal/systems`(44%) の `vision.go` は ebiten 非依存だが、`VisionSystem` の入口関数と `tileRenderAt` の3状態判定が未カバーだった。純ロジックに絞ってテストを追加する。

## 変更

- `internal/systems/vision_pure_test.go` を追加
  - `NewVisionSystem` / `String`
  - プレイヤー不在時の `Update` が何もせず nil を返す早期 return 経路
  - `tileRenderAt`: 格納済みはその状態、不在は未探索の番兵 `TileRenderUnexplored` を返す

依存注入 + `t.Parallel()`、window 非依存。

## カバレッジ

- `NewVisionSystem` `String` `tileRenderAt`: 0% → 100%
- `Update`: 早期 return 経路を追加

`overworldDaylightAnchor` 系は既存 `daylight_test.go` が網羅済みのため対象外。空ボディの `tileRenderInfo()` マーカーは実行文が無く数値が動かないため対象外。

`make check` 緑。

🤖 Generated with [Claude Code](https://claude.com/claude-code)