### PR TITLE
test(activity): カバレッジ増強

### DIFF
--- a/internal/activity/activity_test.go
+++ b/internal/activity/activity_test.go
@@ -85,6 +85,7 @@ func TestActivityCancel(t *testing.T) {
 func TestCanInterrupt_未知のBehaviorNameはfalse(t *testing.T) {
 	t.Parallel()
 
+	// NewActivity の既定 State は Running。GetBehavior のエラーだけで false になる分岐を見る
 	comp := NewActivity(gc.BehaviorName("unknown"), 10)
 	assert.False(t, CanInterrupt(comp), "GetBehaviorがエラーを返す場合は中断不可")
 }

--- a/internal/activity/activity_test.go
+++ b/internal/activity/activity_test.go
@@ -82,6 +82,21 @@ func TestActivityCancel(t *testing.T) {
 	assert.False(t, CanResume(comp), "Expected canceled activity to not be resumable")
 }
 
+func TestCanInterrupt_未知のBehaviorNameはfalse(t *testing.T) {
+	t.Parallel()
+
+	comp := NewActivity(gc.BehaviorName("unknown"), 10)
+	assert.False(t, CanInterrupt(comp), "GetBehaviorがエラーを返す場合は中断不可")
+}
+
+func TestCanResume_未知のBehaviorNameはfalse(t *testing.T) {
+	t.Parallel()
+
+	comp := NewActivity(gc.BehaviorName("unknown"), 10)
+	comp.State = gc.ActivityStatePaused
+	assert.False(t, CanResume(comp), "GetBehaviorがエラーを返す場合は再開不可")
+}
+
 func TestActivityComplete(t *testing.T) {
 	t.Parallel()
 

--- a/internal/activity/activity_test.go
+++ b/internal/activity/activity_test.go
@@ -85,7 +85,6 @@ func TestActivityCancel(t *testing.T) {
 func TestCanInterrupt_未知のBehaviorNameはfalse(t *testing.T) {
 	t.Parallel()
 
-	// NewActivity の既定 State は Running。GetBehavior のエラーだけで false になる分岐を見る
 	comp := NewActivity(gc.BehaviorName("unknown"), 10)
 	assert.False(t, CanInterrupt(comp), "GetBehaviorがエラーを返す場合は中断不可")
 }

--- a/internal/activity/read_test.go
+++ b/internal/activity/read_test.go
@@ -427,7 +427,6 @@ func TestReadBehavior_Finish_未読了なら本は消費されない(t *testing.
 	})
 
 	ra := &ReadBehavior{}
-	// 消費の分岐は comp.State ではなく book.IsCompleted() で決まる。ここは Current<Max で未読了
 	comp := &gc.Activity{Params: &gc.ReadParams{Target: bookEntity}}
 
 	require.NoError(t, ra.Finish(comp, actor, world))

--- a/internal/activity/read_test.go
+++ b/internal/activity/read_test.go
@@ -391,3 +391,150 @@ func TestReadBehavior_Finish_本が消えていれば何もしない(t *testing.
 
 	require.NoError(t, ra.Finish(comp, actor, world))
 }
+
+func TestReadBehavior_Finish_読了した本は消費される(t *testing.T) {
+	t.Parallel()
+
+	world := testutil.InitTestWorld(t)
+	actor := world.ECS.NewEntity()
+	bookEntity := world.ECS.NewEntity()
+	world.Components.Name.Add(bookEntity, &gc.Name{Name: "テスト本"})
+	world.Components.Book.Add(bookEntity, &gc.Book{
+		Effort: gc.IntPool{Max: 10, Current: 10},
+	})
+
+	ra := &ReadBehavior{}
+	comp := &gc.Activity{Params: &gc.ReadParams{Target: bookEntity}, State: gc.ActivityStateCompleted}
+
+	require.NoError(t, ra.Finish(comp, actor, world))
+	assert.False(t, world.ECS.Alive(bookEntity), "読了した本は消費されて消える")
+
+	store := query.GetGameLog(world)
+	recent := store.GetRecent(1)
+	require.Len(t, recent, 1)
+	assert.Contains(t, recent[0], "テスト本")
+}
+
+func TestReadBehavior_Finish_未読了なら本は消費されない(t *testing.T) {
+	t.Parallel()
+
+	world := testutil.InitTestWorld(t)
+	actor := world.ECS.NewEntity()
+	bookEntity := world.ECS.NewEntity()
+	world.Components.Name.Add(bookEntity, &gc.Name{Name: "テスト本"})
+	world.Components.Book.Add(bookEntity, &gc.Book{
+		Effort: gc.IntPool{Max: 10, Current: 5},
+	})
+
+	ra := &ReadBehavior{}
+	comp := &gc.Activity{Params: &gc.ReadParams{Target: bookEntity}, State: gc.ActivityStateRunning}
+
+	require.NoError(t, ra.Finish(comp, actor, world))
+	assert.True(t, world.ECS.Alive(bookEntity), "読了していない本は消費されない")
+
+	store := query.GetGameLog(world)
+	assert.Empty(t, store.GetRecent(1), "読了していないので完了ログは出ない")
+}
+
+func TestReadBehavior_Finish_パラメータ型不一致はエラー(t *testing.T) {
+	t.Parallel()
+
+	world := testutil.InitTestWorld(t)
+	actor := world.ECS.NewEntity()
+
+	ra := &ReadBehavior{}
+	comp := &gc.Activity{}
+
+	err := ra.Finish(comp, actor, world)
+	require.ErrorIs(t, err, ErrParamsTypeMismatch)
+}
+
+func TestReadBehavior_Start_開始ログが出る(t *testing.T) {
+	t.Parallel()
+
+	world := testutil.InitTestWorld(t)
+	actor := world.ECS.NewEntity()
+	bookEntity := world.ECS.NewEntity()
+	world.Components.Name.Add(bookEntity, &gc.Name{Name: "テスト本"})
+	world.Components.Book.Add(bookEntity, &gc.Book{
+		Effort: gc.IntPool{Max: 10},
+	})
+
+	ra := &ReadBehavior{}
+	comp := &gc.Activity{Params: &gc.ReadParams{Target: bookEntity}}
+
+	require.NoError(t, ra.Start(comp, actor, world))
+
+	store := query.GetGameLog(world)
+	recent := store.GetRecent(1)
+	require.Len(t, recent, 1)
+	assert.Contains(t, recent[0], "テスト本")
+}
+
+func TestReadBehavior_Start_本がないとエラー(t *testing.T) {
+	t.Parallel()
+
+	world := testutil.InitTestWorld(t)
+	actor := world.ECS.NewEntity()
+	target := world.ECS.NewEntity() // Bookコンポーネントなし
+
+	ra := &ReadBehavior{}
+	comp := &gc.Activity{Params: &gc.ReadParams{Target: target}}
+
+	err := ra.Start(comp, actor, world)
+	assert.Error(t, err)
+}
+
+func TestReadBehavior_Start_パラメータ型不一致はエラー(t *testing.T) {
+	t.Parallel()
+
+	world := testutil.InitTestWorld(t)
+	actor := world.ECS.NewEntity()
+
+	ra := &ReadBehavior{}
+	comp := &gc.Activity{}
+
+	err := ra.Start(comp, actor, world)
+	require.ErrorIs(t, err, ErrParamsTypeMismatch)
+}
+
+func TestReadBehavior_Canceled_プレイヤーは本の名前が出る(t *testing.T) {
+	t.Parallel()
+
+	world := testutil.InitTestWorld(t)
+	actor := world.ECS.NewEntity()
+	world.Components.Player.Add(actor, &gc.Player{})
+
+	bookEntity := world.ECS.NewEntity()
+	world.Components.Name.Add(bookEntity, &gc.Name{Name: "テスト本"})
+	world.Components.Book.Add(bookEntity, &gc.Book{Effort: gc.IntPool{Max: 10}})
+
+	ra := &ReadBehavior{}
+	comp := &gc.Activity{Params: &gc.ReadParams{Target: bookEntity}, CancelReason: "テスト中断"}
+
+	require.NoError(t, ra.Canceled(comp, actor, world))
+
+	store := query.GetGameLog(world)
+	recent := store.GetRecent(1)
+	require.Len(t, recent, 1)
+	assert.Contains(t, recent[0], "テスト本")
+}
+
+func TestReadBehavior_Canceled_プレイヤー以外はログが出ない(t *testing.T) {
+	t.Parallel()
+
+	world := testutil.InitTestWorld(t)
+	actor := world.ECS.NewEntity() // Playerコンポーネントなし
+
+	bookEntity := world.ECS.NewEntity()
+	world.Components.Name.Add(bookEntity, &gc.Name{Name: "テスト本"})
+	world.Components.Book.Add(bookEntity, &gc.Book{Effort: gc.IntPool{Max: 10}})
+
+	ra := &ReadBehavior{}
+	comp := &gc.Activity{Params: &gc.ReadParams{Target: bookEntity}, CancelReason: "テスト中断"}
+
+	require.NoError(t, ra.Canceled(comp, actor, world))
+
+	store := query.GetGameLog(world)
+	assert.Empty(t, store.GetRecent(1), "プレイヤー以外の中断はログに出さない")
+}

--- a/internal/activity/read_test.go
+++ b/internal/activity/read_test.go
@@ -539,7 +539,7 @@ func TestReadBehavior_Canceled_プレイヤー以外はログが出ない(t *tes
 	assert.Empty(t, store.GetRecent(1), "プレイヤー以外の中断はログに出さない")
 }
 
-func TestReadBehavior_Canceled_パラメータ型不一致でも汎用メッセージが出る(t *testing.T) {
+func TestReadBehavior_Canceled_本の名前が取れないときは汎用メッセージが出る(t *testing.T) {
 	t.Parallel()
 
 	world := testutil.InitTestWorld(t)
@@ -547,7 +547,7 @@ func TestReadBehavior_Canceled_パラメータ型不一致でも汎用メッセ�
 	world.Components.Player.Add(actor, &gc.Player{})
 
 	ra := &ReadBehavior{}
-	comp := &gc.Activity{CancelReason: "テスト中断"} // Params が *ReadParams でないので本の名前は出せない
+	comp := &gc.Activity{CancelReason: "テスト中断"} // Params が *ReadParams でないので本の名前は取れない
 
 	require.NoError(t, ra.Canceled(comp, actor, world))
 

--- a/internal/activity/read_test.go
+++ b/internal/activity/read_test.go
@@ -427,7 +427,8 @@ func TestReadBehavior_Finish_未読了なら本は消費されない(t *testing.
 	})
 
 	ra := &ReadBehavior{}
-	comp := &gc.Activity{Params: &gc.ReadParams{Target: bookEntity}, State: gc.ActivityStateRunning}
+	// 消費の分岐は comp.State ではなく book.IsCompleted() で決まる。ここは Current<Max で未読了
+	comp := &gc.Activity{Params: &gc.ReadParams{Target: bookEntity}}
 
 	require.NoError(t, ra.Finish(comp, actor, world))
 	assert.True(t, world.ECS.Alive(bookEntity), "読了していない本は消費されない")

--- a/internal/activity/read_test.go
+++ b/internal/activity/read_test.go
@@ -538,3 +538,21 @@ func TestReadBehavior_Canceled_プレイヤー以外はログが出ない(t *tes
 	store := query.GetGameLog(world)
 	assert.Empty(t, store.GetRecent(1), "プレイヤー以外の中断はログに出さない")
 }
+
+func TestReadBehavior_Canceled_パラメータ型不一致でも汎用メッセージが出る(t *testing.T) {
+	t.Parallel()
+
+	world := testutil.InitTestWorld(t)
+	actor := world.ECS.NewEntity()
+	world.Components.Player.Add(actor, &gc.Player{})
+
+	ra := &ReadBehavior{}
+	comp := &gc.Activity{CancelReason: "テスト中断"} // Params が *ReadParams でないので本の名前は出せない
+
+	require.NoError(t, ra.Canceled(comp, actor, world))
+
+	store := query.GetGameLog(world)
+	recent := store.GetRecent(1)
+	require.Len(t, recent, 1)
+	assert.Contains(t, recent[0], "interrupted reading")
+}

--- a/internal/activity/reload_test.go
+++ b/internal/activity/reload_test.go
@@ -324,3 +324,19 @@ func TestReloadBehavior_DoTurn_敵が接近すると中断する(t *testing.T) {
 	assert.Equal(t, gc.ActivityStateCanceled, comp.State)
 	assert.Equal(t, "reload interrupted because enemies are nearby", comp.CancelReason)
 }
+
+func TestReloadBehavior_Canceled_中断メッセージがログに出る(t *testing.T) {
+	t.Parallel()
+	world, player, _, _ := setupShootingWorld(t)
+
+	ra := &ReloadBehavior{}
+	comp := NewActivity(gc.BehaviorReload, 100)
+	comp.CancelReason = "reload interrupted because enemies are nearby"
+
+	require.NoError(t, ra.Canceled(comp, player, world))
+
+	store := query.GetGameLog(world)
+	recent := store.GetRecent(1)
+	require.Len(t, recent, 1)
+	assert.Contains(t, recent[0], "interrupted reloading")
+}

--- a/internal/activity/sleep_test.go
+++ b/internal/activity/sleep_test.go
@@ -166,3 +166,19 @@ func TestSleepBehavior_Canceled_プレイヤーは中断理由がログに出る
 	require.Len(t, recent, 1)
 	assert.Contains(t, recent[0], "Sleep interrupted")
 }
+
+func TestSleepBehavior_Canceled_プレイヤー以外はメッセージが出ない(t *testing.T) {
+	t.Parallel()
+	world := testutil.InitTestWorld(t)
+	actor := world.ECS.NewEntity() // Playerコンポーネントなし
+	world.Components.Sleeping.Add(actor, &gc.Sleeping{Quality: consts.PercentBase})
+
+	sb := &SleepBehavior{}
+	comp := &gc.Activity{CancelReason: "woke up from the cold"}
+	require.NoError(t, sb.Canceled(comp, actor, world))
+
+	assert.False(t, world.Components.Sleeping.Has(actor), "中断でSleepingが外れる")
+
+	store := query.GetGameLog(world)
+	assert.Empty(t, store.GetRecent(1), "プレイヤー以外は中断ログを出さない")
+}

--- a/internal/activity/sleep_test.go
+++ b/internal/activity/sleep_test.go
@@ -105,3 +105,64 @@ func TestSleepBehavior_中断すると起床処理が走り理由が記録され
 	assert.Equal(t, gc.ActivityStateCanceled, last.State, "結果は中断")
 	assert.Equal(t, "woke up from hunger", last.Message, "中断理由が記録される")
 }
+
+func TestSleepBehavior_Finish_プレイヤーは起床メッセージが出る(t *testing.T) {
+	t.Parallel()
+	world := testutil.InitTestWorld(t)
+	actor := world.ECS.NewEntity()
+	world.Components.Player.Add(actor, &gc.Player{})
+	world.Components.Sleeping.Add(actor, &gc.Sleeping{Quality: consts.PercentBase})
+
+	sb := &SleepBehavior{}
+	require.NoError(t, sb.Finish(&gc.Activity{}, actor, world))
+
+	assert.False(t, world.Components.Sleeping.Has(actor), "起床でSleepingが外れる")
+
+	store := query.GetGameLog(world)
+	recent := store.GetRecent(1)
+	require.Len(t, recent, 1)
+	assert.Contains(t, recent[0], "refreshed")
+}
+
+func TestSleepBehavior_Finish_プレイヤー以外はメッセージが出ない(t *testing.T) {
+	t.Parallel()
+	world := testutil.InitTestWorld(t)
+	actor := world.ECS.NewEntity() // Playerコンポーネントなし
+	world.Components.Sleeping.Add(actor, &gc.Sleeping{Quality: consts.PercentBase})
+
+	sb := &SleepBehavior{}
+	require.NoError(t, sb.Finish(&gc.Activity{}, actor, world))
+
+	assert.False(t, world.Components.Sleeping.Has(actor), "起床でSleepingが外れる")
+
+	store := query.GetGameLog(world)
+	assert.Empty(t, store.GetRecent(1), "プレイヤー以外は起床ログを出さない")
+}
+
+func TestSleepBehavior_Finish_Sleepingがなくてもpanicしない(t *testing.T) {
+	t.Parallel()
+	world := testutil.InitTestWorld(t)
+	actor := world.ECS.NewEntity() // Sleepingを付けていない
+
+	sb := &SleepBehavior{}
+	require.NoError(t, sb.Finish(&gc.Activity{}, actor, world))
+}
+
+func TestSleepBehavior_Canceled_プレイヤーは中断理由がログに出る(t *testing.T) {
+	t.Parallel()
+	world := testutil.InitTestWorld(t)
+	actor := world.ECS.NewEntity()
+	world.Components.Player.Add(actor, &gc.Player{})
+	world.Components.Sleeping.Add(actor, &gc.Sleeping{Quality: consts.PercentBase})
+
+	sb := &SleepBehavior{}
+	comp := &gc.Activity{CancelReason: "woke up from the cold"}
+	require.NoError(t, sb.Canceled(comp, actor, world))
+
+	assert.False(t, world.Components.Sleeping.Has(actor), "中断でSleepingが外れる")
+
+	store := query.GetGameLog(world)
+	recent := store.GetRecent(1)
+	require.Len(t, recent, 1)
+	assert.Contains(t, recent[0], "Sleep interrupted")
+}

--- a/internal/activity/sleep_test.go
+++ b/internal/activity/sleep_test.go
@@ -182,3 +182,14 @@ func TestSleepBehavior_Canceled_プレイヤー以外はメッセージが出な
 	store := query.GetGameLog(world)
 	assert.Empty(t, store.GetRecent(1), "プレイヤー以外は中断ログを出さない")
 }
