### PR TITLE
ci(review): claude-review を sticky更新でなく前回hide+新規投稿にする

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -21,15 +21,31 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
-      issues: read
+      # 前回レビューを minimize するため write。issue コメントの畳み込みに要る
+      pull-requests: write
+      issues: write
       id-token: write
-    
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7
         with:
           fetch-depth: 1
+
+      # 新規レビューを投稿する前に、前回までの claude-review コメントを OUTDATED として畳む。
+      # sticky で同一コメントを上書きすると履歴を追えないため、毎回新規投稿にし古いのは hide する
+      - name: Hide previous Claude review comments
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR: ${{ github.event.pull_request.number }}
+        run: |
+          gh api "repos/${REPO}/issues/${PR}/comments" --paginate \
+            --jq '.[] | select(.user.login == "claude[bot]") | select(.body | startswith("**Claude finished")) | .node_id' \
+          | while read -r node; do
+              [ -z "$node" ] && continue
+              gh api graphql -f query='mutation($id: ID!) { minimizeComment(input: {classifier: OUTDATED, subjectId: $id}) { minimizedComment { isMinimized } } }' -f id="$node"
+            done
 
       - name: Run Claude Code Review
         id: claude-review
@@ -50,8 +66,9 @@ jobs:
             
             Be constructive and helpful in your feedback.
 
-          # 同じ PR への push では同一コメントを更新し、古いレビューを溜めない。codecov と同じく最新だけ残す
-          use_sticky_comment: true
+          # sticky にすると同一コメントを上書きして履歴が追えない。毎回新規投稿にし、
+          # 前回ぶんは上の Hide ステップで OUTDATED として畳む。最新だけ展開され過去も辿れる
+          use_sticky_comment: false
           
           # Optional: Customize review based on file types
           # direct_prompt: |


### PR DESCRIPTION
## 概要

claude-review が sticky コメント方式で、同じコメントを毎回上書きしている。レビューの履歴が消え、どの指摘がどの版で出てどう対応したかを追えない。**前回ぶんを hide して新規投稿する**方式へ変える。最新だけ展開され、過去も折りたたまれた形で辿れる。bench-compare の hide_and_recreate と同じ思想。

## 変更点

| ファイル | 変更内容 |
|---|---|
| `.github/workflows/claude-code-review.yml` | `use_sticky_comment: false` にして毎回新規投稿。投稿前に前回までの claude-review コメントを `minimizeComment(OUTDATED)` で畳む Hide ステップを追加。minimize のため permissions を `pull-requests/issues: write` へ |

## なぜこの形か

- **履歴を残す**。sticky は最新1件しか残さず、指摘と対応の対応関係が消える。新規投稿+旧 hide なら時系列が残り、折りたたみで最新に集中できる。
- **Hide は限定する**。`claude[bot]` 投稿かつ本文が `**Claude finished` 始まりのトラッキングコメントだけを畳み、他 bot や人間のコメントに触れない。

## 採用しなかった代替

- **sticky のまま**。最新だけ見えるが履歴が消える。今回の不満点そのもの。
- **sticky を切るだけ**。新規投稿は増えるが旧コメントが hide されず溜まる。minimize を足して解決する。

## 検証

- YAML はタブ無し・インデント・block scalar を目視確認。ローカルに actionlint/yaml 検証器が無いため、GitHub Actions のパースで最終確認される。
- 挙動確認はマージ後の次回 push で行う。

## リスク・影響範囲

- この workflow 自体を変更する PR では anti-tampering ガードで claude-review が自己実行を拒む。既知で無害、マージ後に新挙動が効く。
- `minimizeComment` は github-actions[bot] の write 権限で他 bot コメントを畳む。対象を本文 marker で限定しているので誤爆しない。

🤖 Generated with [Claude Code](https://claude.com/claude-code)