### PR TITLE
test(hud): TileFrame のタイル枠描画を検証する

### DIFF
--- a/internal/widgets/hud/tile_frame_test.go
+++ b/internal/widgets/hud/tile_frame_test.go
@@ -4,8 +4,29 @@ import (
 	"image/color"
 	"testing"
 
+	"github.com/hajimehoshi/ebiten/v2"
+	"github.com/kijimaD/ruins/internal/consts"
 	"github.com/stretchr/testify/assert"
 )
+
+// TestTileFrame は投影済みの四隅を線で結ぶ枠描画が実 screen へ描いても落ちないことを検証する。
+// 台形でも四隅を順に結ぶだけなので、正方でない四隅でも描けることを確認する。
+func TestTileFrame(t *testing.T) {
+	t.Parallel()
+
+	screen := ebiten.NewImage(64, 64)
+	// 北西・北東・南東・南西。透視で潰れた台形を模す
+	corners := [4]consts.Coord[consts.ScreenPixel]{
+		{X: 10, Y: 10},
+		{X: 54, Y: 12},
+		{X: 50, Y: 54},
+		{X: 14, Y: 50},
+	}
+
+	assert.NotPanics(t, func() {
+		TileFrame(screen, corners, 2, color.RGBA{R: 255, A: 255})
+	})
+}
 
 func TestScaleAlpha(t *testing.T) {
 	t.Parallel()

--- a/internal/widgets/hud/tile_frame_test.go
+++ b/internal/widgets/hud/tile_frame_test.go
@@ -9,9 +9,10 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-// TestTileFrame は投影済みの四隅を線で結ぶ枠描画が実 screen へ描いても落ちないことを検証する。
-// 台形でも四隅を順に結ぶだけなので、正方でない四隅でも描けることを確認する。
-func TestTileFrame(t *testing.T) {
+// TestTileFrame_台形の四隅を渡して描画しても落ちない は投影済みの四隅を線で結ぶ枠描画が
+// 実 screen へ描いても落ちないことを検証する。台形でも四隅を順に結ぶだけなので、正方でない
+// 四隅でも描けることを確認する。
+func TestTileFrame_台形の四隅を渡して描画しても落ちない(t *testing.T) {
 	t.Parallel()
 
 	screen := ebiten.NewImage(64, 64)


### PR DESCRIPTION
## 概要

`internal/widgets/hud` の `TileFrame` は未カバーだった。透視投影で台形になったタイルの四隅を線で結ぶ枠描画。実 screen へ描いて落ちないことを固定する。

## 変更

`internal/widgets/hud/tile_frame_test.go` に `TestTileFrame` を追加。正方でない台形の四隅を渡し、`ebiten.NewImage` の screen へ描画して NotPanics を確認する。`t.Parallel()`、window 非依存。

## カバレッジ

- `TileFrame`: 0% → 100%

これで hud パッケージの残る 0% 関数は空ボディの no-op Update のみとなる。それらは実行文が無く数値が動かない。

`make check` 緑。

🤖 Generated with [Claude Code](https://claude.com/claude-code)