### PR TITLE
fix(injury): 同一部位の同種負傷を1つに制限する

### DIFF
--- a/internal/activity/injury.go
+++ b/internal/activity/injury.go
@@ -14,8 +14,8 @@ const (
 	injuryChancePercent = 15
 	// injuryInitialTimer は付いた怪我の初期進行度。発症する 25 以上にして即座に効かせる
 	injuryInitialTimer = 40
-	// maxInjuriesPerPartType は1部位に積める同種の怪我の上限。独立傷が溢れないようにする
-	maxInjuriesPerPartType = 3
+	// maxInjuriesPerPartType は1部位に付く同種の怪我の上限。種類が違えば共存する
+	maxInjuriesPerPartType = 1
 )
 
 // injuryTypeFor は武器種から怪我の種類を導く。鈍器は骨折、刃と弾は切り傷。
@@ -29,9 +29,9 @@ func injuryTypeFor(attackType gc.AttackType) gc.ConditionType {
 	}
 }
 
-// applyInjury は命中時に確率で命中部位へ独立した怪我を1つ付ける。
+// applyInjury は命中時に確率で命中部位へ怪我を1つ付ける。
 // 怪我の種類は武器種から導き、命中部位は部位サイズの重みで抽選する。HealthStatus を持つ対象だけが対象。
-// 同じ部位に同種の怪我がソフト上限に達していれば付けない。独立に積むので身体機能と失血は全傷が合算される
+// 同じ部位に同種の怪我が既にあれば付けない。種類や部位が違う傷は独立で、身体機能と失血は全傷が合算される
 func applyInjury(actor, target ecs.Entity, world w.World, attack gc.Attacker) {
 	if !world.Components.HealthStatus.Has(target) {
 		return

--- a/internal/activity/injury_test.go
+++ b/internal/activity/injury_test.go
@@ -74,7 +74,7 @@ func TestApplyInjury_判定に外れると付かない(t *testing.T) {
 	}
 }
 
-func TestApplyInjury_同種の怪我はソフト上限で頭打ち(t *testing.T) {
+func TestApplyInjury_同種の怪我は1部位に1つで頭打ち(t *testing.T) {
 	t.Parallel()
 
 	world := testutil.InitTestWorld(t)


### PR DESCRIPTION
## 概要

同一部位に同種の怪我が3つまで積め、同じ部位で3連続骨折のような不自然な重複と過剰ペナルティが起きていた。`maxInjuriesPerPartType` を 3→1 にし、同じ部位に同じ怪我は1つまでにする。骨折と切り傷のように種類が違えば共存する。

1定数の変更で挙動が自明なため、処理フロー図・データ関係図は省略する。

## 変更点

| ファイル | 変更内容 |
|---|---|
| `internal/activity/injury.go` | `maxInjuriesPerPartType` を 3→1。コメントを「1部位に同種1つ」へ更新 |
| `internal/activity/injury_test.go` | キャップテスト名を「同種の怪我は1部位に1つで頭打ち」へ更新 |

## なぜこの形か

- **上限を1にするとペナルティ過多も同時に解消する**。負傷は身体機能低下と失血を全傷ぶん合算する設計。3同種＝3倍ペナルティで過剰かつ不自然だった。1に絞ると、重複と過剰ペナルティが一手で消える。
- **種類ごとに1つ**なので、骨折と切り傷は骨と出血で別物として共存でき、部位の状態表現は失わない。
- **敵も同じ `applyInjury` を通る**ので、プレイヤー・敵とも一貫して1部位1種になる。命中部位の抽選・種類判定・発生確率は変えない。

## 採用しなかった代替

- **部位ごとに合計1つ（種類を問わず1）**。骨折済みの腕に切り傷が付かず、斬撃が無効になって不自然。判定を「その部位に負傷が既にあるか」に変える必要もある。骨折と出血は共存しうるので、種類ごと1つが自然。

## 検証

- `go build ./...` 緑・`golangci-lint` 0件・`internal/activity`・`internal/components` の全テスト通過。
- 負傷は命中時15%の確率発火なので、決定論的な VRT golden への影響はない。

## リスク・影響範囲

未リリースのバランス調整。挙動は緩和方向（同種の重複と合算ペナルティが減る）で、既存の身体機能・失血の計算式やセーブ形式は変えない。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
