### PR TITLE
feat(trace): ゲームループへ runtime/trace の region を差す

### DIFF
--- a/docs/design/260911224216.md
+++ b/docs/design/260911224216.md
@@ -1,0 +1,73 @@
+---
+status: done # draft|accepted|in-progress|done|superseded|dropped
+tags: [perf, meta] # 領域ラベル
+auto: needs-decision # mechanical=無人着手可 / needs-decision=人の判断必須
+---
+
+# ターンごとにトレースできるようゲームループへ region を差す
+
+## 背景
+
+ゲームが重い。どこが重いかを実プレイの「ターンごと」で見たい。既存の計測資産は次のとおり。
+
+- `net/http/pprof` と `pkg/profile` 経由の CPU/メモリ/**トレース**。`RUINS_PROFILE_CPU/TRACE` で取れる。CPU は集約なので「どのターンが跳ねたか」は出せないが、**トレースは時間軸を持つ**。
+- Shift+Tab の `getPerformanceInfo`。FPS とメモリだけ。システム別・ターン別の内訳は無い。
+
+穴は「トレースにゲームループの意味づけが無い」こと。`RUINS_PROFILE_TRACE` が吐く実行トレースは、goroutine・GC・スケジューラは見えるが、どの区間が「AIフェーズ」か「3D描画」かが分からない。そこへ意味を与える。
+
+## 要件
+
+- ゲームループの各フレーム・各システム・ターンのフェーズを、トレースの region として名前つきで刻む。ターン境界はログイベントで刻む。
+- 既存の `RUINS_PROFILE_TRACE` にそのまま乗せる。新しいフラグもパッケージも足さない。
+- 閲覧は `go tool trace`。region はゲームループの単一 goroutine のレーンへ入れ子で並び、GC・スケジューライベントと同じ時間軸で読める。
+
+## 設計
+
+### 標準の `runtime/trace` ユーザ領域を使う
+
+Go 標準ライブラリの `runtime/trace` は Go 1.11 からユーザ定義の region・task・log を持つ。これで per-turn・per-system の区間を stdlib だけで刻める。独自のスパン記録・書き出しは要らない。region は呼び出し goroutine のスタックへ入れ子で積まれ、ゲームループは単一 goroutine なので frame→system→turnend が素直に入れ子になる。
+
+- 区間: `trace.StartRegion(ctx, name)` と `Region.End()`。task を跨がないので `ctx` は `context.Background()` でよい。
+- ターン境界: `trace.Log(ctx, "turn", 番号)`。
+- トレース無効時は region 生成がほぼゼロコスト。実行トレーサは Go 1.21 で低オーバーヘッド化されている。
+
+### 差し込み点
+
+| 場所 | region / log |
+|---|---|
+| `maingame/game.go` `Update`/`Draw` | frame 最上位 `Update`/`Draw` |
+| `states/updaters.go` `runUpdaters` | 各システムを `String()` 名で |
+| `states/dungeon.go` `DungeonState.Draw` | `draw:3D` |
+| `states/dungeon.go` `drawRenderers` | `draw:<Renderer>` |
+| `systems/turn_system.go` `runAIPhase`/`runEndPhase`/`runTurnEndSystems` | `turn:AI`・`turn:End`・`turnend:<System>` |
+| `systems/turn_system.go` `TurnNumber++` | `trace.Log("turn", N)` |
+
+### 採取と閲覧
+
+新しい配管は不要。既存の `RUINS_PROFILE=development RUINS_PROFILE_TRACE=true …play` で `pkg/profile` が `ProfilePath/trace.out` を吐く。終了後 `go tool trace profiles/trace.out` で開き、ゲームループ goroutine のレーンで region の入れ子を辿る。GC も同じ時間軸に出るので、重いフレームが確保由来か描画由来かを1画面で切り分けられる。
+
+## 変更箇所
+
+| ファイル | 変更内容 |
+|---|---|
+| `internal/maingame/game.go` | Update/Draw に frame region |
+| `internal/states/updaters.go` | `runUpdaters` に per-system region |
+| `internal/states/dungeon.go` | Draw の 3D と `drawRenderers` に描画 region |
+| `internal/systems/turn_system.go` | AI・ターン末・ターン境界の region / log |
+
+## 採用しなかった方法
+
+- **独自の Chrome Trace エミッタ**（`internal/trace` パッケージ）。当初これを書いたが、`runtime/trace` の region で同じことが stdlib で書け、コードが減り、**GC・スケジューラが同じトレースに乗る**利点を捨てていた。標準の受け皿があるのに再実装しており、破棄した。独自の利点は Perfetto UI と低摂動だが、Go 1.21 で実行トレーサは低オーバーヘッド化され、go tool trace の近代ビューアで代替できるので薄い。
+- **OpenTelemetry**。業界標準だが分散システム向けで、単一プロセスのゲームループには過剰。
+- **ライブ HUD オーバーレイ**。「どのターンが跳ねたか」を後から精査するには時系列が要る。
+- **壁時計のターン帯**。Player フェーズは入力待ちアイドルなので、フレーム上の計算バーストを region にし、ターン境界は log で刻む。
+
+## コメント
+
+## 進捗
+
+- [x] `runUpdaters`・turn フェーズ・Draw・frame に `runtime/trace` の region を差す
+- [x] ターン境界を `trace.Log` で刻む
+- [x] 独自 `internal/trace` パッケージと `RUINS_PROFILE_SPANS` フラグを撤去する
+- [x] `make check` が緑
+- [x] 実プレイで `RUINS_PROFILE_TRACE` 採取 → `go tool trace` で region 入れ子と GC を確認する

--- a/internal/maingame/game.go
+++ b/internal/maingame/game.go
@@ -1,8 +1,10 @@
 package maingame
 
 import (
+	"context"
 	"fmt"
 	"runtime"
+	"runtime/trace"
 	"time"
 
 	"github.com/hajimehoshi/ebiten/v2"
@@ -53,6 +55,9 @@ func (game *MainGame) Layout(_, _ int) (int, int) {
 
 // Update はゲームの更新処理を行う
 func (game *MainGame) Update() error {
+	region := trace.StartRegion(context.Background(), "Update")
+	defer region.End()
+
 	// デバッグ表示をトグルする
 	if ebiten.IsKeyPressed(ebiten.KeyShift) && inpututil.IsKeyJustPressed(ebiten.KeyTab) {
 		// パフォーマンスモニターは攻略に関係ないのでトグルできてよい
@@ -74,6 +79,9 @@ func (game *MainGame) Update() error {
 // Draw はゲームの描画処理を行う
 // interface method だからシグネチャは変更できない
 func (game *MainGame) Draw(screen *ebiten.Image) {
+	region := trace.StartRegion(context.Background(), "Draw")
+	defer region.End()
+
 	game.renderer.Draw(screen, game.StateMachine.GetStates(), game.World)
 
 	// パフォーマンスモニターは最前面のデバッグ表示なので、ポスト処理の外で screen へ直に描く。

--- a/internal/states/dungeon.go
+++ b/internal/states/dungeon.go
@@ -1,7 +1,9 @@
 package states
 
 import (
+	"context"
 	"fmt"
+	"runtime/trace"
 
 	"github.com/hajimehoshi/ebiten/v2"
 	gc "github.com/kijimaD/ruins/internal/components"
@@ -264,7 +266,10 @@ func (st *DungeonState) Draw(world w.World, screen *ebiten.Image) error {
 		screen.DrawImage(st.baseImage, nil)
 	}
 	// まず世界レイヤを screen へローポリ3Dで描く。フォグと壁遮蔽は vision の per-tile 暗さで表現する
-	if err := st.three.draw(world, screen); err != nil {
+	r := trace.StartRegion(context.Background(), "draw:3D")
+	err := st.three.draw(world, screen)
+	r.End()
+	if err != nil {
 		return err
 	}
 	// 時間帯の色は vision の環境光として per-tile に効く。全画面フィルタは松明で照らした
@@ -276,12 +281,16 @@ func (st *DungeonState) Draw(world w.World, screen *ebiten.Image) error {
 // drawRenderers は登録済みのレンダラを順に target へ描く。未登録のものは飛ばす。
 func drawRenderers(world w.World, target *ebiten.Image, renderers ...w.Renderer) error {
 	for _, renderer := range renderers {
-		sys, ok := world.Renderers[renderer.String()]
+		name := renderer.String()
+		sys, ok := world.Renderers[name]
 		if !ok {
 			// 未登録は描画されず無音で消える。登録漏れをエラーで表面化させる
-			return fmt.Errorf("renderer not registered: %s", renderer.String())
+			return fmt.Errorf("renderer not registered: %s", name)
 		}
-		if err := sys.Draw(world, target); err != nil {
+		r := trace.StartRegion(context.Background(), "draw:"+name)
+		err := sys.Draw(world, target)
+		r.End()
+		if err != nil {
 			return err
 		}
 	}

--- a/internal/states/updaters.go
+++ b/internal/states/updaters.go
@@ -1,17 +1,27 @@
 package states
 
-import w "github.com/kijimaD/ruins/internal/world"
+import (
+	"context"
+	"runtime/trace"
+
+	w "github.com/kijimaD/ruins/internal/world"
+)
 
 // runUpdaters は指定した updater を world.Updaters から名前で引いて順に回す。
 // メニュー state が HUD 用の再計算 system を毎フレーム回すのに使う。渡すインスタンスは
 // 名前の取得にだけ使い、状態を持つ登録済みインスタンスの実体を実行する。
 func runUpdaters(world w.World, updaters ...w.Updater) error {
 	for _, updater := range updaters {
-		sys, ok := world.Updaters[updater.String()]
+		name := updater.String()
+		sys, ok := world.Updaters[name]
 		if !ok {
 			continue
 		}
-		if err := sys.Update(world); err != nil {
+		// ループ内は明示的に End を呼ぶ。defer だと関数終了まで region が閉じて重なる
+		r := trace.StartRegion(context.Background(), name)
+		err := sys.Update(world)
+		r.End()
+		if err != nil {
 			return err
 		}
 	}

--- a/internal/systems/turn_system.go
+++ b/internal/systems/turn_system.go
@@ -1,6 +1,10 @@
 package systems
 
 import (
+	"context"
+	"runtime/trace"
+	"strconv"
+
 	"github.com/kijimaD/ruins/internal/activity"
 	"github.com/kijimaD/ruins/internal/aiinput"
 	gc "github.com/kijimaD/ruins/internal/components"
@@ -81,6 +85,7 @@ func (sys *TurnSystem) Update(world w.World) error {
 // 複数ターン進める。1ターンは通常フローと同じ 継続ステップ→AI→ターン終了 を回すので、
 // ゲーム上の結果は1フレーム1ターンで進めた場合と変わらず、縮むのは実時間だけ。
 func (sys *TurnSystem) fastForwardActivity(world w.World, turnState *gc.TurnState) error {
+	// fast-forward は1フレームで複数ターン回すので、turn:AI / turn:End が1つの TurnSystem region に連なる
 	for range fastForwardTurnsPerFrame {
 		if !playerHasActivity(world) {
 			break // 完了・中断したら通常進行へ戻す
@@ -101,6 +106,9 @@ func (sys *TurnSystem) fastForwardActivity(world w.World, turnState *gc.TurnStat
 
 // runAIPhase は全AI・NPCを一括処理し、視界の再計算を要求する。
 func runAIPhase(world w.World) error {
+	region := trace.StartRegion(context.Background(), "turn:AI")
+	defer region.End()
+
 	// AIターン: 全AI・NPCを一括処理
 	if err := processAITurn(world); err != nil {
 		return err
@@ -112,12 +120,17 @@ func runAIPhase(world w.World) error {
 
 // runEndPhase はturn end processingをして1ゲームターンを確定させる。
 func runEndPhase(world w.World, turnState *gc.TurnState) error {
+	region := trace.StartRegion(context.Background(), "turn:End")
+	defer region.End()
+
 	if err := processTurnEnd(world); err != nil {
 		return err
 	}
 	// 空間インデックスを無効化する。次ターンで再構築される
 	query.InvalidateSpatialIndex(world)
 	turnState.TurnNumber++
+	// ターン確定はこの1点なので、ここでトレースへ番号を刻む
+	trace.Log(context.Background(), "turn", strconv.Itoa(int(turnState.TurnNumber)))
 	// ゲーム内時間を1ターン進める。昼夜・気温の時間修正がこれに依存する。
 	// GameTime は Dungeon 内で永続なのでセーブ/ロードでも一貫する
 	query.GetGameTime(world).Advance()
@@ -235,8 +248,12 @@ func runTurnEndSystems(world w.World) error {
 		&FireSystem{},
 		&DeadCleanupSystem{},
 	} {
-		if sys, ok := world.Updaters[updater.String()]; ok {
-			if err := sys.Update(world); err != nil {
+		name := updater.String()
+		if sys, ok := world.Updaters[name]; ok {
+			r := trace.StartRegion(context.Background(), "turnend:"+name)
+			err := sys.Update(world)
+			r.End()
+			if err != nil {
 				return err
 			}
 		}


### PR DESCRIPTION
## 概要

ゲームの重さを実プレイの「ターンごと」で見たい。Go 標準の `runtime/trace` のユーザ領域で、ゲームループの各フレーム・各システム・ターンのフェーズを region として刻み、ターン境界を `trace.Log` で刻む。

既存の `RUINS_PROFILE_TRACE` が吐く実行トレースに意味づけを与えるだけ。新しいフラグもパッケージも足さない。閲覧は `go tool trace` で、region はゲームループ goroutine のレーンへ入れ子で並び、GC・スケジューラと同じ時間軸で読める。

当初は独自の Chrome Trace エミッタ（`internal/trace` パッケージ + `RUINS_PROFILE_SPANS`）で実装したが、標準の `runtime/trace`（Go 1.11 で追加、[pkg.go.dev/runtime/trace](https://pkg.go.dev/runtime/trace)）で同じことが書け、コードが減り、GC が同じトレースに乗る利点があるので作り直した。

## 処理フロー

```mermaid
sequenceDiagram
    participant Ebiten
    participant MainGame
    participant runUpdaters
    participant TurnSystem
    participant Trace as runtime.trace
    Ebiten->>MainGame: Update
    MainGame->>Trace: StartRegion Update
    MainGame->>runUpdaters: 各システムを回す
    loop system ごと
        runUpdaters->>Trace: StartRegion システム名
        runUpdaters->>TurnSystem: Update
        Note over TurnSystem: End フェーズで
        TurnSystem->>Trace: StartRegion turn-End と turnend
        TurnSystem->>Trace: Log でターン番号を刻む
        runUpdaters->>Trace: Region.End
    end
    Ebiten->>MainGame: Draw
    MainGame->>Trace: StartRegion Draw と draw-3D と draw-Renderer
    Note over Trace: RUINS_PROFILE_TRACE が trace.out へ書き出す
```

図は概略。`turn:End` は `runEndPhase` の入口、`turnend:<System>` は各ターン末システムごとに刻む。粒度の詳細は設計 doc を参照。

## 変更点

| ファイル | 変更内容 |
|---|---|
| `internal/maingame/game.go` | Update/Draw に frame region |
| `internal/states/updaters.go` | `runUpdaters` に per-system region |
| `internal/states/dungeon.go` | Draw の 3D と `drawRenderers` に描画 region |
| `internal/systems/turn_system.go` | AI・ターン末・ターン境界の region / log |

処理フロー以外の図は、構造が region を差すだけで自明なので省く。

## なぜこの形か

- **標準の受け皿に乗る**。`runtime/trace` の region/task は per-turn・per-system スパンの stdlib 手段。ruins は既に `RUINS_PROFILE_TRACE` で実行トレースを吐いており、そこへ意味づけを足すだけ。新パッケージ・新フラグ・書き出しコードが不要。
- **GC・スケジューラが同じ時間軸に乗る**。重いフレームが確保由来か描画由来かを1画面で切り分けられる。独自エミッタはこれを捨てていた。
- **入れ子は goroutine のスタックで決まる**。ゲームループは単一 goroutine なので frame→system→turnend が素直に入れ子になる。task を跨がないので ctx は `context.Background()`。
- **無効時ほぼゼロコスト**。実行トレーサは Go 1.21 で低オーバーヘッド化されている。

## 採用しなかった代替

- **独自 Chrome Trace エミッタ**（初版）。標準の再実装で、GC 同時可視化を失う。Perfetto UI と低摂動という利点は Go 1.21 の低オーバーヘッド化と go tool trace 近代ビューアで薄い。撤去した。
- **OpenTelemetry**。分散システム向けで単一プロセスのゲームループには過剰。

## 検証

- `make check` 緑。
- 実プレイで `RUINS_PROFILE=development RUINS_PROFILE_TRACE=true …play` → `profiles/trace.out` → `go tool trace` で region 入れ子と GC を確認。

## リスク・影響範囲

未リリースなので後方互換の考慮は不要。計測は既存の dev フラグ配下。無効時ほぼゼロコストで通常プレイへの影響なし。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
