### PR TITLE
test(hud): WeaponSlots の描画契約を fakeCanvas で検証する

### DIFF
--- a/internal/widgets/hud/weapon_slots_test.go
+++ b/internal/widgets/hud/weapon_slots_test.go
@@ -42,9 +42,12 @@ func TestWeaponSlots_Draw_各スロットを描画する(t *testing.T) {
 	world := testutil.InitTestWorld(t)
 	cv := &fakeCanvas{}
 
+	// 武器スロットは仕様上最大5枠で番号は1桁に収まるため、番号は '0'+n で単純に描ける。
+	// テスト用シートは画像を持たないので、装備ありでもスプライトは解決に失敗する。
+	// ここでは WeaponName の有無で drawWeaponSprite の入口分岐が分かれることを通す
 	data := WeaponSlotsData{
 		Slots: []WeaponSlotInfo{
-			// 装備あり、既知シートのスプライト名。スプライト解決を試みる
+			// 装備あり。スプライト解決を試みるが画像が無く描画はしない
 			{WeaponName: "剣", SpriteSheet: "field", SpriteName: "player"},
 			// 装備あり、未知のスプライト名。解決に失敗し描画しない
 			{WeaponName: "槍", SpriteSheet: "field", SpriteName: "unknown_sprite"},
@@ -61,7 +64,8 @@ func TestWeaponSlots_Draw_各スロットを描画する(t *testing.T) {
 	assert.Equal(t, 3, cv.nineSlices, "スロット数ぶんの背景を描く")
 	// 選択中スロットにだけ枠線を重ねる
 	assert.Len(t, cv.strokeRects, 1, "選択スロットに枠線を1つ描く")
-	// スロット番号を各スロットに描く。番号は1始まり
+	// スロット番号を各スロットに描く。番号は1始まり。
+	// 以降は cv.texts をスロット順に添字参照するため、先に長さを固定してから内容を見る
 	require.Len(t, cv.texts, 3, "各スロットに番号を描く")
 	assert.Equal(t, "1", cv.texts[0].str, "先頭スロットの番号は1")
 	assert.Equal(t, "3", cv.texts[2].str, "末尾スロットの番号は3")

--- a/internal/widgets/hud/weapon_slots_test.go
+++ b/internal/widgets/hud/weapon_slots_test.go
@@ -1,0 +1,68 @@
+package hud
+
+import (
+	"testing"
+
+	"github.com/kijimaD/ruins/internal/loader"
+	"github.com/kijimaD/ruins/internal/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newTestWeaponSlots は face 無し、実 UIResources から作った Chrome を持つ WeaponSlots を返す。
+// face は fakeCanvas が無視するため nil でよい。
+func newTestWeaponSlots(t *testing.T) *WeaponSlots {
+	t.Helper()
+	res, err := loader.LoadUIResources()
+	require.NoError(t, err)
+	return NewWeaponSlots(nil, NewChrome(res))
+}
+
+// TestWeaponSlots_Draw_空スロットは何も描かない はスロットが無いとき早期 return することを検証する。
+func TestWeaponSlots_Draw_空スロットは何も描かない(t *testing.T) {
+	t.Parallel()
+
+	ws := newTestWeaponSlots(t)
+	world := testutil.InitTestWorld(t)
+	cv := &fakeCanvas{}
+
+	ws.Draw(cv, WeaponSlotsData{Slots: nil}, world)
+
+	assert.Equal(t, 0, cv.nineSlices, "背景を描かない")
+	assert.Empty(t, cv.texts, "番号を描かない")
+	assert.Empty(t, cv.strokeRects, "枠線を描かない")
+}
+
+// TestWeaponSlots_Draw_各スロットを描画する は各スロットに背景と番号を描き、
+// 選択中スロットに枠線を重ね、装備の有無でスプライト解決経路が分かれることを検証する。
+func TestWeaponSlots_Draw_各スロットを描画する(t *testing.T) {
+	t.Parallel()
+
+	ws := newTestWeaponSlots(t)
+	world := testutil.InitTestWorld(t)
+	cv := &fakeCanvas{}
+
+	data := WeaponSlotsData{
+		Slots: []WeaponSlotInfo{
+			// 装備あり、既知シートのスプライト名。スプライト解決を試みる
+			{WeaponName: "剣", SpriteSheet: "field", SpriteName: "player"},
+			// 装備あり、未知のスプライト名。解決に失敗し描画しない
+			{WeaponName: "槍", SpriteSheet: "field", SpriteName: "unknown_sprite"},
+			// 装備なし。スプライトは描かない
+			{WeaponName: ""},
+		},
+		SelectedSlot:     0,
+		ScreenDimensions: ScreenDimensions{Width: 1024, Height: 768},
+	}
+
+	ws.Draw(cv, data, world)
+
+	// 各スロットに背景をNineSliceで描く
+	assert.Equal(t, 3, cv.nineSlices, "スロット数ぶんの背景を描く")
+	// 選択中スロットにだけ枠線を重ねる
+	assert.Len(t, cv.strokeRects, 1, "選択スロットに枠線を1つ描く")
+	// スロット番号を各スロットに描く。番号は1始まり
+	require.Len(t, cv.texts, 3, "各スロットに番号を描く")
+	assert.Equal(t, "1", cv.texts[0].str, "先頭スロットの番号は1")
+	assert.Equal(t, "3", cv.texts[2].str, "末尾スロットの番号は3")
+}


### PR DESCRIPTION
## 概要

`internal/widgets/hud`(62.7%) の `WeaponSlots` は全関数が未カバーだった。既存の記録用 `fakeCanvas` を使い、ebiten の描画コンテキスト無しに描画命令を論理検証する。ピクセル golden より速く、描画契約が明示的になる。

## 変更

`internal/widgets/hud/weapon_slots_test.go` を追加。

- `TestWeaponSlots_Draw_空スロットは何も描かない`: スロット0件で早期 return
- `TestWeaponSlots_Draw_各スロットを描画する`: 各スロットに背景 NineSlice と番号を描き、選択中スロットにだけ枠線を重ねる。装備あり/なしでスプライト解決経路が分かれる

`loader.LoadUIResources` + `NewChrome`、`testutil.InitTestWorld`、`fakeCanvas`。`t.Parallel()`、window 非依存。

## カバレッジ

- `NewWeaponSlots` `Draw` `drawSlotBackground` `drawSlotNumber`: 0% → 100%
- `drawWeaponSprite`: 0% → 71.4%

`drawWeaponSprite` の最終 `DrawImage` はスプライトの実テクスチャが要るため未到達。テスト用スプライトシートはメタデータのみで画像を持たない。

`make check` 緑。

🤖 Generated with [Claude Code](https://claude.com/claude-code)