### PR TITLE
test(mapspawner): カバレッジ増強

### DIFF
--- a/internal/mapspawner/spawn_offset_test.go
+++ b/internal/mapspawner/spawn_offset_test.go
@@ -80,3 +80,51 @@ func TestSpawnAt_タイル生成エラーを伝播する(t *testing.T) {
 	require.ErrorContains(t, err, "存在しないタイル")
 	assert.Equal(t, gc.Level{}, level, "エラー時はゼロ値のLevelを返す")
 }
+
+// TestSpawnAt_NPC生成エラーを伝播する は spawnNPCs のエラーが SpawnAt を
+// 打ち切り、呼び出し元へそのまま返ることを固定する。
+func TestSpawnAt_NPC生成エラーを伝播する(t *testing.T) {
+	t.Parallel()
+
+	world := testutil.InitTestWorld(t)
+	plan := newTestSpawnPlan(world)
+	plan.NPCs = []mapplanner.NPCSpec{
+		{Coord: consts.Coord[consts.Tile]{X: 1, Y: 1}, Name: "存在しないNPC"},
+	}
+
+	level, err := SpawnAt(world, plan, 0, 0)
+	require.ErrorContains(t, err, "存在しないNPC")
+	assert.Equal(t, gc.Level{}, level, "エラー時はゼロ値のLevelを返す")
+}
+
+// TestSpawnAt_アイテム生成エラーを伝播する は spawnItems のエラーが SpawnAt を
+// 打ち切り、呼び出し元へそのまま返ることを固定する。
+func TestSpawnAt_アイテム生成エラーを伝播する(t *testing.T) {
+	t.Parallel()
+
+	world := testutil.InitTestWorld(t)
+	plan := newTestSpawnPlan(world)
+	plan.Items = []mapplanner.ItemSpec{
+		{Coord: consts.Coord[consts.Tile]{X: 1, Y: 1}, Name: "存在しないアイテム", Count: 1},
+	}
+
+	level, err := SpawnAt(world, plan, 0, 0)
+	require.ErrorContains(t, err, "存在しないアイテム")
+	assert.Equal(t, gc.Level{}, level, "エラー時はゼロ値のLevelを返す")
+}
+
+// TestSpawnAt_Props生成エラーを伝播する は spawnProps のエラーが SpawnAt を
+// 打ち切り、呼び出し元へそのまま返ることを固定する。
+func TestSpawnAt_Props生成エラーを伝播する(t *testing.T) {
+	t.Parallel()
+
+	world := testutil.InitTestWorld(t)
+	plan := newTestSpawnPlan(world)
+	plan.Props = []mapplanner.PropsSpec{
+		{Coord: consts.Coord[consts.Tile]{X: 1, Y: 1}, Name: "存在しないprops"},
+	}
+
+	level, err := SpawnAt(world, plan, 0, 0)
+	require.ErrorContains(t, err, "存在しないprops")
+	assert.Equal(t, gc.Level{}, level, "エラー時はゼロ値のLevelを返す")
+}

