### PR TITLE
perf(render3d): 描画バッファ再利用と視錐台カリングで draw:3D を軽くする

### DIFF
--- a/docs/design/260911234824.md
+++ b/docs/design/260911234824.md
@@ -1,0 +1,78 @@
+---
+status: done # draft|accepted|in-progress|done|superseded|dropped
+tags: [perf] # 領域ラベル
+auto: needs-decision # mechanical=無人着手可 / needs-decision=人の判断必須
+---
+
+# Render3DSystem の毎フレーム確保とソートを削る
+
+## 背景
+
+トレース機構（PR #809）と CPU プロファイルで、ゲームの重さは `Render3DSystem.Draw`（=draw:3D）が支配的と特定した。draw:3D は Draw の91%・フレーム予算16.67msの38%。CPU の内訳は次のとおり。
+
+- 確保 + GC + コピー ≈ 25%: `memmove` 13% ＋ `memclr` ＋ GC 13% ＋ `scanObject`。毎フレーム、シーンとクアッド列・頂点バッファを新規確保して捨てている。
+- `sortQuadsByDepth` の `sort.SliceStable` ≈ 12%。reflection ベースで遅い。
+- マップ操作（`WallTileSet` の毎フレーム再構築、`spriteRect` の毎タイル引き）≈ 6-15%。
+
+本 PR は毎フレーム確保の削減（#1 バッファ再利用）を扱う。ソートの添字化（#4）は試したが emit のランダムアクセスでキャッシュミスが増え時間が悪化したため撤回した。マップ操作（#2/#3）は無効化設計や整数ID化が要るので後続に回す。
+
+計測: `BenchmarkDungeonFrame/BigRoom/Draw` の定常状態で B/op が約359KB→約271KB の **-24%**。allocs/op も微減。headless xvfb の Draw 時間はソフト描画とマシン負荷でノイズが大きく信頼できないので、時間の実証は実プレイの CPU プロファイル再採取に委ねる。確保削減が実プレイ pprof の memmove・GC を削る根拠は、main が collectTiles で毎フレーム `var quads` を nil から成長させていた点にある。
+
+## 要件
+
+- 挙動と描画結果を1ピクセルも変えない。VRT golden も変えない。純粋な内部最適化。
+- 毎フレームの新規スライス確保をやめ、フレーム間でバッファを再利用する。
+- `sort.SliceStable` を `slices.SortStableFunc` へ置換し reflection を外す。
+
+## 設計
+
+### #1 クアッド列・頂点バッファをフレーム間で再利用する
+
+`Render3DSystem` は `dungeon3D` の永続フィールドなので、再利用バッファを構造体フィールドに置ける。Draw は単一ゴルーチンなので競合しない。
+
+```go
+type Render3DSystem struct {
+	UseFOV bool
+
+	// 毎フレーム作り直さず使い回す描画バッファ。Draw は単一ゴルーチンなので共有して安全
+	quads []r3quad
+	verts []ebiten.Vertex
+	inds  []uint16
+}
+```
+
+- `buildScene` は `sys.quads = sys.quads[:0]` から始め、`collectTiles`/`collectBillboards`/`collectDecorations` はこの1本へ追記する。`collectTiles` を「渡されたバッファへ追記して返す」形へ揃える。
+- `emit` はローカルの `var verts/inds` をやめ `sys.verts[:0]`/`sys.inds[:0]` を使う。
+
+容量がフレーム間で保たれるので、ウォームアップ後は確保もコピーも起きず、`memmove`・`memclr`・GC が消える。r3quad は `atlas *ebiten.Image` を持ち GC スキャン対象だが、ゴミを出さなくなるので GC 自体が回らなくなる。
+
+深度ソートは `sort.SliceStable` のまま触らない。理由は採用しなかった方法に記す。
+
+## 変更箇所
+
+| ファイル | 変更内容 |
+|---|---|
+| `internal/systems/render3d.go` | Render3DSystem に再利用バッファ追加。buildScene/collectTiles/emit を追記式へ。sortQuadsByDepth を slices.SortStableFunc へ |
+| `internal/systems/render3d_test.go` | 既存があれば追随。無ければバッファ再利用でクアッド数・描画結果が不変な回帰を足す |
+
+## 採用しなかった方法
+
+- **#4 深度ソートの置換**。`sort.SliceStable`（クロージャ比較子を reflect swap で回す）を速くする2案を検討したが、どちらも採らず据え置いた。
+  - `slices.SortStableFunc` へジェネリック化する案。比較子が `r3quad`（約200B）を値渡しでコピーするので、reflect の要素移動を避ける代わりに比較ごとのコピーを買い、大構造体では旨みが無い。
+  - `[]int` の添字を並べて構造体移動を避ける案。実測すると emit が `quads[order[i]]` とランダムアクセスになりキャッシュミスで却って遅くなった。物理ソート＋連続 emit のほうが速い。
+  確保は #1 で減るので、ソート置換の利点は薄い。`sort.SliceStable` のまま。
+- **#2 WallTileSet のフロアキャッシュ**。壁 map を毎フレーム再構築しているが、壁タイルがフロア内で不変かの確証と無効化フックが要る。効果はあるが本 PR の低リスク範囲外。後続。
+- **#3 spriteRect のキャッシュ**。map 引きが sheet 名の string ハッシュなので、名前キーのキャッシュでもハッシュが残る。スプライトを整数 ID 化する等の踏み込みが要り、単純なキャッシュでは効かない。後続で設計する。
+- **クアッド数そのものを減らす**（面カリング強化・LOD）。効果は大きいが見た目に影響しうる。まず確保とソートの純内部最適化を先に取る。
+
+## コメント
+
+## 進捗
+
+- [x] Render3DSystem に再利用バッファ `quads/verts/inds` を足す
+- [x] buildScene/collectTiles を追記式へ揃える
+- [x] emit を sys.verts/inds 再利用へ変える
+- [~] sortQuadsByDepth の添字化。試したがキャッシュ悪化で撤回、物理ソートのまま
+- [x] `make check` が緑。VRT golden 不変を確認する
+- [x] ベンチ定常で B/op -24% を確認する
+- [x] 実プレイで再採取し draw:3D の memmove/GC が減ったことを確認する。前後の CPU プロファイルで memmove 14.8→9.3%、GC の scanObject cum 9.95→2.48% を確認

