### PR TITLE
ci: PR の bot コメントを溜めず最新1件だけ追える形にする

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -195,6 +195,9 @@ jobs:
         uses: marocchino/sticky-pull-request-comment@v3
         with:
           header: bench-compare
+          # 毎回、古いコメントを畳んで末尾に新規投稿する。in-place 更新だと初回位置に留まり埋もれる
+          hide_and_recreate: true
+          hide_classify: "OUTDATED"
           path: cmp.md
       - name: gate on catastrophic regression
         if: steps.cmp.outputs.bad != ''

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -50,8 +50,8 @@ jobs:
             
             Be constructive and helpful in your feedback.
 
-          # Optional: Use sticky comments to make Claude reuse the same comment on subsequent pushes to the same PR
-          # use_sticky_comment: true
+          # 同じ PR への push では同一コメントを更新し、古いレビューを溜めない。codecov と同じく最新だけ残す
+          use_sticky_comment: true
           
           # Optional: Customize review based on file types
           # direct_prompt: |


### PR DESCRIPTION
## 概要

PR に溜まる bot コメントを整理し、最新の1件を追いやすくしつつ過去も辿れるようにする。

- **Claude Code Review**: 毎 push で新規コメントを投稿し、1つの PR に15件も累積していた。`use_sticky_comment` を有効にして同一コメントの更新にする。
- **bench-compare**: 既に sticky で1件だが、in-place 更新は初回の投稿位置に留まるため、レビュー往復で PR が伸びると上に埋もれて辿りにくい。`hide_and_recreate: true` で毎回、古いコメントを畳んで末尾に新規投稿する。

構造が自明な CI 設定変更なので、処理フロー図・データ関係図は省略する。

## 変更点

| ファイル | 変更内容 |
|---|---|
| `.github/workflows/claude-code-review.yml` | `use_sticky_comment: true` を有効化 |
| `.github/workflows/check.yml` | bench の sticky コメントに `hide_and_recreate: true` + `hide_classify: OUTDATED` を追加 |

## なぜこの形か

- **最新を末尾に・古いものは畳んで残す**。in-place 更新は内容が最新でも位置が初回のままで埋もれる。`hide_and_recreate` は毎回、古いコメントを GitHub 上で minimize＝折り畳んで末尾に新規投稿するので、最新は末尾に展開表示され、過去のベンチ結果は畳まれたまま残って展開すれば追える。
- **claude は use_sticky_comment（in-place）が最善**。`anthropics/claude-code-action` は畳み/末尾再投稿の相当機能を持たないが、1件に集約されれば累積は解消する。

## 採用しなかった代替

- **`recreate: true`**。古いコメントを削除して末尾に作り直す。1件・最下部で見つけやすいが、過去のベンチ結果が消えて後から辿れない。履歴を残す `hide_and_recreate` を採る。
- **bench を in-place のまま維持**。1件だが初回位置に留まり埋もれる。「後から辿りにくい」を解消できない。

## 検証

- YAML 構文とキーを js-yaml で確認（`hide_and_recreate: true` / `use_sticky_comment: true`）。
- 実挙動はワークフロー設定がマージ後に効くため、本 PR の CI 実行と後続 PR で確認する。

## リスク・影響範囲

CI コメントの表示挙動のみ。ベンチの退化ゲート判定・ビルド・テストには影響しない。未リリースのゲーム挙動とも無関係。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
