### PR TITLE
test(states): デバッグメニューの世界変異アクションを検証する

### DIFF
--- a/internal/states/debug_actions_test.go
+++ b/internal/states/debug_actions_test.go
@@ -6,109 +6,138 @@ import (
 	gc "github.com/kijimaD/ruins/internal/components"
 	"github.com/kijimaD/ruins/internal/consts"
 	"github.com/kijimaD/ruins/internal/testutil"
+	w "github.com/kijimaD/ruins/internal/world"
 	"github.com/kijimaD/ruins/internal/world/lifecycle"
+	"github.com/kijimaD/ruins/internal/world/query"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-// TestDebugStarveHunger は満腹度を0にすること、プレイヤー不在ではエラーを返すことを検証する。
+// spawnTestPlayer はプレイヤーを1体置いた world を返す。
+func spawnTestPlayer(t *testing.T) w.World {
+	t.Helper()
+	world := testutil.InitTestWorld(t)
+	_, err := lifecycle.SpawnPlayer(world, consts.Coord[consts.Tile]{X: 5, Y: 5}, "ash")
+	require.NoError(t, err)
+	return world
+}
+
 func TestDebugStarveHunger(t *testing.T) {
 	t.Parallel()
 
-	world := testutil.InitTestWorld(t)
-	player, err := lifecycle.SpawnPlayer(world, consts.Coord[consts.Tile]{X: 5, Y: 5}, "ash")
-	require.NoError(t, err)
+	t.Run("満腹度を0にする", func(t *testing.T) {
+		t.Parallel()
+		world := spawnTestPlayer(t)
+		player, err := query.GetPlayerEntity(world)
+		require.NoError(t, err)
 
-	// 事前に満腹にしておく
-	hunger := world.Components.Hunger.Get(player)
-	hunger.Current = hunger.Max
-	require.Positive(t, hunger.Current)
+		// 事前に満腹にしておく
+		hunger := world.Components.Hunger.Get(player)
+		require.Positive(t, hunger.Max)
+		hunger.Current = hunger.Max
 
-	require.NoError(t, debugStarveHunger(world))
-	assert.Zero(t, world.Components.Hunger.Get(player).Current, "満腹度は0になる")
+		require.NoError(t, debugStarveHunger(world))
+		assert.Zero(t, world.Components.Hunger.Get(player).Current, "満腹度は0になる")
+	})
 
-	// プレイヤー不在ではエラー
-	empty := testutil.InitTestWorld(t)
-	assert.Error(t, debugStarveHunger(empty))
+	t.Run("プレイヤー不在はエラーを返す", func(t *testing.T) {
+		t.Parallel()
+		assert.ErrorContains(t, debugStarveHunger(testutil.InitTestWorld(t)), "player")
+	})
 }
 
-// TestDebugExhaustFatigue は疲労を上限まで上げること、プレイヤー不在ではエラーを返すことを検証する。
 func TestDebugExhaustFatigue(t *testing.T) {
 	t.Parallel()
 
-	world := testutil.InitTestWorld(t)
-	player, err := lifecycle.SpawnPlayer(world, consts.Coord[consts.Tile]{X: 5, Y: 5}, "ash")
-	require.NoError(t, err)
+	t.Run("疲労を上限まで上げる", func(t *testing.T) {
+		t.Parallel()
+		world := spawnTestPlayer(t)
+		player, err := query.GetPlayerEntity(world)
+		require.NoError(t, err)
 
-	require.NoError(t, debugExhaustFatigue(world))
-	fatigue := world.Components.Fatigue.Get(player)
-	assert.Equal(t, fatigue.Max, fatigue.Current, "疲労は上限まで上がる")
+		require.NoError(t, debugExhaustFatigue(world))
+		fatigue := world.Components.Fatigue.Get(player)
+		assert.Equal(t, fatigue.Max, fatigue.Current, "疲労は上限まで上がる")
+	})
 
-	empty := testutil.InitTestWorld(t)
-	assert.Error(t, debugExhaustFatigue(empty))
+	t.Run("プレイヤー不在はエラーを返す", func(t *testing.T) {
+		t.Parallel()
+		assert.ErrorContains(t, debugExhaustFatigue(testutil.InitTestWorld(t)), "player")
+	})
 }
 
-// TestDebugInflictConditions は主要部位へ状態異常を付与すること、プレイヤー不在ではエラーを返すことを検証する。
 func TestDebugInflictConditions(t *testing.T) {
 	t.Parallel()
 
-	world := testutil.InitTestWorld(t)
-	player, err := lifecycle.SpawnPlayer(world, consts.Coord[consts.Tile]{X: 5, Y: 5}, "ash")
-	require.NoError(t, err)
+	t.Run("主要部位へ状態異常を付与する", func(t *testing.T) {
+		t.Parallel()
+		world := spawnTestPlayer(t)
+		player, err := query.GetPlayerEntity(world)
+		require.NoError(t, err)
 
-	require.NoError(t, debugInflictConditions(world))
+		require.NoError(t, debugInflictConditions(world))
+		hs := world.Components.HealthStatus.Get(player)
+		assert.True(t, hasCondition(hs, gc.BodyPartArms, gc.ConditionFracture), "腕に骨折を付与する")
+		assert.True(t, hasCondition(hs, gc.BodyPartTorso, gc.ConditionLiverIllness), "胴に肝疾患を付与する")
+	})
 
-	hs := world.Components.HealthStatus.Get(player)
-	assert.True(t, hasCondition(hs, gc.BodyPartArms, gc.ConditionFracture), "腕に骨折を付与する")
-	assert.True(t, hasCondition(hs, gc.BodyPartTorso, gc.ConditionLiverIllness), "胴に肝疾患を付与する")
-
-	empty := testutil.InitTestWorld(t)
-	assert.Error(t, debugInflictConditions(empty))
+	t.Run("プレイヤー不在はエラーを返す", func(t *testing.T) {
+		t.Parallel()
+		assert.ErrorContains(t, debugInflictConditions(testutil.InitTestWorld(t)), "player")
+	})
 }
 
-// TestDebugTreatAllConditions は付与済みの全状態異常へ良質な治療を適用することを検証する。
 func TestDebugTreatAllConditions(t *testing.T) {
 	t.Parallel()
 
-	world := testutil.InitTestWorld(t)
-	player, err := lifecycle.SpawnPlayer(world, consts.Coord[consts.Tile]{X: 5, Y: 5}, "ash")
-	require.NoError(t, err)
+	t.Run("付与済みの全状態異常へ良質な治療を適用する", func(t *testing.T) {
+		t.Parallel()
+		world := spawnTestPlayer(t)
+		player, err := query.GetPlayerEntity(world)
+		require.NoError(t, err)
 
-	// 先に状態異常を付与してから治療する
-	require.NoError(t, debugInflictConditions(world))
-	require.NoError(t, debugTreatAllConditions(world))
+		// 先に状態異常を付与してから治療する
+		require.NoError(t, debugInflictConditions(world))
+		require.NoError(t, debugTreatAllConditions(world))
 
-	hs := world.Components.HealthStatus.Get(player)
-	treated := 0
-	for p := range hs.Parts {
-		for _, c := range hs.Parts[p].Conditions {
-			assert.EqualValues(t, 150, c.TendQuality, "全条件に良質な治療が入る")
-			treated++
+		hs := world.Components.HealthStatus.Get(player)
+		treated := 0
+		for p := range hs.Parts {
+			for _, c := range hs.Parts[p].Conditions {
+				assert.EqualValues(t, 150, c.TendQuality, "全条件に良質な治療が入る")
+				treated++
+			}
 		}
-	}
-	assert.Positive(t, treated, "治療対象の条件が存在する")
+		assert.Positive(t, treated, "治療対象の条件が存在する")
+	})
 
-	empty := testutil.InitTestWorld(t)
-	assert.Error(t, debugTreatAllConditions(empty))
+	t.Run("プレイヤー不在はエラーを返す", func(t *testing.T) {
+		t.Parallel()
+		assert.ErrorContains(t, debugTreatAllConditions(testutil.InitTestWorld(t)), "player")
+	})
 }
 
-// TestPlayerGridElement はプレイヤーの座標を返すこと、プレイヤー不在ではエラーを返すことを検証する。
 func TestPlayerGridElement(t *testing.T) {
 	t.Parallel()
 
-	world := testutil.InitTestWorld(t)
-	_, err := lifecycle.SpawnPlayer(world, consts.Coord[consts.Tile]{X: 5, Y: 7}, "ash")
-	require.NoError(t, err)
+	t.Run("プレイヤーの座標を返す", func(t *testing.T) {
+		t.Parallel()
+		world := testutil.InitTestWorld(t)
+		_, err := lifecycle.SpawnPlayer(world, consts.Coord[consts.Tile]{X: 5, Y: 7}, "ash")
+		require.NoError(t, err)
 
-	grid, err := playerGridElement(world)
-	require.NoError(t, err)
-	require.NotNil(t, grid)
-	assert.Equal(t, consts.Tile(5), grid.X)
-	assert.Equal(t, consts.Tile(7), grid.Y)
+		grid, err := playerGridElement(world)
+		require.NoError(t, err)
+		require.NotNil(t, grid)
+		assert.Equal(t, consts.Tile(5), grid.X)
+		assert.Equal(t, consts.Tile(7), grid.Y)
+	})
 
-	empty := testutil.InitTestWorld(t)
-	_, err = playerGridElement(empty)
-	assert.Error(t, err)
+	t.Run("プレイヤー不在はエラーを返す", func(t *testing.T) {
+		t.Parallel()
+		_, err := playerGridElement(testutil.InitTestWorld(t))
+		assert.ErrorContains(t, err, "player")
+	})
 }
 
 // hasCondition は指定部位に指定種別の状態異常があるかを返す。

--- a/internal/states/debug_actions_test.go
+++ b/internal/states/debug_actions_test.go
@@ -1,0 +1,122 @@
+package states
+
+import (
+	"testing"
+
+	gc "github.com/kijimaD/ruins/internal/components"
+	"github.com/kijimaD/ruins/internal/consts"
+	"github.com/kijimaD/ruins/internal/testutil"
+	"github.com/kijimaD/ruins/internal/world/lifecycle"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestDebugStarveHunger は満腹度を0にすること、プレイヤー不在ではエラーを返すことを検証する。
+func TestDebugStarveHunger(t *testing.T) {
+	t.Parallel()
+
+	world := testutil.InitTestWorld(t)
+	player, err := lifecycle.SpawnPlayer(world, consts.Coord[consts.Tile]{X: 5, Y: 5}, "ash")
+	require.NoError(t, err)
+
+	// 事前に満腹にしておく
+	hunger := world.Components.Hunger.Get(player)
+	hunger.Current = hunger.Max
+	require.Positive(t, hunger.Current)
+
+	require.NoError(t, debugStarveHunger(world))
+	assert.Zero(t, world.Components.Hunger.Get(player).Current, "満腹度は0になる")
+
+	// プレイヤー不在ではエラー
+	empty := testutil.InitTestWorld(t)
+	assert.Error(t, debugStarveHunger(empty))
+}
+
+// TestDebugExhaustFatigue は疲労を上限まで上げること、プレイヤー不在ではエラーを返すことを検証する。
+func TestDebugExhaustFatigue(t *testing.T) {
+	t.Parallel()
+
+	world := testutil.InitTestWorld(t)
+	player, err := lifecycle.SpawnPlayer(world, consts.Coord[consts.Tile]{X: 5, Y: 5}, "ash")
+	require.NoError(t, err)
+
+	require.NoError(t, debugExhaustFatigue(world))
+	fatigue := world.Components.Fatigue.Get(player)
+	assert.Equal(t, fatigue.Max, fatigue.Current, "疲労は上限まで上がる")
+
+	empty := testutil.InitTestWorld(t)
+	assert.Error(t, debugExhaustFatigue(empty))
+}
+
+// TestDebugInflictConditions は主要部位へ状態異常を付与すること、プレイヤー不在ではエラーを返すことを検証する。
+func TestDebugInflictConditions(t *testing.T) {
+	t.Parallel()
+
+	world := testutil.InitTestWorld(t)
+	player, err := lifecycle.SpawnPlayer(world, consts.Coord[consts.Tile]{X: 5, Y: 5}, "ash")
+	require.NoError(t, err)
+
+	require.NoError(t, debugInflictConditions(world))
+
+	hs := world.Components.HealthStatus.Get(player)
+	assert.True(t, hasCondition(hs, gc.BodyPartArms, gc.ConditionFracture), "腕に骨折を付与する")
+	assert.True(t, hasCondition(hs, gc.BodyPartTorso, gc.ConditionLiverIllness), "胴に肝疾患を付与する")
+
+	empty := testutil.InitTestWorld(t)
+	assert.Error(t, debugInflictConditions(empty))
+}
+
+// TestDebugTreatAllConditions は付与済みの全状態異常へ良質な治療を適用することを検証する。
+func TestDebugTreatAllConditions(t *testing.T) {
+	t.Parallel()
+
+	world := testutil.InitTestWorld(t)
+	player, err := lifecycle.SpawnPlayer(world, consts.Coord[consts.Tile]{X: 5, Y: 5}, "ash")
+	require.NoError(t, err)
+
+	// 先に状態異常を付与してから治療する
+	require.NoError(t, debugInflictConditions(world))
+	require.NoError(t, debugTreatAllConditions(world))
+
+	hs := world.Components.HealthStatus.Get(player)
+	treated := 0
+	for p := range hs.Parts {
+		for _, c := range hs.Parts[p].Conditions {
+			assert.EqualValues(t, 150, c.TendQuality, "全条件に良質な治療が入る")
+			treated++
+		}
+	}
+	assert.Positive(t, treated, "治療対象の条件が存在する")
+
+	empty := testutil.InitTestWorld(t)
+	assert.Error(t, debugTreatAllConditions(empty))
+}
+
+// TestPlayerGridElement はプレイヤーの座標を返すこと、プレイヤー不在ではエラーを返すことを検証する。
+func TestPlayerGridElement(t *testing.T) {
+	t.Parallel()
+
+	world := testutil.InitTestWorld(t)
+	_, err := lifecycle.SpawnPlayer(world, consts.Coord[consts.Tile]{X: 5, Y: 7}, "ash")
+	require.NoError(t, err)
+
+	grid, err := playerGridElement(world)
+	require.NoError(t, err)
+	require.NotNil(t, grid)
+	assert.Equal(t, consts.Tile(5), grid.X)
+	assert.Equal(t, consts.Tile(7), grid.Y)
+
+	empty := testutil.InitTestWorld(t)
+	_, err = playerGridElement(empty)
+	assert.Error(t, err)
+}
+
+// hasCondition は指定部位に指定種別の状態異常があるかを返す。
+func hasCondition(hs *gc.HealthStatus, part gc.BodyPart, ct gc.ConditionType) bool {
+	for _, c := range hs.Parts[part].Conditions {
+		if c.Type == ct {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## 概要

`internal/states`(61.9%) の `debug_menu.go` は世界を変異させる実処理が全て未カバーだった。これらは `func(world) error` の形で state のUIから切り離されているため、メニューを起動せず world だけで直接検証できる。

## 変更

`internal/states/debug_actions_test.go` を追加。各関数の正常系とプレイヤー不在のエラー系を検証する。

- `debugStarveHunger`: 満腹度を0にする
- `debugExhaustFatigue`: 疲労を上限まで上げる
- `debugInflictConditions`: 腕へ骨折、胴へ肝疾患などを付与する
- `debugTreatAllConditions`: 付与済み全条件へ良質な治療(TendQuality=150)を適用する
- `playerGridElement`: プレイヤー座標を返す

`testutil.InitTestWorld` + `lifecycle.SpawnPlayer`。`t.Parallel()`、window 非依存。

## カバレッジ

各関数が 0% → 83〜92%。残る未カバーは「プレイヤーが該当コンポーネントを持たない」防御的中間分岐で、`SpawnPlayer` は常に付与するため到達しない。

`make check` 緑。

🤖 Generated with [Claude Code](https://claude.com/claude-code)