--- a/internal/mapspawner/spawn_offset_test.go
+++ b/internal/mapspawner/spawn_offset_test.go
@@ -1,6 +1,7 @@
 package mapspawner
 
 import (
+	"math"
 	"testing"
 
 	gc "github.com/kijimaD/ruins/internal/components"
@@ -52,7 +53,8 @@ func TestSpawn_オフセットなしは原点配置(t *testing.T) {
 	require.NoError(t, err)
 
 	query := ecs.NewFilter1[gc.GridElement](world.ECS).Query()
-	minX, minY := consts.Tile(1<<30), consts.Tile(1<<30)
+	// 最小座標を求めるためのセンチネル。どの実タイル座標より大きい値を初期値に置く
+	minX, minY := consts.Tile(math.MaxInt32), consts.Tile(math.MaxInt32)
 	for query.Next() {
 		g := world.Components.GridElement.Get(query.Entity())
 		minX = min(minX, g.X)

--- a/internal/mapspawner/spawner_test.go
+++ b/internal/mapspawner/spawner_test.go
@@ -171,6 +171,119 @@ func TestPopulateStorageLoot_未知のルートテーブルはエラー(t *testi
 	assert.ErrorContains(t, err, "存在しないテーブル")
 }
 
+// newTestLootRaws は populateStorageLoot の危険度・アイテム解決の分岐を狙うための
+// 最小のItemTable/ItemGroupを持つRawMasterを生成する。エントリは実在しない
+// "nonexistent_item" を参照するため、実際のスポーンではworld側のRawMasterで解決に失敗する。
+func newTestLootRaws() oapi.Raws {
+	return oapi.Raws{
+		ItemTables: &[]oapi.ItemTable{
+			{
+				Id: "test_item_table",
+				Entries: []oapi.ItemTableEntry{
+					{Id: "test_item_group", Weight: 1, MinDanger: 1, MaxDanger: 5},
+				},
+			},
+		},
+		ItemGroups: &[]oapi.ItemGroup{
+			{
+				Id: "test_item_group",
+				Entries: []oapi.ItemGroupEntry{
+					{Id: "nonexistent_item", Weight: 1, Pack: "1d1"},
+				},
+			},
+		},
+	}
+}
+
+func TestPopulateStorageLoot_LootCount表記が不正ならエラー(t *testing.T) {
+	t.Parallel()
+
+	world := testutil.InitTestWorld(t)
+	raws := newTestLootRaws()
+	plan := newTestSpawnPlan(world)
+	plan.RawMaster = &raws
+	plan.RNG = rand.New(rand.NewPCG(1, 1))
+	plan.Danger = 1
+
+	propRaw := oapi.Prop{
+		Storage: &oapi.StorageRaw{
+			LootTableId: new("test_item_table"),
+			LootCount:   new("不正な表記"),
+		},
+	}
+	storageEntity := world.ECS.NewEntity()
+
+	err := populateStorageLoot(world, plan, storageEntity, propRaw)
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "invalid lootCount notation")
+}
+
+func TestPopulateStorageLoot_危険度が最小値未満ならエラー(t *testing.T) {
+	t.Parallel()
+
+	world := testutil.InitTestWorld(t)
+	raws := newTestLootRaws()
+	plan := newTestSpawnPlan(world)
+	plan.RawMaster = &raws
+	plan.RNG = rand.New(rand.NewPCG(1, 1))
+	plan.Danger = 0 // MinDanger(1)未満
+
+	propRaw := oapi.Prop{
+		Storage: &oapi.StorageRaw{LootTableId: new("test_item_table")},
+	}
+	storageEntity := world.ECS.NewEntity()
+
+	err := populateStorageLoot(world, plan, storageEntity, propRaw)
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "failed to draw item")
+}
+
+func TestPopulateStorageLoot_危険度がテーブル範囲外ならアイテムを収納しない(t *testing.T) {
+	t.Parallel()
+
+	world := testutil.InitTestWorld(t)
+	raws := newTestLootRaws()
+	plan := newTestSpawnPlan(world)
+	plan.RawMaster = &raws
+	plan.RNG = rand.New(rand.NewPCG(1, 1))
+	plan.Danger = 99 // エントリのMaxDanger(5)を超える
+
+	propRaw := oapi.Prop{
+		Storage: &oapi.StorageRaw{LootTableId: new("test_item_table")},
+	}
+	storageEntity := world.ECS.NewEntity()
+
+	err := populateStorageLoot(world, plan, storageEntity, propRaw)
+	require.NoError(t, err, "候補が無い場合はエラーにせず何も収納しない")
+
+	query := ecs.NewFilter1[gc.LocationInStorage](world.ECS).Query()
+	count := 0
+	for query.Next() {
+		count++
+	}
+	assert.Equal(t, 0, count, "危険度が範囲外なら何も収納されない")
+}
+
+func TestPopulateStorageLoot_アイテム生成に失敗したらエラー(t *testing.T) {
+	t.Parallel()
+
+	world := testutil.InitTestWorld(t)
+	raws := newTestLootRaws()
+	plan := newTestSpawnPlan(world)
+	plan.RawMaster = &raws // アイテム解決用。実体スポーンはworld側のRawMasterで行われる
+	plan.RNG = rand.New(rand.NewPCG(1, 1))
+	plan.Danger = 3 // エントリのMinDanger(1)〜MaxDanger(5)の範囲内
+
+	propRaw := oapi.Prop{
+		Storage: &oapi.StorageRaw{LootTableId: new("test_item_table")},
+	}
+	storageEntity := world.ECS.NewEntity()
+
+	err := populateStorageLoot(world, plan, storageEntity, propRaw)
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "nonexistent_item")
+}
+
 func TestPopulateStorageLoot_ルートテーブルからアイテムを収納する(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## 概要

`internal/mapspawner` パッケージのテストカバレッジを増強する。本体コードの変更はなく、`*_test.go` へのテスト追加のみ。

対象は `SpawnAt` のエラー伝播経路と `populateStorageLoot` の分岐で、これまでテストが無かった箇所を狙った。

カバレッジ: 88.5% → 93.5%（パッケージ単体、`go test -cover ./internal/mapspawner/...`）

## 変更点

| ファイル | 変更内容 |
|---|---|
| `internal/mapspawner/spawn_offset_test.go` | `SpawnAt` が `spawnNPCs`/`spawnItems`/`spawnProps` のエラーをそのまま伝播し、`Level` をゼロ値のまま打ち切ることを固定するテストを追加 |
| `internal/mapspawner/spawner_test.go` | `populateStorageLoot` の `LootCount` 不正表記・危険度が最小値未満・危険度がテーブル範囲外・アイテム解決失敗の4分岐にテストを追加 |

## なぜこの形か

- `SpawnAt` は6つの生成ステップを順に呼び、いずれかが失敗したら即座にエラーを返して打ち切る契約を持つ。既存テストはタイル生成の失敗しか固定していなかったため、NPC・アイテム・Props生成の失敗でも同じ契約が成り立つことを固定した。
  - `spawnDoors`・`spawnPortals` の失敗経路は `lifecycle.SpawnDoor` が常に `nil` エラーを返す実装のため到達不能と判断し、対象から外した。
- `populateStorageLoot` はルートテーブルの危険度フィルタや `ParseDice` 失敗など複数の分岐を持つが、既存テストは「未知のルートテーブル」と「正常系」の2つのみだった。分岐・境界・エラーパスを狙うというテスト方針に沿って、危険度の下限違反・候補ゼロ・アイテム解決失敗の分岐を追加した。
  - `populateStorageLoot` は `metaPlan.RawMaster` でアイテムテーブルを解決し、実体スポーンは `world.Resources.RawMaster` で行う設計になっている。この分離を利用し、存在しないアイテムIDを参照する最小の `oapi.Raws` をテスト側で組み立てることで、共有 `RawMaster`（並行テスト間で共有されるため変更不可）を汚さずにアイテム解決失敗を再現した。

## 採用しなかった代替

- `spawnNPCs` 内の `SpawnNeutralNPC`/`SpawnEnemy` のエラー分岐（中立NPCなのにDialog未設定、敵なのにAI未設定）も狙う案があったが、該当するrawデータが実データに存在するか不明で、テスト用にrawを追加すると本体コードでない変更が必要になるため見送った。
- `spawnDoors`/`spawnPortals` のエラー分岐は、対応する `lifecycle.SpawnDoor`/`SpawnProp("warp_next")` が通常実行では失敗しない実装のため、無理に到達させるテストを書かず見送った。

## 検証

- `go build ./...`: 成功
- `go test -cover ./internal/mapspawner/...`（xvfb-run + bwrap）: 全テスト成功、カバレッジ 93.5%
- `golangci-lint run ./internal/mapspawner/...`: 0 issues
- `golangci-lint run ./...`（全パッケージ）: 0 issues
- `go test ./...`（全パッケージ、xvfb-run + bwrap）: 全テスト成功、既存テストへの影響なし

## リスク・影響範囲

テストファイルのみの変更で本体コードに影響しないため、リスクなし。

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011qLcU5KncqVPFZP7MhPtMg

---
_Generated by [Claude Code](https://claude.ai/code/session_011qLcU5KncqVPFZP7MhPtMg)_