+
+func TestSleepBehavior_Canceled_Sleepingがなくてもpanicしない(t *testing.T) {
+	t.Parallel()
+	world := testutil.InitTestWorld(t)
+	actor := world.ECS.NewEntity() // Sleepingを付けていない
+	world.Components.Player.Add(actor, &gc.Player{})
+
+	sb := &SleepBehavior{}
+	comp := &gc.Activity{CancelReason: "woke up from the cold"}
+	require.NoError(t, sb.Canceled(comp, actor, world))
+}

--- a/internal/activity/use_item_test.go
+++ b/internal/activity/use_item_test.go
@@ -200,6 +200,36 @@ func TestUseItemBehavior_DoTurn(t *testing.T) {
 		assert.Equal(t, 2, countBackpackByRawID(world, actor, "bread"))
 	})
 
+	t.Run("自傷ダメージアイテムを使用して使用者にダメージが入る", func(t *testing.T) {
+		t.Parallel()
+		world := testutil.InitTestWorld(t)
+
+		actor := world.ECS.NewEntity()
+		world.Components.Player.Add(actor, &gc.Player{})
+		world.Components.HP.Add(actor, &gc.HP{Current: 100, Max: 100})
+
+		item := world.ECS.NewEntity()
+		world.Components.Name.Add(item, &gc.Name{Name: "毒薬"})
+		world.Components.RawID.Add(item, &gc.RawID{ID: "poison"})
+		world.Components.InflictsDamage.Add(item, &gc.InflictsDamage{Amount: 10})
+		world.Components.Consumable.Add(item, &gc.Consumable{})
+		world.Components.LocationInBackpack.Add(item, &gc.LocationInBackpack{Owner: actor})
+
+		comp := &gc.Activity{
+			BehaviorName: gc.BehaviorUseItem,
+			State:        gc.ActivityStateRunning,
+			Params:       &gc.UseItemParams{Target: item},
+		}
+
+		ua := &UseItemBehavior{}
+		err := ua.DoTurn(comp, actor, world)
+
+		require.NoError(t, err)
+		assert.Equal(t, gc.ActivityStateCompleted, comp.State)
+		assert.Equal(t, 90, world.Components.HP.Get(actor).Current, "自傷ダメージぶんHPが減る")
+		assert.Equal(t, 0, countBackpackByRawID(world, actor, "poison"), "使用したアイテムは消費される")
+	})
+
 	t.Run("Targetがnilの場合はキャンセルされる", func(t *testing.T) {
 		t.Parallel()
 		world := testutil.InitTestWorld(t)


### PR DESCRIPTION
## 概要

`internal/activity` パッケージのテストカバレッジを増強する。本体コードは変更せず `*_test.go` のみ追加する。

カバレッジ: 85.1% → 87.2%

対象は既存テストが薄かったライフサイクルメソッド。狙った振る舞いは次のとおり。

- `ReadBehavior.Start`: 本が見つかり読書開始ログが出る場合、パラメータ型不一致、本が存在しない場合の3分岐
- `ReadBehavior.Finish`: 読了時に本が消費される場合、未読了で消費されない場合、パラメータ型不一致の3分岐
- `ReadBehavior.Canceled`: プレイヤーで本が残っている場合にログへ本の名前が出る分岐、プレイヤー以外はログが出ない分岐
- `SleepBehavior.Finish`/`Canceled`: プレイヤーには起床・中断メッセージが出て`Sleeping`が外れる分岐、プレイヤー以外はメッセージが出ない分岐、`Sleeping`未付与でもpanicしない分岐
- `ReloadBehavior.Canceled`: 中断時にログへメッセージが出る契約
- `UseItemBehavior.DoTurn` 経由の `damageEffect.apply`: 自傷ダメージアイテム使用でHPが減り、アイテムが消費される分岐。既存テストが空腹度回復アイテムしか通していなかった
- `CanInterrupt`/`CanResume`: 未知の`BehaviorName`で`GetBehavior`がエラーを返す分岐

構造・挙動が自明な小さい PR のため、処理フロー図・データ関係図・コールグラフは省く。

## 変更点

| ファイル | 変更内容 |
| --- | --- |
| `internal/activity/activity_test.go` | `CanInterrupt`/`CanResume`の未知`BehaviorName`分岐のテストを追加 |
| `internal/activity/read_test.go` | `Start`/`Finish`/`Canceled`の未テスト分岐を追加 |
| `internal/activity/sleep_test.go` | `Finish`/`Canceled`のプレイヤー分岐・`Sleeping`未付与分岐を追加 |
| `internal/activity/reload_test.go` | `Canceled`の中断ログ契約テストを追加 |
| `internal/activity/use_item_test.go` | `damageEffect`経由の自傷ダメージテストを追加 |

## なぜこの形か

ログのみで分岐のない一行実装（例: `move.go`/`pickup.go`/`door.go`等の`Canceled`)はテストを足さなかった。`ruins-code`の「カバレッジ稼ぎの無意味なテストは書かない」に従い、分岐・契約のあるメソッドだけを対象にした。

## 検証

- `go build ./...`: 成功
- `golangci-lint run ./internal/activity/...`: 0 issues
- `golangci-lint run ./...`: 0 issues
- `make test`: 全パッケージ成功。`internal/activity`は87.2%



---
_Generated by [Claude Code](https://claude.ai/code/session_01We8XPJyvtx6JLKqF6rVPQm)_