### PR TITLE
test(states): デバッグメニューの生成アクションを検証する

### DIFF
--- a/internal/states/debug_spawn_test.go
+++ b/internal/states/debug_spawn_test.go
@@ -1,0 +1,80 @@
+package states
+
+import (
+	"testing"
+
+	gc "github.com/kijimaD/ruins/internal/components"
+	"github.com/kijimaD/ruins/internal/consts"
+	"github.com/kijimaD/ruins/internal/testutil"
+	w "github.com/kijimaD/ruins/internal/world"
+	"github.com/kijimaD/ruins/internal/world/lifecycle"
+	"github.com/mlange-42/ark/ecs"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// countGridEntitiesAt は指定座標にあるエンティティ数を数える。
+func countGridEntitiesAt(t *testing.T, world w.World, coord consts.Coord[consts.Tile]) int {
+	t.Helper()
+	n := 0
+	q := ecs.NewFilter1[gc.GridElement](world.ECS).Query()
+	for q.Next() {
+		if world.Components.GridElement.Get(q.Entity()).Coord == coord {
+			n++
+		}
+	}
+	return n
+}
+
+// TestSpawnPropNearPlayer はプレイヤーの近傍に prop を生成すること、プレイヤー不在では
+// エラーを返すことを検証する。
+func TestSpawnPropNearPlayer(t *testing.T) {
+	t.Parallel()
+
+	world := testutil.InitTestWorld(t)
+	_, err := lifecycle.SpawnPlayer(world, consts.Coord[consts.Tile]{X: 5, Y: 5}, "ash")
+	require.NoError(t, err)
+
+	target := consts.Coord[consts.Tile]{X: 7, Y: 5} // playerX+2
+	before := countGridEntitiesAt(t, world, target)
+	require.NoError(t, spawnPropNearPlayer(world, "barrel"))
+	assert.Equal(t, before+1, countGridEntitiesAt(t, world, target), "近傍に prop を1体生成する")
+
+	empty := testutil.InitTestWorld(t)
+	assert.Error(t, spawnPropNearPlayer(empty, "barrel"))
+}
+
+// TestSpawnEnemyNearPlayer はプレイヤーの近傍に敵を生成すること、プレイヤー不在では
+// エラーを返すことを検証する。
+func TestSpawnEnemyNearPlayer(t *testing.T) {
+	t.Parallel()
+
+	world := testutil.InitTestWorld(t)
+	_, err := lifecycle.SpawnPlayer(world, consts.Coord[consts.Tile]{X: 5, Y: 5}, "ash")
+	require.NoError(t, err)
+
+	target := consts.Coord[consts.Tile]{X: 13, Y: 5} // playerX+8
+	require.NoError(t, spawnEnemyNearPlayer(world, "moss_turtle"))
+	assert.Equal(t, 1, countGridEntitiesAt(t, world, target), "近傍に敵を1体生成する")
+
+	empty := testutil.InitTestWorld(t)
+	assert.Error(t, spawnEnemyNearPlayer(empty, "moss_turtle"))
+}
+
+// TestSpawnStorageWithItems は収納 prop とその在庫を生成すること、プレイヤー不在では
+// エラーを返すことを検証する。
+func TestSpawnStorageWithItems(t *testing.T) {
+	t.Parallel()
+
+	world := testutil.InitTestWorld(t)
+	_, err := lifecycle.SpawnPlayer(world, consts.Coord[consts.Tile]{X: 5, Y: 5}, "ash")
+	require.NoError(t, err)
+
+	target := consts.Coord[consts.Tile]{X: 7, Y: 5} // playerX+2
+	before := countGridEntitiesAt(t, world, target)
+	require.NoError(t, spawnStorageWithItems(world))
+	assert.Equal(t, before+1, countGridEntitiesAt(t, world, target), "収納 prop を1体生成する")
+
+	empty := testutil.InitTestWorld(t)
+	assert.Error(t, spawnStorageWithItems(empty))
+}

--- a/internal/states/debug_spawn_test.go
+++ b/internal/states/debug_spawn_test.go
@@ -18,6 +18,7 @@ func countGridEntitiesAt(t *testing.T, world w.World, coord consts.Coord[consts.
 	t.Helper()
 	n := 0
 	q := ecs.NewFilter1[gc.GridElement](world.ECS).Query()
+	defer q.Close() // 早期リターンを入れても world をアンロックする安全ネット
 	for q.Next() {
 		if world.Components.GridElement.Get(q.Entity()).Coord == coord {
 			n++
@@ -26,55 +27,65 @@ func countGridEntitiesAt(t *testing.T, world w.World, coord consts.Coord[consts.
 	return n
 }
 
-// TestSpawnPropNearPlayer はプレイヤーの近傍に prop を生成すること、プレイヤー不在では
-// エラーを返すことを検証する。
 func TestSpawnPropNearPlayer(t *testing.T) {
 	t.Parallel()
 
-	world := testutil.InitTestWorld(t)
-	_, err := lifecycle.SpawnPlayer(world, consts.Coord[consts.Tile]{X: 5, Y: 5}, "ash")
-	require.NoError(t, err)
+	t.Run("近傍にpropを生成する", func(t *testing.T) {
+		t.Parallel()
+		world := testutil.InitTestWorld(t)
+		_, err := lifecycle.SpawnPlayer(world, consts.Coord[consts.Tile]{X: 5, Y: 5}, "ash")
+		require.NoError(t, err)
 
-	target := consts.Coord[consts.Tile]{X: 7, Y: 5} // playerX+2
-	before := countGridEntitiesAt(t, world, target)
-	require.NoError(t, spawnPropNearPlayer(world, "barrel"))
-	assert.Equal(t, before+1, countGridEntitiesAt(t, world, target), "近傍に prop を1体生成する")
+		target := consts.Coord[consts.Tile]{X: 7, Y: 5} // playerX+2
+		before := countGridEntitiesAt(t, world, target)
+		require.NoError(t, spawnPropNearPlayer(world, "barrel"))
+		assert.Equal(t, before+1, countGridEntitiesAt(t, world, target), "近傍に prop を1体生成する")
+	})
 
-	empty := testutil.InitTestWorld(t)
-	assert.Error(t, spawnPropNearPlayer(empty, "barrel"))
+	t.Run("プレイヤー不在はエラーを返す", func(t *testing.T) {
+		t.Parallel()
+		assert.Error(t, spawnPropNearPlayer(testutil.InitTestWorld(t), "barrel"))
+	})
 }
 
-// TestSpawnEnemyNearPlayer はプレイヤーの近傍に敵を生成すること、プレイヤー不在では
-// エラーを返すことを検証する。
 func TestSpawnEnemyNearPlayer(t *testing.T) {
 	t.Parallel()
 
-	world := testutil.InitTestWorld(t)
-	_, err := lifecycle.SpawnPlayer(world, consts.Coord[consts.Tile]{X: 5, Y: 5}, "ash")
-	require.NoError(t, err)
+	t.Run("近傍に敵を生成する", func(t *testing.T) {
+		t.Parallel()
+		world := testutil.InitTestWorld(t)
+		_, err := lifecycle.SpawnPlayer(world, consts.Coord[consts.Tile]{X: 5, Y: 5}, "ash")
+		require.NoError(t, err)
 
-	target := consts.Coord[consts.Tile]{X: 13, Y: 5} // playerX+8
-	require.NoError(t, spawnEnemyNearPlayer(world, "moss_turtle"))
-	assert.Equal(t, 1, countGridEntitiesAt(t, world, target), "近傍に敵を1体生成する")
+		target := consts.Coord[consts.Tile]{X: 13, Y: 5} // playerX+8
+		before := countGridEntitiesAt(t, world, target)
+		require.NoError(t, spawnEnemyNearPlayer(world, "moss_turtle"))
+		assert.Equal(t, before+1, countGridEntitiesAt(t, world, target), "近傍に敵を1体生成する")
+	})
 
-	empty := testutil.InitTestWorld(t)
-	assert.Error(t, spawnEnemyNearPlayer(empty, "moss_turtle"))
+	t.Run("プレイヤー不在はエラーを返す", func(t *testing.T) {
+		t.Parallel()
+		assert.Error(t, spawnEnemyNearPlayer(testutil.InitTestWorld(t), "moss_turtle"))
+	})
 }
 
-// TestSpawnStorageWithItems は収納 prop とその在庫を生成すること、プレイヤー不在では
-// エラーを返すことを検証する。
 func TestSpawnStorageWithItems(t *testing.T) {
 	t.Parallel()
 
-	world := testutil.InitTestWorld(t)
-	_, err := lifecycle.SpawnPlayer(world, consts.Coord[consts.Tile]{X: 5, Y: 5}, "ash")
-	require.NoError(t, err)
+	t.Run("収納propを生成する", func(t *testing.T) {
+		t.Parallel()
+		world := testutil.InitTestWorld(t)
+		_, err := lifecycle.SpawnPlayer(world, consts.Coord[consts.Tile]{X: 5, Y: 5}, "ash")
+		require.NoError(t, err)
 
-	target := consts.Coord[consts.Tile]{X: 7, Y: 5} // playerX+2
-	before := countGridEntitiesAt(t, world, target)
-	require.NoError(t, spawnStorageWithItems(world))
-	assert.Equal(t, before+1, countGridEntitiesAt(t, world, target), "収納 prop を1体生成する")
+		target := consts.Coord[consts.Tile]{X: 7, Y: 5} // playerX+2
+		before := countGridEntitiesAt(t, world, target)
+		require.NoError(t, spawnStorageWithItems(world))
+		assert.Equal(t, before+1, countGridEntitiesAt(t, world, target), "収納 prop を1体生成する")
+	})
 
-	empty := testutil.InitTestWorld(t)
-	assert.Error(t, spawnStorageWithItems(empty))
+	t.Run("プレイヤー不在はエラーを返す", func(t *testing.T) {
+		t.Parallel()
+		assert.Error(t, spawnStorageWithItems(testutil.InitTestWorld(t)))
+	})
 }


### PR DESCRIPTION
## 概要

`internal/states` の `debug_menu.go` の生成系ヘルパーが未カバーだった。UIから分離された `func(world) error` なので、メニューを起動せず world だけで直接検証できる。

## 変更

`internal/states/debug_spawn_test.go` を追加。各関数の正常系とプレイヤー不在のエラー系を検証する。

- `spawnPropNearPlayer`: プレイヤーの近傍(X+2)へ prop を生成する
- `spawnEnemyNearPlayer`: プレイヤーの近傍(X+8)へ敵を生成する
- `spawnStorageWithItems`: 収納 prop と在庫を生成する

期待座標のエンティティ数が1増えることを `GridElement` クエリで確認する。`testutil.InitTestWorld` + `lifecycle.SpawnPlayer`。`t.Parallel()`、window 非依存。

## カバレッジ

- `spawnPropNearPlayer` `spawnEnemyNearPlayer`: 0% → 100%
- `spawnStorageWithItems`: 0% → 84.6%

残る未カバーは在庫生成の防御的エラー経路のみ。

`make check` 緑。

🤖 Generated with [Claude Code](https://claude.com/claude-code)