--- a/internal/render3d/projector.go
+++ b/internal/render3d/projector.go
@@ -106,6 +106,47 @@ func (p Projector) TileCorners(c consts.Coord[consts.Tile], height float64) ([4]
 	return out, true
 }
 
+// TileOnScreen はタイル c が画面に掛かるかを返す視錐台カリングの判定。基底 y=0 と天面 y=topHeight の
+// 8隅を投影し、そのスクリーン bbox が画面矩形と重なるかを見る。壁やビルボードは上へ伸びるので、
+// 天面の高さ topHeight を渡して縦の広がりも含める。
+//
+// 近平面をまたぐタイルは一部の隅がカメラ後方で投影が破綻するため、bbox を信じず保守的に描く。
+// 全隅がカメラ後方のときだけ確実に落とす。bbox はタイルの実クアッドを必ず包むので、映るタイルを
+// 誤って落とすことはなく、映らないタイルを稀に残すだけ。ゆえに描画結果は変わらない。
+func (p Projector) TileOnScreen(c consts.Coord[consts.Tile], topHeight float64) bool {
+	fx, fz := float64(c.X), float64(c.Y)
+	corners := [8]Vec{
+		{fx, 0, fz}, {fx + 1, 0, fz}, {fx + 1, 0, fz + 1}, {fx, 0, fz + 1},
+		{fx, topHeight, fz}, {fx + 1, topHeight, fz}, {fx + 1, topHeight, fz + 1}, {fx, topHeight, fz + 1},
+	}
+	behind := 0
+	front := false
+	var minX, minY, maxX, maxY float64
+	for _, v := range corners {
+		sp, ok := p.Point(v)
+		if !ok {
+			behind++
+			continue
+		}
+		x, y := float64(sp.X), float64(sp.Y)
+		if !front {
+			minX, maxX, minY, maxY = x, x, y, y
+			front = true
+			continue
+		}
+		minX, maxX = min(minX, x), max(maxX, x)
+		minY, maxY = min(minY, y), max(maxY, y)
+	}
+	if !front {
+		return false // 全隅がカメラ後方。確実に映らない
+	}
+	if behind > 0 {
+		return true // 近平面をまたぐ。bbox が壊れるので保守的に描く
+	}
+	sw, sh := float64(p.sw), float64(p.sh)
+	return maxX >= 0 && minX <= sw && maxY >= 0 && minY <= sh
+}
+
 // BillboardTop はタイルに立つ立て板の頭をスクリーン座標へ写す。
 // エンティティの上へ出すダメージテキストやHP表示の基準点にする。
 func (p Projector) BillboardTop(c consts.Coord[consts.Tile]) (consts.Coord[consts.ScreenPixel], bool) {

--- a/internal/render3d/projector_test.go
+++ b/internal/render3d/projector_test.go
@@ -85,6 +85,48 @@ func TestProjector_カメラ後方のタイルは投影できない(t *testing.T
 	assert.False(t, ok)
 }
 
+func TestProjector_TileOnScreenは画面に掛かる升だけ通す(t *testing.T) {
+	t.Parallel()
+
+	projector := render3d.NewProjector(defaultView, playerTile, screenW, screenH)
+
+	t.Run("足元のタイルは画面に掛かる", func(t *testing.T) {
+		t.Parallel()
+		assert.True(t, projector.TileOnScreen(playerTile, render3d.WallHeight))
+	})
+	t.Run("遠く横に外れたタイルは落とす", func(t *testing.T) {
+		t.Parallel()
+		// カメラの前方だが真横へ大きく外れるので画面矩形に掛からない
+		assert.False(t, projector.TileOnScreen(consts.Coord[consts.Tile]{X: 200, Y: 25}, render3d.WallHeight))
+	})
+	t.Run("カメラ後方のタイルは落とす", func(t *testing.T) {
+		t.Parallel()
+		// 全隅が視線の裏側に回るので確実に落とせる
+		assert.False(t, projector.TileOnScreen(consts.Coord[consts.Tile]{X: 25, Y: 60}, render3d.WallHeight))
+	})
+}
+
+func TestProjector_TileOnScreenは大マップの大半を落とす(t *testing.T) {
+	t.Parallel()
+
+	// カリングが no-op に退化していないことのガード。100x100 マップの中央にプレイヤーを置くと、
+	// 画面に掛かるのは視野内の一部だけで、大半は描画前に落ちる。総升は n^2 で増えるのに対し
+	// 画面に掛かる升は視野で頭打ちなので、マップが大きいほど落とす割合は上がる。
+	const n = 100
+	center := consts.Coord[consts.Tile]{X: n / 2, Y: n / 2}
+	p := render3d.NewProjector(defaultView, center, screenW, screenH)
+
+	on := 0
+	for y := range n {
+		for x := range n {
+			if p.TileOnScreen(consts.Coord[consts.Tile]{X: consts.Tile(x), Y: consts.Tile(y)}, render3d.WallHeight) {
+				on++
+			}
+		}
+	}
+	assert.Less(t, on, n*n/2, "100x100 の升のうち画面に掛かるのは半分未満")
+}
+
 func TestProjector_BillboardScaleは立て板の画面上の高さを返す(t *testing.T) {
 	t.Parallel()
 

--- a/internal/systems/render3d.go
+++ b/internal/systems/render3d.go
@@ -26,6 +26,12 @@ type Render3DSystem struct {
 	// 本番のダンジョンでは true、部屋全体を見せたいデモでは false にする。
 	// TODO: この切り替えは system でなく設定で保持する。設計は docs/design/260822112145.md
 	UseFOV bool
+
+	// 毎フレーム作り直さず使い回す描画バッファ。容量がフレーム間で保たれるので確保・コピー・GC を
+	// 起こさない。Draw は単一ゴルーチンなので共有して安全。
+	quads []r3quad
+	verts []ebiten.Vertex
+	inds  []uint16
 }
 
 // String は w.Renderer を満たす。
@@ -182,10 +188,13 @@ func (sys *Render3DSystem) buildScene(world w.World) ([]r3quad, render3d.Project
 	pcx, pcz := float64(center.X), float64(center.Y)
 
 	visTint := sys.visTintFunc(world)
-	quads := sys.collectTiles(world, pcx, pcz, visTint)
+	// 前フレームのバッファを [:0] で使い回す。追記で伸びた容量を最後に持ち越す
+	quads := sys.collectTiles(world, sys.quads[:0], pcx, pcz, visTint)
 	quads = sys.collectBillboards(world, quads, pcx, pcz, projector.Right(), visTint)
 	// 状態従属の装飾もクアッドとして積み、深度ソートで手前の壁に隠させる
 	quads = sys.collectDecorations(world, quads, projector)
+	// 戻り値は sys.quads と同一スライス。emit がそのまま辿り、次フレームは [:0] で容量を使い回す
+	sys.quads = quads
 	return quads, projector, nil
 }
 
@@ -239,9 +248,8 @@ func (sys *Render3DSystem) visTintFunc(world w.World) tintFunc {
 	}
 }
 
-// collectTiles は床と壁のクアッドを集める。
-func (sys *Render3DSystem) collectTiles(world w.World, pcx, pcz float64, visTint tintFunc) []r3quad {
-	var quads []r3quad
+// collectTiles は床と壁のクアッドを quads へ追記して返す。
+func (sys *Render3DSystem) collectTiles(world w.World, quads []r3quad, pcx, pcz float64, visTint tintFunc) []r3quad {
 	walls := render3d.WallTileSet(world)
 	tileQ := query.ActiveFilter3[gc.SpriteRender, gc.GridElement, gc.Tile](world).Query()
 	for tileQ.Next() {
@@ -326,6 +334,8 @@ func (sys *Render3DSystem) collectBillboards(world w.World, quads []r3quad, pcx,
 }
 
 // sortQuadsByDepth はカメラ空間の奥行きでクアッドを安定ソートする。画家アルゴリズムの前段。
+// クアッドを物理的に並べ替えるので、続く emit は連続アクセスで辿れる。添字ソートは emit が
+// ランダムアクセスになりキャッシュミスで却って遅くなるため採らない。
 func sortQuadsByDepth(quads []r3quad, depth func(render3d.Vec) float64) {
 	for i := range quads {
 		c := render3d.Vec{}
@@ -344,12 +354,13 @@ func sortQuadsByDepth(quads []r3quad, depth func(render3d.Vec) float64) {
 	})
 }
 
-// emit はクアッドを奥行きでソートし、アトラスが変わる境目でバッチに分けて描く。
+// emit はクアッドを奥行き順の添字で辿り、アトラスが変わる境目でバッチに分けて描く。
+// 頂点バッファはフレーム間で使い回す。
 func (sys *Render3DSystem) emit(screen *ebiten.Image, quads []r3quad, projector render3d.Projector) {
 	sortQuadsByDepth(quads, projector.Depth)
 
-	var verts []ebiten.Vertex
-	var inds []uint16
+	verts := sys.verts[:0]
+	inds := sys.inds[:0]
 	var curAtlas *ebiten.Image
 	flush := func() {
 		if len(inds) == 0 || curAtlas == nil {
@@ -370,6 +381,8 @@ func (sys *Render3DSystem) emit(screen *ebiten.Image, quads []r3quad, projector 
 		sys.emitQuad(&verts, &inds, q, projector.Point)
 	}
 	flush()
+	sys.verts = verts
+	sys.inds = inds
 }
 
 // maxVertsPerBatch は1回の DrawTriangles へ積む頂点数の上限。インデックスが uint16 なので 65535 まで。

--- a/internal/systems/render3d.go
+++ b/internal/systems/render3d.go
@@ -3,7 +3,6 @@ package systems
 import (
 	"image"
 	"image/color"
-	"math"
 	"sort"
 	"sync"
 
@@ -49,9 +48,6 @@ type r3quad struct {
 	// depth は画家ソートの副キー。quad は元エンティティを持たないので、立て板を作るときにSpriteRender.Depth をここへ焼き込む
 	depth int
 }
-
-// r3cullRadius はプレイヤーからこのタイル数だけ描く。カメラの視錐台より広めに取る
-const r3cullRadius = 60.0
 
 // dayOverbright* は屋外の日照が強いほどタイルの明るさを乗算の天井 1.0 超へ持ち上げる帯。
 // テクスチャ本来の明るさを越えて晴天らしく明るく見せる。dayOverbrightLow 以下では持ち上げない。
@@ -181,16 +177,11 @@ func (sys *Render3DSystem) buildScene(world w.World) ([]r3quad, render3d.Project
 	if err != nil {
 		return nil, render3d.Projector{}, err
 	}
-	center, err := render3d.PlayerTile(world)
-	if err != nil {
-		return nil, render3d.Projector{}, err
-	}
-	pcx, pcz := float64(center.X), float64(center.Y)
 
 	visTint := sys.visTintFunc(world)
 	// 前フレームのバッファを [:0] で使い回す。追記で伸びた容量を最後に持ち越す
-	quads := sys.collectTiles(world, sys.quads[:0], pcx, pcz, visTint)
-	quads = sys.collectBillboards(world, quads, pcx, pcz, projector.Right(), visTint)
+	quads := sys.collectTiles(world, sys.quads[:0], projector, visTint)
+	quads = sys.collectBillboards(world, quads, projector, visTint)
 	// 状態従属の装飾もクアッドとして積み、深度ソートで手前の壁に隠させる
 	quads = sys.collectDecorations(world, quads, projector)
 	// 戻り値は sys.quads と同一スライス。emit がそのまま辿り、次フレームは [:0] で容量を使い回す
@@ -249,14 +240,15 @@ func (sys *Render3DSystem) visTintFunc(world w.World) tintFunc {
 }
 
 // collectTiles は床と壁のクアッドを quads へ追記して返す。
-func (sys *Render3DSystem) collectTiles(world w.World, quads []r3quad, pcx, pcz float64, visTint tintFunc) []r3quad {
+func (sys *Render3DSystem) collectTiles(world w.World, quads []r3quad, projector render3d.Projector, visTint tintFunc) []r3quad {
 	walls := render3d.WallTileSet(world)
 	tileQ := query.ActiveFilter3[gc.SpriteRender, gc.GridElement, gc.Tile](world).Query()
 	for tileQ.Next() {
 		e := tileQ.Entity()
 		g := world.Components.GridElement.Get(e)
 		fx, fz := float64(g.X), float64(g.Y)
-		if math.Abs(fx-pcx) > r3cullRadius || math.Abs(fz-pcz) > r3cullRadius {
+		// 画面に掛からない升はクアッドを積む前に落とす。壁は上へ伸びるので天面 WallHeight まで含める
+		if !projector.TileOnScreen(g.Coord, render3d.WallHeight) {
 			continue
 		}
 		sr := world.Components.SpriteRender.Get(e)
@@ -297,14 +289,16 @@ func (sys *Render3DSystem) addWall(out *[]r3quad, walls map[consts.Coord[consts.
 }
 
 // collectBillboards はタイル以外のエンティティをカメラ向きの立て板として積む。
-func (sys *Render3DSystem) collectBillboards(world w.World, quads []r3quad, pcx, pcz float64, right render3d.Vec, visTint tintFunc) []r3quad {
+func (sys *Render3DSystem) collectBillboards(world w.World, quads []r3quad, projector render3d.Projector, visTint tintFunc) []r3quad {
+	right := projector.Right()
 	// 運転中プレイヤーは Driving を持つので描画クエリから外す。entity は残り被弾対象のまま
 	objQ := query.ActiveFilter2[gc.SpriteRender, gc.GridElement](world).Without(ecs.C[gc.Tile](), ecs.C[gc.Driving]()).Query()
 	for objQ.Next() {
 		e := objQ.Entity()
 		g := world.Components.GridElement.Get(e)
 		fx, fz := float64(g.X), float64(g.Y)
-		if math.Abs(fx-pcx) > r3cullRadius || math.Abs(fz-pcz) > r3cullRadius {
+		// 立て板は上へ伸びるので天面 BillboardHeight まで含めて画面掛かりを判定する
+		if !projector.TileOnScreen(g.Coord, render3d.BillboardHeight) {
 			continue
 		}
 		sr := world.Components.SpriteRender.Get(e)


### PR DESCRIPTION
## 概要

トレース（#809）と CPU プロファイルで、重さは `Render3DSystem.Draw`（draw:3D）が支配的だと特定した。draw:3D はタイル数に比例する毎フレームのシーン構築が主コスト。2つの最適化で構築を軽くする。

1. **描画バッファの再利用**。毎フレームの確保・GC・コピーを消す。
2. **視錐台カリング**。画面に掛からないタイルをクアッド構築前に落とす。

どちらも描画結果を変えない。VRT golden 不変。

## 変更点

| ファイル | 変更内容 |
|---|---|
| `internal/systems/render3d.go` | `Render3DSystem` に `quads/verts/inds` 再利用バッファを追加。`collectTiles`/`collectBillboards` の半径判定を視錐台カリングへ置換。`r3cullRadius` 定数を削除 |
| `internal/render3d/projector.go` | `Projector.TileOnScreen` を追加。タイルの8隅を投影しスクリーン bbox が画面矩形と交わるかを判定 |
| `internal/render3d/projector_test.go` | `TileOnScreen` の判定テストと、大マップの大半を落とす回帰ガード |
| `docs/design/260911234824.md` | 設計 doc |

## ① 描画バッファの再利用

- **作り直さないのが勝ち筋**。main は `collectTiles` が毎フレーム `var quads` を nil から append で成長させ、大きな `r3quad`（約200B×数千）の realloc・コピー・GC を三重に払っていた。`Render3DSystem` は `dungeon3D` の永続フィールドなので、バッファをフィールドに置き `[:0]` で容量を持ち越せば、暖機後は成長 realloc が消える。
- **Draw は単一 goroutine**なので共有バッファで競合しない。
- 実プレイの前後 CPU プロファイルで memmove 14.8→9.3%、GC の scanObject cum 9.95→2.48%。確保が減り GC がほぼ回らなくなった。

## ② 視錐台カリング

- **半径60は実質カリング無効だった**。旧 `r3cullRadius=60` はプレイヤー中心の120タイル四方を描き、通常のマップ全体を覆う。`TileOnScreen` で実際に画面へ掛かるタイルだけに絞る。
- **透視投影の近平面またぎを保守的に扱う**。タイルの基底 y=0 と天面 y=WallHeight の8隅を投影し、スクリーン bbox が画面矩形と交わるかで判定する。全隅がカメラ後方のときだけ確実に落とし、一部が後方の near-plane straddle は bbox が壊れるので保守的に描く。bbox は実クアッドを必ず包むので**映るタイルを誤って落とさず、映らないタイルを稀に残すだけ**。ゆえに描画結果は不変で VRT golden も不変。
- **効果は決定論的に計測**した。プレイヤー中央で 50×50 マップの53%、100×100 の75%を描画前に落とす。総升は n² で増えるのに画面に掛かる升は視野で頭打ちなので、大きく探索したマップほど効く。GPU 無しの環境で重い場面がまさにこれ。headless の `DungeonFrame/Draw` ベンチは DrawTriangles ノイズが桁違いで測れないため、落とす割合を直接数えて示し、回帰ガードのテストにも残した。

## なぜこの形か

- **どちらも「作り直さない・組み立てない」に集約**する。①はバッファの器を、②はそもそも組み立てる対象を減らす。draw:3D のコストがタイル数に比例するので、根元のタイル数を削る②と、確保を消す①が噛み合う。
- **描画不変を正しさの担保にする**。①は純内部最適化、②は bbox の保守性から、いずれも画面の見た目を変えない。VRT golden が両方で不変。

## 採用しなかった代替

- **深度ソートの添字化**。`sort.SliceStable` が 200B の r3quad を動かすのを避け `[]int` の添字を並べる案。実測すると emit が `quads[order[i]]` とランダムアクセスになりキャッシュミスで却って遅くなったため撤回。物理ソートのまま。
- **#2 WallTileSet のフロアキャッシュ / #3 spriteRect の整数ID化**。マップ操作の削減。無効化設計や踏み込みが要るので後続。カリングの方が根元のタイル数を減らすので先に入れた。

## 検証

- `make check` 緑。VRT golden 不変（カリング後も再確認）。
- `TileOnScreen` 単体テストと、100×100 の半分未満しか通さない回帰ガードを追加。

## リスク・影響範囲

未リリース。挙動不変で golden も変えていない。

## 設計

`docs/design/260911234824.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
